### PR TITLE
Misc fixes

### DIFF
--- a/mpmath/libmp/__init__.py
+++ b/mpmath/libmp/__init__.py
@@ -25,10 +25,10 @@ from .libhyper import (NoConvergence, make_hyp_summator, mpc_agm, mpc_agm1,
                        mpc_ellipk, mpc_si, mpf_agm, mpf_agm1, mpf_besseljn,
                        mpf_ci, mpf_ci_si, mpf_e1, mpf_ei, mpf_ellipe,
                        mpf_ellipk, mpf_erf, mpf_erfc, mpf_expint, mpf_si)
-from .libintmath import (bin_to_radix, bitcount, eulernum, gcd, ifac, ifib,
-                         isprime, isqrt, isqrt_fast, isqrt_small, list_primes,
-                         moebius, numeral, sqrt_fixed, sqrtrem, stirling1,
-                         stirling2, trailing)
+from .libintmath import (bin_to_radix, bitcount, eulernum, gcd, giant_steps,
+                         ifac, ifib, isprime, isqrt, isqrt_fast, isqrt_small,
+                         list_primes, moebius, numeral, sqrt_fixed, sqrtrem,
+                         stirling1, stirling2, trailing)
 from .libmpc import (complex_int_pow, mpc_abs, mpc_acos, mpc_acosh, mpc_add,
                      mpc_add_mpf, mpc_arg, mpc_asin, mpc_asinh, mpc_atan,
                      mpc_atanh, mpc_cbrt, mpc_ceil, mpc_conjugate, mpc_cos,

--- a/mpmath/libmp/libintmath.py
+++ b/mpmath/libmp/libintmath.py
@@ -299,13 +299,12 @@ else:
         return res
 
 
-def ifib(n, _cache={}):
+@lru_cache(maxsize=250)
+def ifib(n):
     """Computes the nth Fibonacci number as an integer, for
     integer n."""
     if n < 0:
         return (-1)**(-n+1) * ifib(-n)
-    if n in _cache:
-        return _cache[n]
     m = n
     # Use Dijkstra's logarithmic algorithm
     # The following implementation is basically equivalent to
@@ -320,8 +319,6 @@ def ifib(n, _cache={}):
             qq = q*q
             p, q = p*p+qq, qq+2*p*q
             n >>= 1
-    if m < 250:
-        _cache[m] = b
     return b
 
 MAX_FACTORIAL_CACHE = 1000
@@ -464,9 +461,8 @@ def moebius(n):
 #     computes first all
 #     the previous ones, and keeps them in the CACHE
 
-MAX_EULER_CACHE = 500
-
-def eulernum(m, _cache={0:MPZ_ONE}):
+@lru_cache(maxsize=500)
+def eulernum(m):
     r"""
     Computes the Euler numbers `E(n)`, which can be defined as
     coefficients of the Taylor expansion of `1/cosh x`:
@@ -486,12 +482,9 @@ def eulernum(m, _cache={0:MPZ_ONE}):
     # for odd m > 1, the Euler numbers are zero
     if m & 1:
         return MPZ_ZERO
-    f = _cache.get(m)
-    if f:
-        return f
-    MAX = MAX_EULER_CACHE
     n = m
     a = [MPZ(_) for _ in [0,0,1,0,0,0]]
+    suma = MPZ(1)
     for  n in range(1, m+1):
         for j in range(n+1, -1, -2):
             a[j+1] = (j-1)*a[j] + (j+1)*a[j+2]
@@ -499,10 +492,7 @@ def eulernum(m, _cache={0:MPZ_ONE}):
         suma = 0
         for k in range(n+1, -1, -2):
             suma += a[k+1]
-            if n <= MAX:
-                _cache[n] = ((-1)**(n//2))*(suma // 2**n)
-        if n == m:
-            return ((-1)**(n//2))*suma // 2**n
+    return ((-1)**(n//2))*suma // 2**n
 
 def stirling1(n, k):
     """

--- a/mpmath/libmp/libintmath.py
+++ b/mpmath/libmp/libintmath.py
@@ -415,6 +415,12 @@ def isprime(n):
             return False
     return True
 
+if BACKEND == 'gmpy':
+    isprime = gmpy.is_prime
+elif BACKEND == 'sage':
+    def isprime(n):
+        return MPZ(n).is_prime(False)
+
 def moebius(n):
     """
     Evaluates the Moebius function which is `mu(n) = (-1)^k` if `n`

--- a/mpmath/tests/test_functions2.py
+++ b/mpmath/tests/test_functions2.py
@@ -12,6 +12,7 @@ from mpmath import (agm, airyai, airybi, appellf1, bei, ber, besseli, besselj,
                     legenq, li, log, meijerg, mp, mpc, mpf, nan, ncdf, npdf,
                     nthroot, pi, qp, quadts, shi, si, spherharm, sqrt, struveh,
                     struvel, whitm, whitw)
+from mpmath.libmp import BACKEND
 
 
 def test_bessel():
@@ -2358,8 +2359,7 @@ def test_issue_569():
     r = betainc(1, 2, 1, 1)
     assert isinstance(r, mp.mpf) and r == 0
 
+@pytest.mark.skipif(BACKEND != 'gmpy', reason="gmpy isn't used")
 def test_issue_274():
-    pytest.importorskip("gmpy2")
-
     with pytest.raises(ValueError):
         mp.fraction(1, 100).func(1000, 0xdead)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ Documentation = 'http://mpmath.org/doc/current/'
 tests = ['pytest>=6', 'numpy<=1.25.2; python_version<"3.12"']
 develop = ['mpmath[tests]', 'flake518>=1.5; python_version>="3.9"',
            'pytest-cov', 'wheel', 'build']
-gmpy = ['gmpy2>=2.1.0a4; platform_python_implementation!="PyPy" and python_version<"3.12"']
+gmpy = ['gmpy2>=2.1.0a4; platform_python_implementation!="PyPy" and python_version<"3.12"',
+        'gmpy2>=2.2.0a1; platform_python_implementation!="PyPy" and python_version>="3.12"']
 docs = ['sphinx']
 [tool.setuptools]
 zip-safe = true


### PR DESCRIPTION
* use lru_cache() in ifib() and eulernum()
* use isprime() alternatives from backends
* amend https://github.com/mpmath/mpmath/commit/425858e06b32fc9ef9c218dba0eb03b46f3bc820
* add giant_steps() to libmp
* depend on gmpy2>=2.2.0a1 for CPython>=3.12