### PR TITLE
Matrix equality: Implement M == None, raise exception for unknown types

### DIFF
--- a/mpmath/matrices/matrices.py
+++ b/mpmath/matrices/matrices.py
@@ -690,8 +690,19 @@ class _matrix(object):
         return -self + other
 
     def __eq__(self, other):
-        return self.__rows == other.__rows and self.__cols == other.__cols \
-               and self.__data == other.__data
+        if other is None:
+            return False
+        try:
+            return self.__rows == other.__rows and self.__cols == other.__cols \
+                   and self.__data == other.__data
+        except AttributeError:
+            return NotImplemented
+
+    def __ne__(self, other):
+        v = self.__eq__(other)
+        if v is NotImplemented:
+            return v
+        return not v
 
     def __len__(self):
         if self.rows == 1:

--- a/mpmath/tests/test_matrices.py
+++ b/mpmath/tests/test_matrices.py
@@ -7,7 +7,13 @@ def test_matrix_basic():
     for i in range(3):
         A1[i,i] = 1
     assert A1 == eye(3)
+    assert not A1 != eye(3)
     assert A1 == matrix(A1)
+    assert A1 != 'hello'
+    assert not A1 == 'hello'
+    assert not A1 == 42
+    assert not A1 == None
+    assert A1 != None
     A2 = matrix(3, 2)
     assert not A2._matrix__data
     A3 = matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
@@ -16,6 +22,8 @@ def test_matrix_basic():
     assert not (1, 1) in A3._matrix__data
     A4 = matrix([[1, 2, 3], [4, 5, 6]])
     A5 = matrix([[6, -1], [3, 2], [0, -3]])
+    assert not A4 == A5
+    assert A4 != A5
     assert A4 * A5 == matrix([[12, -6], [39, -12]])
     assert A1 * A3 == A3 * A1 == A3
     pytest.raises(ValueError, lambda: A2*A2)
@@ -192,10 +200,13 @@ def test_matrix_numpy():
     try:
         import numpy
     except ImportError:
-        return
+        pytest.skip("NumPy not installed")
     l = [[1, 2], [3, 4], [5, 6]]
     a = numpy.array(l)
+    m = matrix(l)
     assert matrix(l) == matrix(a)
+    assert m.__eq__(a) == NotImplemented
+    assert m.__ne__(a) == NotImplemented
 
 def test_interval_matrix_scalar_mult():
     """Multiplication of iv.matrix and any scalar type"""


### PR DESCRIPTION
The following statements now no longer give a cryptic error message:
```
>>> import mpmath, numpy
>>> mpmath.eye(2) == None
False
>>> mpmath.eye(2) == numpy.eye(2)   
...
NotImplementedError: Unsupported type for testing equality: mpmath.matrix == <type 'numpy.ndarray'>
```