### PR TITLE
fix xrange NameError under Python 3

### DIFF
--- a/mpmath/tests/test_linalg.py
+++ b/mpmath/tests/test_linalg.py
@@ -3,6 +3,7 @@
 from __future__ import division
 
 from mpmath import *
+xrange = libmp.backend.xrange
 
 # XXX: these shouldn't be visible(?)
 LU_decomp = mp.LU_decomp


### PR DESCRIPTION
Trivial fix :) Please pull.
