### PR TITLE
(Update on PR #543) Fixed TypeError in `LU_comp`, updated `determinant` docs and added `rank` function for matrices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ htmlcov/
 
 # Visual Studio files
 .vs/
+
+# PyCharm files
+.idea/

--- a/docs/matrices.rst
+++ b/docs/matrices.rst
@@ -260,6 +260,12 @@ so called norms.
 Linear algebra
 --------------
 
+Determinant
+...........
+
+.. autofunction :: mpmath.det
+
+
 Decompositions
 ..............
 

--- a/docs/matrices.rst
+++ b/docs/matrices.rst
@@ -260,10 +260,12 @@ so called norms.
 Linear algebra
 --------------
 
-Determinant
-...........
+Determinant and Rank
+....................
 
 .. autofunction :: mpmath.det
+
+.. autofunction :: mpmath.rank
 
 
 Decompositions

--- a/mpmath/__init__.py
+++ b/mpmath/__init__.py
@@ -172,6 +172,7 @@ svd_r = mp.svd_r
 svd_c = mp.svd_c
 svd = mp.svd
 gauss_quadrature = mp.gauss_quadrature
+rank = mp.rank
 
 expm = mp.expm
 sqrtm = mp.sqrtm

--- a/mpmath/matrices/linalg.py
+++ b/mpmath/matrices/linalg.py
@@ -536,7 +536,63 @@ class LinearAlgebraMethods:
 
     def det(ctx, A):
         """
-        Calculate the determinant of a matrix.
+        Calculate the determinant of a square matrix.
+        The determinant is the normed, alternating n-linear from,
+        i.e. a multiplicative map for each matrix into the
+        field of numbers of its entries.
+
+        **Examples**
+
+        Determinant of identity is 1.
+
+        >>> from mpmath import *
+        >>> A = eye(3)
+        >>> print(det(A))
+        1
+
+        But in general a matrix can have any number as its determinant.
+
+        >>> A = matrix([[2, 6, 4],[3, 8, 6],[1, 1, 2]])
+        >>> print(det(A))
+        0
+
+        The determinant is vanishing if a matrix has no inverse.
+
+        >>> A = matrix([[1, 3, 2],[0, 1, 0],[0, 0, 0]])
+        >>> print(det(A))
+        0
+
+        But, matrix has determinate different from zero full rank if and only is is equivalent to identity,
+
+        >>> A = matrix([[1, 3, -2], [1, 9, -6], [1, 4, -3]])
+        >>> print(det(A))
+        -2
+
+        i.e. has an inverse matrix.
+
+        >>> B = 0.5 * matrix([[3, -1, 0], [3, 1, -4], [5, 1, -6]])
+        >>> A*B == eye(3)
+        True
+        >>> print(det(A))
+        -0.5
+
+        As mentioned, the determinant is multiplicative, i.e.
+
+        >>> det(A*B) == det(A) * det(b)
+        True
+        >>> 2*det(B) == det(2*B)
+        True
+
+        Moreover, a matrix of integers has an inverse matrix of integers
+        if and only if the determinat is equal to either 1 or -1.
+
+        >>> A = matrix([[1, 0, 1],[-2, 1, -2],[-4, 1, -5]])
+        >>> B = matrix([[3, -1, 1],[2, 1, 0],[-2, 1, -1]])
+        >>> A*B == eye(3)
+        True
+        >>> print(det(A), det(B))
+        -2.0 -0.5
+
         """
         prec = ctx.prec
         try:

--- a/mpmath/matrices/linalg.py
+++ b/mpmath/matrices/linalg.py
@@ -134,6 +134,9 @@ class LinearAlgebraMethods:
                 if current > biggest: # TODO: what if equal?
                     biggest = current
                     p[j] = k
+            # without pivot LU fails
+            if p[j] is None:
+                raise ZeroDivisionError('matrix is numerically singular')
             # swap rows according to p
             ctx.swap_row(A, j, p[j])
             if ctx.absmin(A[j,j]) <= tol:
@@ -539,8 +542,6 @@ class LinearAlgebraMethods:
         try:
             # do not overwrite A
             A = ctx.matrix(A).copy()
-            if any(all(ctx.almosteq(0, x) for x in A[:, c]) for c in range(A.cols)):
-                return 0 * A[0, 0]
             # use LU factorization to calculate determinant
             try:
                 R, p = ctx.LU_decomp(A)

--- a/mpmath/matrices/linalg.py
+++ b/mpmath/matrices/linalg.py
@@ -539,6 +539,8 @@ class LinearAlgebraMethods:
         try:
             # do not overwrite A
             A = ctx.matrix(A).copy()
+            if any(all(ctx.almosteq(0, x) for x in A[:, c]) for c in range(A.cols)):
+                return 0 * A[0, 0]
             # use LU factorization to calculate determinant
             try:
                 R, p = ctx.LU_decomp(A)

--- a/mpmath/tests/test_linalg.py
+++ b/mpmath/tests/test_linalg.py
@@ -69,6 +69,9 @@ A10 = matrix([[1.0 + 1.0j, 2.0, 2.0],
             [4.0, 5.0, 6.0],
             [7.0, 8.0, 9.0]])
 b10 = [1.0, 1.0 + 1.0j, 1.0]
+A11 = matrix([[4, 0, -2],
+             [2, 0, -4],
+             [2, 0, 5.5]])
 
 
 def test_LU_decomp():
@@ -193,6 +196,8 @@ def test_det():
     assert det(A5) == 1
     assert round(det(A6)) == 78356463
     assert det(zeros(3)) == 0
+    assert det(A11) == 0
+
 
 def test_cond():
     A = matrix([[1.2969, 0.8648], [0.2161, 0.1441]])

--- a/mpmath/tests/test_linalg.py
+++ b/mpmath/tests/test_linalg.py
@@ -4,8 +4,8 @@ import pytest
 
 from mpmath import (cond, det, diag, exp, expm, extend, extradps, eye, fp,
                     hilbert, inf, inverse, iv, j, lu, lu_solve, matrix, mnorm,
-                    mp, mpc, mpf, nint, norm, pi, qr, qr_solve, rand,
-                    randmatrix, residual, zeros)
+                    mp, mpc, mpf, nint, norm, pi, qr, qr_solve, rand, rank,
+                    randmatrix, residual, zeros, absmin, eps)
 
 
 # XXX: these shouldn't be visible(?)
