### PR TITLE
WIP: Python 3 rounding

### DIFF
--- a/mpmath/tests/test_round.py
+++ b/mpmath/tests/test_round.py
@@ -1,0 +1,37 @@
+import mpmath
+from mpmath import *
+import sys
+
+def test_basics():
+    assert round(mpf('3.5')) == mpf('4')
+    assert round(mpf('3.5'), 1) == mpf('3.5')
+
+def test_default():
+    a = mpf('20') / mpf('3')
+    assert round(a, 0) == round(a)
+
+def test_lowprec():
+    with(workdps(64)):
+        a = mpf('2000') / mpf('3')
+        assert str(round(a, -1)) in ('670.0', '670')
+        assert str(round(a)) in ('667.0', '667')
+        assert str(round(a, 1)) == '666.7'
+        assert str(round(a, 2)) == '666.67'
+
+def test_highprec():
+    if sys.version_info[0] >= 3:
+        with(workdps(64)):
+            a = mpf('2000') / mpf('3')
+            assert str(round(a, 32)) == '666.66666666666666666666666666666667'
+
+def test_types():
+    if sys.version_info[0] < 3:
+        a = mpf('2000') / mpf('3')
+        assert isinstance(round(a, 32), float)
+    else:
+        with(workdps(64)):
+            a = mpf('2000') / mpf('3')
+            assert isinstance(round(a, 32), mpf)
+            assert isinstance(round(a, 15), mpf)
+            assert isinstance(round(a), (int, mpf))  # TODO?
+            assert isinstance(round(a, -1), (int, mpf))


### PR DESCRIPTION
Python 2 rounding always made floats but Python 3 has more general
semantics [1].  To take advantage of those, we have `__round__` return
an `mpf` intead of a `float`.

[1] https://docs.python.org/3/library/functions.html#round

### TODO List
- [x] basic implementation(s)
- [x] some basic tests
- [ ] should we always return an mpf or out an `int` or `mpz` be appropriate?
- [ ] add a Python 2 fallback
- [ ] more tests
- [ ] add `mpc.__round__`
- [ ] support other rounding modes.  Is there something like `mp.dps` but for rounding mode?  I notice each mpf knows its rounding mode inside `._ctxdata` but where do I set that?

### algorithms

I've tried two rather embarrassing implementations but not happy with either.  Do we need to modify/generalize `mpf_round_int`?

Help very much welcome!