### PR TITLE
Add initial ABC support.

### DIFF
--- a/mpmath/ctx_iv.py
+++ b/mpmath/ctx_iv.py
@@ -530,6 +530,9 @@ class MPIntervalContext(StandardBaseContext):
 #     parts of the expected interfaces.  See
 #     http://docs.python.org/2/library/numbers.html for list of abstract
 #     methods.
-import numbers
-numbers.Complex.register(ivmpc)
-numbers.Real.register(ivmpf)
+try:
+    import numbers
+    numbers.Complex.register(ivmpc)
+    numbers.Real.register(ivmpf)
+except ImportError:
+    pass

--- a/mpmath/ctx_mp_python.py
+++ b/mpmath/ctx_mp_python.py
@@ -1134,6 +1134,9 @@ class PythonMPContext(object):
 #     parts of the expected interfaces.  See
 #     http://docs.python.org/2/library/numbers.html for list of abstract
 #     methods.
-import numbers
-numbers.Complex.register(_mpc)
-numbers.Real.register(_mpf)
+try:
+    import numbers
+    numbers.Complex.register(_mpc)
+    numbers.Real.register(_mpf)
+except ImportError:
+    pass

--- a/mpmath/rational.py
+++ b/mpmath/rational.py
@@ -233,5 +233,8 @@ mpq_5_4 = mpq((5,4))
 #     parts of the expected interfaces.  See
 #     http://docs.python.org/2/library/numbers.html for list of abstract
 #     methods.
-import numbers
-numbers.Rational.register(mpq)
+try:
+    import numbers
+    numbers.Rational.register(mpq)
+except ImportError:
+    pass


### PR DESCRIPTION
We do not use subclassing in order to keep it as simple as possible. This
precludes the use of `@abstractmethod`, however it keeps the
`__init__`/`__new__` unchanged.

Not using subclassing/`@abstractmethod` means that checks whether the inferface
conforms to the requirements of the ABC are not done. Given the simplicity of
the interface in our case, this is the prefered approach. Conformity of the
interface is checked durring developpement.
# Examples

`issubclass` works as well.

```
In [12]: import numbers

In [13]: import mpmath

In [14]: isinstance(mpmath.mpf(0.23), numbers.Complex)
Out[14]: True

In [15]: isinstance(mpmath.mpf(0.23), numbers.Real)
Out[15]: True

In [16]: isinstance(mpmath.mpf(0.23), numbers.Rational)
Out[16]: False
```

```
In [18]: isinstance(mpmath.mpc(0.23), numbers.Complex)
Out[18]: True

In [19]: isinstance(mpmath.mpc(0.23), numbers.Real)
Out[19]: False
```

```
In [20]: isinstance(mpmath.mpi(0.23), numbers.Complex)
Out[20]: True

In [21]: isinstance(mpmath.mpi(0.23), numbers.Real)
Out[21]: True

In [22]: isinstance(mpmath.mpi(0.23), numbers.Rational)
Out[22]: False
```

```
In [23]: isinstance(mpmath.mpi(0.23+1j), numbers.Complex)
Out[23]: True

In [24]: isinstance(mpmath.mpi(0.23+1j), numbers.Real)
Out[24]: False
```
