### PR TITLE
improved hypsum non-convergence behaviour

### DIFF
--- a/mpmath/ctx_mp.py
+++ b/mpmath/ctx_mp.py
@@ -705,7 +705,7 @@ maxterms, or set zeroprec."""
             max_total_jump += abs(d)
         while 1:
             if extraprec > maxprec:
-                raise ValueError(ctx._hypsum_msg % (prec, prec+extraprec))
+                raise ctx.NoConvergence(ctx._hypsum_msg % (prec, prec+extraprec))
             wp = prec + extraprec
             if magnitude_check:
                 mag_dict = dict((n,None) for n in magnitude_check)

--- a/mpmath/functions/hypergeometric.py
+++ b/mpmath/functions/hypergeometric.py
@@ -440,7 +440,11 @@ def _hyp2f1(ctx, a_s, b_s, z, **kwargs):
     # possibly in finitely many terms
     if absz <= 0.8 or (ctx.isint(a) and a <= 0 and a >= -1000) or \
                       (ctx.isint(b) and b <= 0 and b >= -1000):
-        return ctx.hypsum(2, 1, (atype, btype, ctype), [a, b, c], z, **kwargs)
+        try:
+            return ctx.hypsum(2, 1, (atype, btype, ctype), [a, b, c], z, **kwargs)
+        except ctx.NoConvergence:
+            if kwargs.get('force_series', False):
+                raise
 
     orig = ctx.prec
     try:

--- a/mpmath/tests/test_functions2.py
+++ b/mpmath/tests/test_functions2.py
@@ -1381,7 +1381,7 @@ def test_hyper_param_accuracy():
     assert (hyp1f1(-10000, 1000, 100)*10**424).ae(-3.1046080515824859974)
     assert (hyp2f1(1000,1.5,-3.5,-0.75,maxterms=100000)*10**231).ae(-4.0534790813913998643)
     assert legenp(2, 3, 0.25) == 0
-    pytest.raises(ValueError, lambda: hypercomb(lambda a: [([],[],[],[],[a],[-a],0.5)], [3]))
+    pytest.raises(mp.NoConvergence, lambda: hypercomb(lambda a: [([],[],[],[],[a],[-a],0.5)], [3]))
     assert hypercomb(lambda a: [([],[],[],[],[a],[-a],0.5)], [3], infprec=200) == inf
     assert meijerg([[],[]],[[0,0,0,0],[]],0.1).ae(1.5680822343832351418)
     assert (besselk(400,400)*10**94).ae(1.4387057277018550583)


### PR DESCRIPTION
This change includes two `hypsum` related fixes:
1. It turns the `ValueError` exception, raised in `mp.hypsum` when encountering convergence problems, into a more appropriate `NoConvergence` exception - just as `fp.hypsum` does already.
2. It properly handles this `NoConvergence` exception withing the "fast path" of [`hyp2f1`](https://github.com/mpmath/mpmath/blob/1258e33e1618a6c537947775a03a7746362c4cee/mpmath/functions/hypergeometric.py#L439-L443). The same behavior is already used in the "fast path"s of [`_hyp2f0`](https://github.com/mpmath/mpmath/blob/1258e33e1618a6c537947775a03a7746362c4cee/mpmath/functions/hypergeometric.py#L982-L988), [`_hypq1fq`](https://github.com/mpmath/mpmath/blob/1258e33e1618a6c537947775a03a7746362c4cee/mpmath/functions/hypergeometric.py#L496-L500), and [`_hyp_borel`](https://github.com/mpmath/mpmath/blob/1258e33e1618a6c537947775a03a7746362c4cee/mpmath/functions/hypergeometric.py#L694-L697) - and was broken since `hypsum` never raised the expected `NoConvergence` exception (in the `mp` context). Similar to `_hyp2f0`, this behavior can be suppressed with the keyword argument `force_series=True`.

I've also seen that similar issues may be affecting [`hypercomb`](https://github.com/mpmath/mpmath/blob/1258e33e1618a6c537947775a03a7746362c4cee/mpmath/functions/hypergeometric.py#L76), since it also raise `ValueError` instead of `NoConvergence` to signal convergence issues. If interested, I could also change that function appropriately.

I've verified in known pathological case (`mpmath.hyp2f1(3814.269794854973, -1985.4387491751415, 5369.1679108495828, 0.70000000000000007).ae('4.1656634124024037e-532')`) that both "fast path" (with raised `maxprec`) and the "slow path" (which is actually faster) bow yield the same result. If interested, I can also add this as a test case.

This change may positivity affect some of the cases alluded to in #296. For the issues #14 and #495 it shifts the convergence issue into the "slow path", which may be preferable.
