### PR TITLE
PEP8 fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,6 @@ jobs:
       run: |
         python -We:invalid -m compileall -f mpmath -q
         pycodestyle
-        ruff --help >/dev/null 2>&1 && ruff --format=github --select=E703,E712,E713 .
     - name: Tests
       run: pytest
     - name: Remove gmpy on 2.7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
       run: |
         python -We:invalid -m compileall -f mpmath -q
         pycodestyle
+        ruff --help >/dev/null 2>&1 && ruff --format=github --select=E703,E712,E713 .
     - name: Tests
       run: pytest
     - name: Remove gmpy on 2.7

--- a/demo/manydigits.py
+++ b/demo/manydigits.py
@@ -92,7 +92,7 @@ print("C17: S= -4*Zeta(2) - 2*Zeta(3) + 4*Zeta(2)*Zeta(3) + 2*Zeta(5)")
 print(pr(-4*zeta(2) - 2*zeta(3) + 4*zeta(2)*zeta(3) + 2*zeta(5)))
 print()
 
-print("C18: Catalan G = Sum{i=0}{\infty}(-1)^i/(2i+1)^2")
+print(r"C18: Catalan G = Sum{i=0}{\infty}(-1)^i/(2i+1)^2")
 print(pr(catalan))
 print()
 

--- a/mpmath/calculus/extrapolation.py
+++ b/mpmath/calculus/extrapolation.py
@@ -2109,7 +2109,7 @@ def limit(ctx, f, x, direction=1, exp=False, **kwargs):
             values.append(g(k+1))
 
     # XXX: steps used by nsum don't work well
-    if not 'steps' in kwargs:
+    if 'steps' not in kwargs:
         kwargs['steps'] = [10]
 
     return +ctx.adaptive_extrapolation(update, None, kwargs)

--- a/mpmath/calculus/optimization.py
+++ b/mpmath/calculus/optimization.py
@@ -38,7 +38,7 @@ class Newton:
         else:
             raise ValueError('expected 1 starting point, got %i' % len(x0))
         self.f = f
-        if not 'df' in kwargs:
+        if 'df' not in kwargs:
             def df(x):
                 return self.ctx.diff(f, x)
         else:
@@ -126,13 +126,13 @@ class MNewton:
             raise ValueError('expected 1 starting point, got %i' % len(x0))
         self.x0 = x0[0]
         self.f = f
-        if not 'df' in kwargs:
+        if 'df' not in kwargs:
             def df(x):
                 return self.ctx.diff(f, x)
         else:
             df = kwargs['df']
         self.df = df
-        if not 'd2f' in kwargs:
+        if 'd2f' not in kwargs:
             def d2f(x):
                 return self.ctx.diff(df, x)
         else:
@@ -183,13 +183,13 @@ class Halley:
             raise ValueError('expected 1 starting point, got %i' % len(x0))
         self.x0 = x0[0]
         self.f = f
-        if not 'df' in kwargs:
+        if 'df' not in kwargs:
             def df(x):
                 return self.ctx.diff(f, x)
         else:
             df = kwargs['df']
         self.df = df
-        if not 'd2f' in kwargs:
+        if 'd2f' not in kwargs:
             def d2f(x):
                 return self.ctx.diff(df, x)
         else:
@@ -529,7 +529,7 @@ class ANewton:
             raise ValueError('expected 1 starting point, got %i' % len(x0))
         self.x0 = x0[0]
         self.f = f
-        if not 'df' in kwargs:
+        if 'df' not in kwargs:
             def df(x):
                 return self.ctx.diff(f, x)
         else:
@@ -944,7 +944,7 @@ def findroot(ctx, f, x0, solver='secant', tol=None, verbose=False, verify=True, 
         if multidimensional:
             # only one multidimensional solver available at the moment
             solver = MDNewton
-            if not 'norm' in kwargs:
+            if 'norm' not in kwargs:
                 norm = lambda x: ctx.norm(x, 'inf')
                 kwargs['norm'] = norm
             else:

--- a/mpmath/calculus/polynomials.py
+++ b/mpmath/calculus/polynomials.py
@@ -171,7 +171,7 @@ def polyroots(ctx, coeffs, maxsteps=50, cleanup=True, extraprec=10,
         if roots_init is None:
             roots = [ctx.mpc((0.4+0.9j)**n) for n in xrange(deg)]
         else:
-            roots = [None]*deg;
+            roots = [None]*deg
             deg_init = min(deg, len(roots_init))
             roots[:deg_init] = list(roots_init[:deg_init])
             roots[deg_init:] = [ctx.mpc((0.4+0.9j)**n) for n

--- a/mpmath/ctx_base.py
+++ b/mpmath/ctx_base.py
@@ -320,7 +320,7 @@ class StandardBaseContext(Context,
                             % len(args))
         if n < 1:
             raise ValueError('n must be greater than 0')
-        if not 'endpoint' in kwargs or kwargs['endpoint']:
+        if 'endpoint' not in kwargs or kwargs['endpoint']:
             if n == 1:
                 return [ctx.mpf(a)]
             step = (b - a) / ctx.mpf(n - 1)

--- a/mpmath/functions/bessel.py
+++ b/mpmath/functions/bessel.py
@@ -618,19 +618,19 @@ def _airy_zero(ctx, which, k, derivative, complex=False):
     k = int(k)
     if k < 1:
         raise ValueError("k cannot be less than 1")
-    if not derivative in (0,1):
+    if derivative not in (0, 1):
         raise ValueError("Derivative should lie between 0 and 1")
     if which == 0:
         if derivative:
             return ctx.findroot(lambda z: ctx.airyai(z,1),
                 -U(3*ctx.pi*(4*k-3)/8))
         return ctx.findroot(ctx.airyai, -T(3*ctx.pi*(4*k-1)/8))
-    if which == 1 and complex == False:
+    if which == 1 and complex is False:
         if derivative:
             return ctx.findroot(lambda z: ctx.airybi(z,1),
                 -U(3*ctx.pi*(4*k-1)/8))
         return ctx.findroot(ctx.airybi, -T(3*ctx.pi*(4*k-3)/8))
-    if which == 1 and complex == True:
+    if which == 1 and complex is True:
         if derivative:
             t = 3*ctx.pi*(4*k-3)/8 + 0.75j*ctx.ln2
             s = ctx.expjpi(ctx.mpf(1)/3) * T(t)
@@ -861,7 +861,7 @@ def bessel_zero(ctx, kind, prime, v, m, isoltol=0.01, _interval_cache={}):
             raise ValueError("v cannot be negative")
         if m < 1:
             raise ValueError("m cannot be less than 1")
-        if not prime in (0,1):
+        if prime not in (0, 1):
             raise ValueError("prime should lie between 0 and 1")
         if kind == 1:
             if prime: f = lambda x: ctx.besselj(v,x,derivative=1)

--- a/mpmath/libmp/gammazeta.py
+++ b/mpmath/libmp/gammazeta.py
@@ -1633,27 +1633,27 @@ def complex_stirling_series(x, y, prec):
     sim = -y
 
     # Add initial terms of Stirling's series
-    sre += tre//12; sim += tim//12;
+    sre += tre//12; sim += tim//12
     tre, tim = ((tre*ure-tim*uim)>>prec), ((tre*uim+tim*ure)>>prec)
-    sre -= tre//360; sim -= tim//360;
+    sre -= tre//360; sim -= tim//360
     tre, tim = ((tre*ure-tim*uim)>>prec), ((tre*uim+tim*ure)>>prec)
-    sre += tre//1260; sim += tim//1260;
+    sre += tre//1260; sim += tim//1260
     tre, tim = ((tre*ure-tim*uim)>>prec), ((tre*uim+tim*ure)>>prec)
-    sre -= tre//1680; sim -= tim//1680;
-    tre, tim = ((tre*ure-tim*uim)>>prec), ((tre*uim+tim*ure)>>prec)
-    if abs(tre) + abs(tim) < 5: return sre, sim
-    sre += tre//1188; sim += tim//1188;
-    tre, tim = ((tre*ure-tim*uim)>>prec), ((tre*uim+tim*ure)>>prec)
-    sre -= 691*tre//360360; sim -= 691*tim//360360;
-    tre, tim = ((tre*ure-tim*uim)>>prec), ((tre*uim+tim*ure)>>prec)
-    sre += tre//156; sim += tim//156;
+    sre -= tre//1680; sim -= tim//1680
     tre, tim = ((tre*ure-tim*uim)>>prec), ((tre*uim+tim*ure)>>prec)
     if abs(tre) + abs(tim) < 5: return sre, sim
-    sre -= 3617*tre//122400; sim -= 3617*tim//122400;
+    sre += tre//1188; sim += tim//1188
     tre, tim = ((tre*ure-tim*uim)>>prec), ((tre*uim+tim*ure)>>prec)
-    sre += 43867*tre//244188; sim += 43867*tim//244188;
+    sre -= 691*tre//360360; sim -= 691*tim//360360
     tre, tim = ((tre*ure-tim*uim)>>prec), ((tre*uim+tim*ure)>>prec)
-    sre -= 174611*tre//125400; sim -= 174611*tim//125400;
+    sre += tre//156; sim += tim//156
+    tre, tim = ((tre*ure-tim*uim)>>prec), ((tre*uim+tim*ure)>>prec)
+    if abs(tre) + abs(tim) < 5: return sre, sim
+    sre -= 3617*tre//122400; sim -= 3617*tim//122400
+    tre, tim = ((tre*ure-tim*uim)>>prec), ((tre*uim+tim*ure)>>prec)
+    sre += 43867*tre//244188; sim += 43867*tim//244188
+    tre, tim = ((tre*ure-tim*uim)>>prec), ((tre*uim+tim*ure)>>prec)
+    sre -= 174611*tre//125400; sim -= 174611*tim//125400
     tre, tim = ((tre*ure-tim*uim)>>prec), ((tre*uim+tim*ure)>>prec)
     if abs(tre) + abs(tim) < 5: return sre, sim
 

--- a/mpmath/matrices/eigen_symmetric.py
+++ b/mpmath/matrices/eigen_symmetric.py
@@ -1614,7 +1614,7 @@ def svd_r(ctx, A, full_matrices = False, compute_uv = True, overwrite_a = False)
         S = svd_r_raw(ctx, A, V, calc_u = True)
 
         if n > m:
-            if full_matrices == False:
+            if full_matrices is False:
                 V = V[:m,:]
 
             S = S[:m]
@@ -1718,7 +1718,7 @@ def svd_c(ctx, A, full_matrices = False, compute_uv = True, overwrite_a = False)
         S = svd_c_raw(ctx, A, V, calc_u = True)
 
         if n > m:
-            if full_matrices == False:
+            if full_matrices is False:
                 V = V[:m,:]
 
             S = S[:m]

--- a/mpmath/tests/runtests.py
+++ b/mpmath/tests/runtests.py
@@ -27,7 +27,9 @@ one of the arguments in their name are executed.
 
 """
 
-import sys, os, traceback
+import os
+import sys
+import traceback
 
 profile = False
 if "-profile" in sys.argv:

--- a/mpmath/tests/test_basic_ops.py
+++ b/mpmath/tests/test_basic_ops.py
@@ -342,107 +342,107 @@ def test_floor_ceil_nint_frac():
 
 def test_isnan_etc():
     from mpmath.rational import mpq
-    assert isnan(nan) == True
-    assert isnan(3) == False
-    assert isnan(mpf(3)) == False
-    assert isnan(inf) == False
-    assert isnan(mpc(2,nan)) == True
-    assert isnan(mpc(2,nan)) == True
-    assert isnan(mpc(nan,nan)) == True
-    assert isnan(mpc(2,2)) == False
-    assert isnan(mpc(nan,inf)) == True
-    assert isnan(mpc(inf,inf)) == False
-    assert isnan(mpq((3,2))) == False
-    assert isnan(mpq((0,1))) == False
-    assert isinf(inf) == True
-    assert isinf(-inf) == True
-    assert isinf(3) == False
-    assert isinf(nan) == False
-    assert isinf(3+4j) == False
-    assert isinf(mpc(inf)) == True
-    assert isinf(mpc(3,inf)) == True
-    assert isinf(mpc(inf,3)) == True
-    assert isinf(mpc(inf,inf)) == True
-    assert isinf(mpc(nan,inf)) == True
-    assert isinf(mpc(inf,nan)) == True
-    assert isinf(mpc(nan,nan)) == False
-    assert isinf(mpq((3,2))) == False
-    assert isinf(mpq((0,1))) == False
-    assert isnormal(3) == True
-    assert isnormal(3.5) == True
-    assert isnormal(mpf(3.5)) == True
-    assert isnormal(0) == False
-    assert isnormal(mpf(0)) == False
-    assert isnormal(0.0) == False
-    assert isnormal(inf) == False
-    assert isnormal(-inf) == False
-    assert isnormal(nan) == False
-    assert isnormal(float(inf)) == False
-    assert isnormal(mpc(0,0)) == False
-    assert isnormal(mpc(3,0)) == True
-    assert isnormal(mpc(0,3)) == True
-    assert isnormal(mpc(3,3)) == True
-    assert isnormal(mpc(0,nan)) == False
-    assert isnormal(mpc(0,inf)) == False
-    assert isnormal(mpc(3,nan)) == False
-    assert isnormal(mpc(3,inf)) == False
-    assert isnormal(mpc(3,-inf)) == False
-    assert isnormal(mpc(nan,0)) == False
-    assert isnormal(mpc(inf,0)) == False
-    assert isnormal(mpc(nan,3)) == False
-    assert isnormal(mpc(inf,3)) == False
-    assert isnormal(mpc(inf,nan)) == False
-    assert isnormal(mpc(nan,inf)) == False
-    assert isnormal(mpc(nan,nan)) == False
-    assert isnormal(mpc(inf,inf)) == False
-    assert isnormal(mpq((3,2))) == True
-    assert isnormal(mpq((0,1))) == False
-    assert isint(3) == True
-    assert isint(0) == True
-    assert isint(long(3)) == True
-    assert isint(long(0)) == True
-    assert isint(mpf(3)) == True
-    assert isint(mpf(0)) == True
-    assert isint(mpf(-3)) == True
-    assert isint(mpf(3.2)) == False
-    assert isint(3.2) == False
-    assert isint(nan) == False
-    assert isint(inf) == False
-    assert isint(-inf) == False
-    assert isint(mpc(0)) == True
-    assert isint(mpc(3)) == True
-    assert isint(mpc(3.2)) == False
-    assert isint(mpc(3,inf)) == False
-    assert isint(mpc(inf)) == False
-    assert isint(mpc(3,2)) == False
-    assert isint(mpc(0,2)) == False
-    assert isint(mpc(3,2),gaussian=True) == True
-    assert isint(mpc(3,0),gaussian=True) == True
-    assert isint(mpc(0,3),gaussian=True) == True
-    assert isint(3+4j) == False
-    assert isint(3+4j, gaussian=True) == True
-    assert isint(3+0j) == True
-    assert isint(mpq((3,2))) == False
-    assert isint(mpq((3,9))) == False
-    assert isint(mpq((9,3))) == True
-    assert isint(mpq((0,4))) == True
-    assert isint(mpq((1,1))) == True
-    assert isint(mpq((-1,1))) == True
-    assert mp.isnpint(0) == True
-    assert mp.isnpint(1) == False
-    assert mp.isnpint(-1) == True
-    assert mp.isnpint(-1.1) == False
-    assert mp.isnpint(-1.0) == True
-    assert mp.isnpint(mp.mpq(1,2)) == False
-    assert mp.isnpint(mp.mpq(-1,2)) == False
-    assert mp.isnpint(mp.mpq(-3,1)) == True
-    assert mp.isnpint(mp.mpq(0,1)) == True
-    assert mp.isnpint(mp.mpq(1,1)) == False
-    assert mp.isnpint(0+0j) == True
-    assert mp.isnpint(-1+0j) == True
-    assert mp.isnpint(-1.1+0j) == False
-    assert mp.isnpint(-1+0.1j) == False
-    assert mp.isnpint(0+0.1j) == False
+    assert isnan(nan) is True
+    assert isnan(3) is False
+    assert isnan(mpf(3)) is False
+    assert isnan(inf) is False
+    assert isnan(mpc(2, nan)) is True
+    assert isnan(mpc(2, nan)) is True
+    assert isnan(mpc(nan, nan)) is True
+    assert isnan(mpc(2, 2)) is False
+    assert isnan(mpc(nan, inf)) is True
+    assert isnan(mpc(inf, inf)) is False
+    assert isnan(mpq((3, 2))) is False
+    assert isnan(mpq((0, 1))) is False
+    assert isinf(inf) is True
+    assert isinf(-inf) is True
+    assert isinf(3) is False
+    assert isinf(nan) is False
+    assert isinf(3 + 4j) is False
+    assert isinf(mpc(inf)) is True
+    assert isinf(mpc(3, inf)) is True
+    assert isinf(mpc(inf, 3)) is True
+    assert isinf(mpc(inf, inf)) is True
+    assert isinf(mpc(nan, inf)) is True
+    assert isinf(mpc(inf, nan)) is True
+    assert isinf(mpc(nan, nan)) is False
+    assert isinf(mpq((3, 2))) is False
+    assert isinf(mpq((0, 1))) is False
+    assert isnormal(3) is True
+    assert isnormal(3.5) is True
+    assert isnormal(mpf(3.5)) is True
+    assert isnormal(0) is False
+    assert isnormal(mpf(0)) is False
+    assert isnormal(0.0) is False
+    assert isnormal(inf) is False
+    assert isnormal(-inf) is False
+    assert isnormal(nan) is False
+    assert isnormal(float(inf)) is False
+    assert isnormal(mpc(0, 0)) is False
+    assert isnormal(mpc(3, 0)) is True
+    assert isnormal(mpc(0, 3)) is True
+    assert isnormal(mpc(3, 3)) is True
+    assert isnormal(mpc(0, nan)) is False
+    assert isnormal(mpc(0, inf)) is False
+    assert isnormal(mpc(3, nan)) is False
+    assert isnormal(mpc(3, inf)) is False
+    assert isnormal(mpc(3, -inf)) is False
+    assert isnormal(mpc(nan, 0)) is False
+    assert isnormal(mpc(inf, 0)) is False
+    assert isnormal(mpc(nan, 3)) is False
+    assert isnormal(mpc(inf, 3)) is False
+    assert isnormal(mpc(inf, nan)) is False
+    assert isnormal(mpc(nan, inf)) is False
+    assert isnormal(mpc(nan, nan)) is False
+    assert isnormal(mpc(inf, inf)) is False
+    assert isnormal(mpq((3, 2))) is True
+    assert isnormal(mpq((0, 1))) is False
+    assert isint(3) is True
+    assert isint(0) is True
+    assert isint(long(3)) is True
+    assert isint(long(0)) is True
+    assert isint(mpf(3)) is True
+    assert isint(mpf(0)) is True
+    assert isint(mpf(-3)) is True
+    assert isint(mpf(3.2)) is False
+    assert isint(3.2) is False
+    assert isint(nan) is False
+    assert isint(inf) is False
+    assert isint(-inf) is False
+    assert isint(mpc(0)) is True
+    assert isint(mpc(3)) is True
+    assert isint(mpc(3.2)) is False
+    assert isint(mpc(3, inf)) is False
+    assert isint(mpc(inf)) is False
+    assert isint(mpc(3, 2)) is False
+    assert isint(mpc(0, 2)) is False
+    assert isint(mpc(3, 2), gaussian=True) is True
+    assert isint(mpc(3, 0), gaussian=True) is True
+    assert isint(mpc(0, 3), gaussian=True) is True
+    assert isint(3 + 4j) is False
+    assert isint(3 + 4j, gaussian=True) is True
+    assert isint(3 + 0j) is True
+    assert isint(mpq((3, 2))) is False
+    assert isint(mpq((3, 9))) is False
+    assert isint(mpq((9, 3))) is True
+    assert isint(mpq((0, 4))) is True
+    assert isint(mpq((1, 1))) is True
+    assert isint(mpq((-1, 1))) is True
+    assert mp.isnpint(0) is True
+    assert mp.isnpint(1) is False
+    assert mp.isnpint(-1) is True
+    assert mp.isnpint(-1.1) is False
+    assert mp.isnpint(-1.0) is True
+    assert mp.isnpint(mp.mpq(1, 2)) is False
+    assert mp.isnpint(mp.mpq(-1, 2)) is False
+    assert mp.isnpint(mp.mpq(-3, 1)) is True
+    assert mp.isnpint(mp.mpq(0, 1)) is True
+    assert mp.isnpint(mp.mpq(1, 1)) is False
+    assert mp.isnpint(0 + 0j) is True
+    assert mp.isnpint(-1 + 0j) is True
+    assert mp.isnpint(-1.1 + 0j) is False
+    assert mp.isnpint(-1 + 0.1j) is False
+    assert mp.isnpint(0 + 0.1j) is False
 
 
 def test_issue_438():

--- a/mpmath/tests/test_interval.py
+++ b/mpmath/tests/test_interval.py
@@ -22,7 +22,7 @@ def test_interval_identity():
     assert mpi(-5, 5) in w
     assert mpi(2, inf) in w
     assert mpi(0, 2) in mpi(0, 10)
-    assert not (3 in mpi(-inf, 0))
+    assert 3 not in mpi(-inf, 0)
 
 def test_interval_hash():
     assert hash(mpi(3)) == hash(3)

--- a/mpmath/tests/test_matrices.py
+++ b/mpmath/tests/test_matrices.py
@@ -13,7 +13,7 @@ def test_matrix_basic():
     A3 = matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     assert list(A3) == list(range(1, 10))
     A3[1,1] = 0
-    assert not (1, 1) in A3._matrix__data
+    assert (1, 1) not in A3._matrix__data
     A4 = matrix([[1, 2, 3], [4, 5, 6]])
     A5 = matrix([[6, -1], [3, 2], [0, -3]])
     assert A4 * A5 == matrix([[12, -6], [39, -12]])

--- a/mpmath/tests/torture.py
+++ b/mpmath/tests/torture.py
@@ -38,7 +38,8 @@ TODO:
 """
 
 
-import sys, os
+import os
+import sys
 from timeit import default_timer as clock
 
 if "-nogmpy" in sys.argv:

--- a/mpmath/usertools.py
+++ b/mpmath/usertools.py
@@ -84,7 +84,7 @@ def timing(f, *args, **kwargs):
     if t > 0.05 or once:
         return t
     for i in range(3):
-        t1=clock();
+        t1=clock()
         # Evaluate multiple times because the timer function
         # has a significant overhead
         g();g();g();g();g();g();g();g();g();g()

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ gmpy =
     gmpy2>=2.1.0a4; platform_python_implementation!="PyPy"
 docs = sphinx
 [pycodestyle]
-select = E10,E11,E13,E703,E71,E9,W1,W2,W3,W6
+select = E101,E111,E112,E113,E703,E712,E713,W191,W291,W292,W293,W391
 exclude = .eggs,.git
 [tool:pytest]
 testpaths = mpmath docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,10 +31,9 @@ tests_require = mpmath[tests]
 [options.extras_require]
 tests = pytest >= 4.6
 develop = %(tests)s
-          codecov
           pycodestyle
           pytest-cov
-          ruff; python_version>"3.6"
+          codecov
           wheel
 gmpy =
     gmpy2>=2.1.0a4; platform_python_implementation!="PyPy"

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ gmpy =
     gmpy2>=2.1.0a4; platform_python_implementation!="PyPy"
 docs = sphinx
 [pycodestyle]
-select = E101,W191,W291,W293,E111,E112,E113,W292,W391
+select = E101,W191,W291,W293,E111,E112,E113,W292,W391,E703,E712,E713
 exclude = .eggs,.git
 [tool:pytest]
 testpaths = mpmath docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,9 +31,10 @@ tests_require = mpmath[tests]
 [options.extras_require]
 tests = pytest >= 4.6
 develop = %(tests)s
+          codecov
           pycodestyle
           pytest-cov
-          codecov
+          ruff; python_version>"3.6"
           wheel
 gmpy =
     gmpy2>=2.1.0a4; platform_python_implementation!="PyPy"

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ gmpy =
     gmpy2>=2.1.0a4; platform_python_implementation!="PyPy"
 docs = sphinx
 [pycodestyle]
-select = E101,W191,W291,W293,E111,E112,E113,W292,W391,E703,E712,E713
+select = E10,E11,E13,E703,E71,E9,W1,W2,W3,W6
 exclude = .eggs,.git
 [tool:pytest]
 testpaths = mpmath docs


### PR DESCRIPTION
Describe the tool `ruff`, how it finds three pep8 issues, and how it fixes those 3 issues.

[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.

% `ruff --select=E703,E712,E713 --statistics .`
```
 12	E703	[*] Statement ends with an unnecessary semicolon
105	E712	[*] Comparison to `False` should be `cond is False`
 13	E713	[*] Test for membership should be `not in`
```
% ` ruff --select=E703,E712,E713 --fix .`
```
Found 130 errors (130 fixed, 0 remaining).
```