@@ -78,6 +78,9 @@ A12 = matrix([[1,0,0],
               [0,1,0],
               [0,0,1.0j]])
 
+A13 = matrix([[2, 6, 4],
+              [3, 8, 6],
+              [1, 1, 2]])
 
 def test_LU_decomp():
     A = A3.copy()
@@ -337,3 +340,18 @@ def test_qr():
             n1 = norm(eye(m) - Q.conjugate() * Q.T)
             #print ' Norm of I - Q.conjugate() * Q.T = ', n1
             assert n1 <= maxnorm
+
+def test_rank():
+    assert rank(A1) == 3
+    assert rank(A2) == 4
+    assert rank(A3) == 5
+    assert rank(A4) == 5
+    assert rank(A5) == 3
+    assert rank(A6) == 3
+    assert rank(zeros(3)) == 0
+    assert rank(A11) == 2
+    assert rank(A1*A11) == 2
+    assert rank(A11*A11) == 2
+    iszerofunc = lambda x: not bool(x)
+    assert rank(A13) == 2
+    assert rank(A13, iszerofunc) == 3

--- a/mpmath/tests/test_linalg.py
+++ b/mpmath/tests/test_linalg.py
@@ -69,9 +69,14 @@ A10 = matrix([[1.0 + 1.0j, 2.0, 2.0],
             [4.0, 5.0, 6.0],
             [7.0, 8.0, 9.0]])
 b10 = [1.0, 1.0 + 1.0j, 1.0]
+
 A11 = matrix([[4, 0, -2],
              [2, 0, -4],
              [2, 0, 5.5]])
+
+A12 = matrix([[1,0,0],
+              [0,1,0],
+              [0,0,1.0j]])
 
 
 def test_LU_decomp():
@@ -95,6 +100,12 @@ def test_LU_decomp():
     bak = A.copy()
     LU_decomp(A, overwrite=1)
     assert A != bak
+
+    try:
+        LU_decomp(A11)
+        assert False
+    except ZeroDivisionError:
+        assert True
 
 def test_inverse():
     for A in [A1, A2, A5]:
@@ -197,7 +208,7 @@ def test_det():
     assert round(det(A6)) == 78356463
     assert det(zeros(3)) == 0
     assert det(A11) == 0
-
+    assert absmin(det(A12*1e-30) - 1e-30) < eps
 
 def test_cond():
     A = matrix([[1.2969, 0.8648], [0.2161, 0.1441]])

--- a/mpmath/tests/test_linalg.py
+++ b/mpmath/tests/test_linalg.py
@@ -101,11 +101,7 @@ def test_LU_decomp():
     LU_decomp(A, overwrite=1)
     assert A != bak
 
-    try:
-        LU_decomp(A11)
-        assert False
-    except ZeroDivisionError:
-        assert True
+    pytest.raises(ZeroDivisionError, LU_decomp, A11)
 
 def test_inverse():
     for A in [A1, A2, A5]:


### PR DESCRIPTION
This is an update on PR #543 

- fixed an issue in `LU_comp` which raised TypeError on singular matrices
- added documentation of `determinant` function of matrices 
- added `rank` function of matrices 

(PR #543 was originally opened and closed by _sonntagsgesicht_)
