### PR TITLE
Fix running pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,10 @@
 [pytest]
+pythonpath = .
+doctest_optionflags = IGNORE_EXCEPTION_DETAIL
+addopts = --doctest-modules
+          --ignore=setup.py
+          --doctest-glob='*.txt'
+          --doctest-glob='*.rst'
+norecursedirs = docs/plots demo .eggs .git build
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,12 +41,6 @@ docs = sphinx
 [pycodestyle]
 select = E101,W191,W291,W293,E111,E112,E113,W292,W391
 exclude = .eggs,.git
-[tool:pytest]
-doctest_optionflags = IGNORE_EXCEPTION_DETAIL
-addopts = --doctest-modules
-          --ignore=setup.py
-          --doctest-glob='*.txt'
-norecursedirs = doc/source/plots demo .eggs .git
 [coverage:run]
 branch = True
 omit = mpmath/tests/*


### PR DESCRIPTION
Running pytest doesn't work quite right. Changes here:
 - move all pytest configuration from setup.cfg to pytest.ini to avoid having different configurations
 - add . to pythonpath so the mpmath module here takes precedence in case mpmath is installed in system
 - fix norecursedirs: doc/source/plots -> docs/plots
 - add build to norecursedirs so pytest works even after building mpmath
 - add '*.rst' to globs so pytest picks a few tests in docs/*.rst

With this changes I can run `pytest` on a clean git clone. It will test this mpmath module (and not  the system-installed one, which is an older version). It will run all tests (not just the ones in`test_*.py`). Also, `pytest` still works after running `python setup.py build`. Adding this new `pytest.ini` to the extracted tarball from pypi also makes pytest work ok.

**Please ship `pytest.ini` with pypi tarballs so pytest works there.**