### PR TITLE
Allow returning information from findroot solvers

### DIFF
--- a/mpmath/calculus/optimization.py
+++ b/mpmath/calculus/optimization.py
@@ -671,7 +671,7 @@ class MDNewton:
             while True:
                 if x1 == x0:
                     if self.verbose:
-                        print("canceled, won't get more excact")
+                        print("canceled, won't get more exact")
                     cancel = True
                     break
                 fx = self.ctx.matrix(f(*x1))

--- a/mpmath/tests/test_rootfinding.py
+++ b/mpmath/tests/test_rootfinding.py
@@ -70,7 +70,7 @@ def test_multidimensional():
     def f(*x):
         return [3*x[0]**2-2*x[1]**2-1, x[0]**2-2*x[0]+x[1]**2+2*x[1]-8]
     assert mnorm(jacobian(f, (1,-2)) - matrix([[6,8],[0,-2]]),1) < 1.e-7
-    for x, error in MDNewton(mp, f, (1,-2), verbose=0,
+    for x, error, details in MDNewton(mp, f, (1,-2), verbose=0,
                              norm=lambda x: norm(x, inf)):
         pass
     assert norm(f(*x), 2) < 1e-14


### PR DESCRIPTION
This information can be used to create basin diagrams for roots. I have some large exponentials and luckily mpmath is able to solve roughly 2/3 of the points for which SciPy overflows. I don't know if the iteration counts are comparable with those from SciPy's "hybr" solver.

The general approach is provided in `findroot` with an example in `MDNewton`. I assume more information can be returned from other solvers as the need arises.