### PR TITLE
Correct pow() for mpf's to be consistent with mpfr/float's

### DIFF
--- a/mpmath/libmp/libelefun.py
+++ b/mpmath/libmp/libelefun.py
@@ -337,6 +337,8 @@ def mpf_pow(s, t, prec, rnd=round_fast):
                 return mpf_pow_int(mpf_sqrt(s, prec+10,
                     reciprocal_rnd[rnd]), -tman, prec, rnd)
             return mpf_pow_int(mpf_sqrt(s, prec+10, rnd), tman, prec, rnd)
+    if s == fone:
+        return fone
     # General formula: s**t = exp(t*log(s))
     # TODO: handle rnd direction of the logarithm carefully
     c = mpf_log(s, prec+10, rnd)

--- a/mpmath/libmp/libmpf.py
+++ b/mpmath/libmp/libmpf.py
@@ -1033,6 +1033,8 @@ def mpf_pow_int(s, n, prec, rnd=round_fast):
             if n > 0: return [finf, fninf][n & 1]
             if n == 0: return fnan
             return fzero
+        if n == 0:
+            return fone
         return fnan
 
     n = int(n)

--- a/mpmath/tests/test_special.py
+++ b/mpmath/tests/test_special.py
@@ -74,7 +74,8 @@ def test_special_powers():
     assert (-inf)**-2 == 0
     assert (-inf)**-3 == 0
     assert isnan(nan**5)
-    assert isnan(nan**0)
+    assert nan**0 == 1
+    assert 1**inf == 1
 
 def test_functions_special():
     assert exp(inf) == inf


### PR DESCRIPTION
Before nan's were handled differently than described in the IEEE 754 standard.  Now, as for float's or gmpy2.mpfr's:
  * pow(1, y) returns 1 for any y, even a nan
  * pow(x, 0) returns 1 for any x, even a nan

Closes #516

See also:
https://en.cppreference.com/w/c/numeric/math/pow
https://www.mpfr.org/mpfr-current/mpfr.html#index-mpfr_005fpow
https://docs.python.org/3/library/math.html#math.pow