### PR TITLE
Consistency of log base in error computation

### DIFF
--- a/mpmath/calculus/quadrature.py
+++ b/mpmath/calculus/quadrature.py
@@ -196,7 +196,7 @@ class QuadratureRule(object):
             D2 = self.ctx.log(abs(results[-1]-results[-3]), 10)
         except ValueError:
             return epsilon
-        D3 = -prec
+        D3 = -prec*log(10)/log(2)
         D4 = min(0, max(D1**2/D2, 2*D1, D3))
         return self.ctx.mpf(10) ** int(D4)
 


### PR DESCRIPTION
It struck me as odd that the errors D1 and D2, which are clearly base-10 log, get compared on equal footing with D3, which is base-2 log. Is that correct? it would seem the precision is a bit overestimated here (it should hardly ever matter, because by the time D3 is dominant, it doesn't seem we'd be able to do much to get a more accurate result anyway)
