### PR TITLE
quadsing: quadrature for integrals with (fractional power like) singalarities at endpoints

### DIFF
--- a/docs/calculus/integration.rst
+++ b/docs/calculus/integration.rst
@@ -16,6 +16,11 @@ Oscillatory quadrature (``quadosc``)
 
 .. autofunction:: mpmath.quadosc
 
+Quadrature for singular integrals (``quadsing``)
+............................................
+
+.. autofunction:: mpmath.quadsing
+
 Quadrature rules
 ................
 

--- a/mpmath/__init__.py
+++ b/mpmath/__init__.py
@@ -104,6 +104,7 @@ quadgl = mp.quadgl
 quadts = mp.quadts
 quadosc = mp.quadosc
 quadsubdiv = mp.quadsubdiv
+quadsing = mp.quadsing
 
 invertlaplace = mp.invertlaplace
 invlaptalbot = mp.invlaptalbot

--- a/mpmath/tests/test_quad.py
+++ b/mpmath/tests/test_quad.py
@@ -93,3 +93,12 @@ def test_expmath_fail():
     assert ae(quadts(lambda x: atan(x)/(x*sqrt(1-x**2)), [0, 1]), pi*log(1+sqrt(2))/2)
     assert ae(quadts(lambda x: log(1+x**2)/x**2, [0, 1]),         pi/2-log(2))
     assert ae(quadts(lambda x: x**2/((1+x**4)*sqrt(1-x**4)), [0, 1]),     pi/8)
+
+def test_quadsing():
+    assert quadsing(lambda s: s**(-9/mpf(10)), [0, 1], where="left").ae(10)
+    assert quadsing(lambda s: s**(-11/mpf(10)), [1, inf], where="right").ae(10)
+    a, b = mpf(1)/7, mpf(1)/9
+    x, y = mpf(11), mpf(3)
+    assert quadsing(lambda t: (x-t)**(a-1)*(t-y)**(b-1), [y, x], where="both").ae(beta(a,b)*(x-y)**(a+b-1))
+    assert quadsing(lambda t: t**(a-1)/(1+t)**(a+b), [0, inf], where="both").ae(beta(a,b))
+    assert quadsing(lambda t: exp(t)*(-t)**(a-1), [-inf, 0], where="right").ae(gamma(a))

--- a/mpmath/tests/test_quad.py
+++ b/mpmath/tests/test_quad.py
@@ -95,6 +95,7 @@ def test_expmath_fail():
     assert ae(quadts(lambda x: x**2/((1+x**4)*sqrt(1-x**4)), [0, 1]),     pi/8)
 
 def test_quadsing():
+    # functionality tests
     assert quadsing(lambda s: s**(-9/mpf(10)), [0, 1], where="left").ae(10)
     assert quadsing(lambda s: s**(-11/mpf(10)), [1, inf], where="right").ae(10)
     a, b = mpf(1)/7, mpf(1)/9
@@ -102,3 +103,13 @@ def test_quadsing():
     assert quadsing(lambda t: (x-t)**(a-1)*(t-y)**(b-1), [y, x], where="both").ae(beta(a,b)*(x-y)**(a+b-1))
     assert quadsing(lambda t: t**(a-1)/(1+t)**(a+b), [0, inf], where="both").ae(beta(a,b))
     assert quadsing(lambda t: exp(t)*(-t)**(a-1), [-inf, 0], where="right").ae(gamma(a))
+    # code coverage tests
+    assert quadsing(lambda x: exp(-x*x),[mp.inf,-mp.inf], where="both").ae(-sqrt(pi))
+    assert quadsing(lambda x: exp(-x*x),[mp.inf,-mp.inf], where="left").ae(-sqrt(pi))
+    assert quadsing(lambda x: exp(-x*x),[mp.inf,-mp.inf], where="right").ae(-sqrt(pi))
+    assert quadsing(lambda x: exp(-x*x),[-mp.inf,0], where="both").ae(sqrt(pi)/2)
+    assert quadsing(lambda x: exp(-x*x),[-mp.inf,0], where="left").ae(sqrt(pi)/2)
+    assert quadsing(lambda x: exp(-x*x),[-mp.inf,0], where="right").ae(sqrt(pi)/2)
+    assert quadsing(lambda x: exp(-x*x),[0,mp.inf], where="both").ae(sqrt(pi)/2)
+    assert quadsing(lambda x: exp(-x*x),[0,mp.inf], where="left").ae(sqrt(pi)/2)
+    assert quadsing(lambda x: exp(-x*x),[0,mp.inf], where="right").ae(sqrt(pi)/2)

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ develop = %(tests)s
           codecov
           wheel
 gmpy =
-    gmpy2>=2.1.0a4; platform_python_implementation!="PyPy"
+    gmpy2>=2.1.0a4; platform_python_implementation!="PyPy" and python_version < "3.10"
 docs = sphinx
 [pycodestyle]
 select = E101,W191,W291,W293,E111,E112,E113,W292,W391


### PR DESCRIPTION
Hi.

mpmath's quad is surprisingly bad at integrating something like 
quad(lambda x: x**(-99999999/mpf(100000000)), [0, 1])

I added the function function quadsing which can handle such integrals.
The function works reasonably well for power-like singularities x**e with 
complex exponent e at endpoints. 

Greetings
  Timo

Edit: The check was not successful because 3.10-dev could not build gmpy as dependency...