### PR TITLE
Support randmatrix() for mp.iv and mp contexts

### DIFF
--- a/mpmath/ctx_base.py
+++ b/mpmath/ctx_base.py
@@ -1,4 +1,5 @@
 from operator import gt, lt
+import random
 
 from . import libmp
 from .calculus.calculus import CalculusMethods
@@ -452,6 +453,26 @@ class StandardBaseContext(Context,
                 raise ctx.NoConvergence("maxcalls: function evaluated %i times" % N)
             return f(*args, **kwargs)
         return f_maxcalls_wrapped
+
+    def rand(ctx):
+        """
+        Get a random number in the range ``[0.0, 1.0)`` with (almost) uniform distribution.
+
+        This method is a replacement for ``random.random()``. It is roughly equal
+        to ``random.randint(0, 2 ** prec - 1) / (2 ** prec)``, where ``prec``
+        is the current resolution in bits.
+
+        Just like ``random.random()`` and most other floating-point random number
+        generators, the distribution is not perfect:
+
+        Some float values within ``[0,1)`` will never be returned, for example,
+        ``2 ** -(prec + 1)`` is impossible. See
+        http://mumble.net/~campbell/2014/04/28/uniform-random-float
+        for a lengthy discussion.
+        """
+        # slow default implementation of rand() that works for arbitrary precision.
+        return ctx.convert(random.getrandbits(ctx.prec)) * (ctx.convert(2) ** (-ctx.prec))
+
 
     def memoize(ctx, f):
         """


### PR DESCRIPTION
Before, `mpmath.iv.randmatrix()` caused an error. Now it works correctly:

```
>>> import mpmath
>>> mpmath.iv.randmatrix(3)
matrix(
[['[0.66382280562735496154, 0.66382280562735496154]', '[0.016861908353603016764, 0.016861908353603016764]', '[0.73734056129022396142, 0.73734056129022396142]'],
 ['[0.36647301100616180847, 0.36647301100616180847]', '[0.62220372249504873885, 0.62220372249504873885]', '[0.48761902415903068952, 0.48761902415903068952]'],
 ['[0.81322606973113087392, 0.81322606973113087392]', '[0.15903271707414323721, 0.15903271707414323721]', '[0.090983058161586249923, 0.090983058161586249923]']])
>>> type(mpmath.fp.randmatrix(3)[0,0])
<type 'float'>
>>> type(mpmath.mp.randmatrix(3)[0,0])
<class 'mpmath.ctx_mp_python.mpf'>
>>> type(mpmath.iv.randmatrix(3)[0,0])
<class 'mpmath.ctx_iv.ivmpf'>
```

- [ ] Is it okay that I moved `import random` to the top level? AFAIK it should even be faster this way.