### PR TITLE
Misc fixes

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -74,11 +74,6 @@ Python interpreter and do the following::
     >>> print(2*pi)
     6.2831853071795864769252867665590057683943387987502
 
-.. note::
-
-    If you have are upgrading mpmath from an earlier version, you may have to
-    manually uninstall the old version or remove the old files.
-
 Using gmpy (optional)
 ---------------------
 

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -74,21 +74,35 @@ Python interpreter and do the following::
     >>> print(2*pi)
     6.2831853071795864769252867665590057683943387987502
 
+.. warning::
+
+   By default, mpmath uses Python integers internally.  Beware that now CPython
+   has a `global limit
+   <https://docs.python.org/3/library/stdtypes.html#integer-string-conversion-length-limitation>`_
+   for converting between :class:`int` and :class:`str`.  This affects
+   conversion to mpmath types from big decimal strings.  For example::
+
+       >>> mpf('1' * 500_000)
+       Traceback (most recent call last):
+       ...
+       ValueError: Exceeds the limit (4300 digits) for integer string conversion...
+
+   You could use ``sys.set_int_max_str_digits(0)`` to disable this limitation.
+
 Using gmpy (optional)
 ---------------------
 
-By default, mpmath uses Python integers internally. If `gmpy
-<https://github.com/aleaxit/gmpy>`_ version 2.1.0a4 or later is installed on
-your system, mpmath will automatically detect it and transparently use gmpy
-integers instead. This makes mpmath much faster, especially at high precision
-(approximately above 100 digits).
+If `gmpy <https://github.com/aleaxit/gmpy>`_ version 2.1.0a4 or later is
+installed on your system, mpmath will automatically detect it and transparently
+use gmpy integers instead of Python integers.  This makes mpmath much faster,
+especially at high precision (approximately above 100 digits).
 
 To verify that mpmath uses gmpy, check the internal variable ``BACKEND`` is
 equal to 'gmpy'.
 
-The gmpy mode can be disabled by setting the ``MPMATH_NOGMPY`` environment
-variable. Note that the mode cannot be switched during runtime; mpmath must be
-re-imported for this change to take effect.
+Using the gmpy backend can be disabled by setting the ``MPMATH_NOGMPY``
+environment variable.  Note that the mode cannot be switched during runtime;
+mpmath must be re-imported for this change to take effect.
 
 Running tests
 -------------

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -83,8 +83,8 @@ your system, mpmath will automatically detect it and transparently use gmpy
 integers instead. This makes mpmath much faster, especially at high precision
 (approximately above 100 digits).
 
-To verify that mpmath uses gmpy, check the internal variable ``BACKEND`` is not
-equal to 'python'.
+To verify that mpmath uses gmpy, check the internal variable ``BACKEND`` is
+equal to 'gmpy'.
 
 The gmpy mode can be disabled by setting the ``MPMATH_NOGMPY`` environment
 variable. Note that the mode cannot be switched during runtime; mpmath must be

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -74,6 +74,12 @@ Python interpreter and do the following::
     >>> print(2*pi)
     6.2831853071795864769252867665590057683943387987502
 
+..
+    >>> import mpmath, pytest
+    >>> if mpmath.libmp.backend.BACKEND != 'python':
+    ...     pytest.skip('skip the rest')
+    >>>
+
 .. warning::
 
    By default, mpmath uses Python integers internally.  Beware that now CPython

--- a/mpmath/ctx_mp_python.py
+++ b/mpmath/ctx_mp_python.py
@@ -539,12 +539,21 @@ class _mpc(mpnumeric):
     def __new__(cls, real=0, imag=0):
         s = object.__new__(cls)
         if isinstance(real, complex_types):
-            real, imag = real.real, real.imag
+            r_real, r_imag = real.real, real.imag
         elif hasattr(real, '_mpc_'):
-            s._mpc_ = real._mpc_
-            return s
-        real = cls.context.mpf(real)
-        imag = cls.context.mpf(imag)
+            r_real, r_imag = real._mpc_
+        else:
+            r_real, r_imag = real, 0
+        if isinstance(imag, complex_types):
+            i_real, i_imag = imag.real, imag.imag
+        elif hasattr(imag, '_mpc_'):
+            i_real, i_imag = imag._mpc_
+        else:
+            i_real, i_imag = imag, 0
+        r_real, r_imag = map(cls.context.mpf, [r_real, r_imag])
+        i_real, i_imag = map(cls.context.mpf, [i_real, i_imag])
+        real = r_real - i_imag
+        imag = r_imag + i_real
         s._mpc_ = (real._mpf_, imag._mpf_)
         return s
 

--- a/mpmath/ctx_mp_python.py
+++ b/mpmath/ctx_mp_python.py
@@ -86,6 +86,8 @@ class _mpf(mpnumeric):
             if a == b:
                 return a
             raise ValueError("can only create mpf from zero-width interval")
+        if type(x).__module__ == 'decimal':
+            return from_Decimal(x, prec, rounding)
         raise TypeError("cannot create mpf from " + repr(x))
 
     @classmethod

--- a/mpmath/ctx_mp_python.py
+++ b/mpmath/ctx_mp_python.py
@@ -42,30 +42,21 @@ class _mpf(mpnumeric):
             if 'dps' in kwargs:
                 prec = dps_to_prec(kwargs['dps'])
             rounding = kwargs.get('rounding', rounding)
+        v = new(cls)
         if type(val) is cls:
-            sign, man, exp, bc = val._mpf_
-            if (not man) and exp:
-                return val
-            v = new(cls)
-            v._mpf_ = normalize(sign, man, exp, bc, prec, rounding)
-            return v
+            val = val._mpf_
         elif type(val) is tuple:
-            if len(val) == 2:
-                v = new(cls)
+            if len(val) == 4:
+                pass
+            elif len(val) == 2:
                 v._mpf_ = from_man_exp(val[0], val[1], prec, rounding)
                 return v
-            if len(val) == 4:
-                if val not in (finf, fninf, fnan):
-                    sign, man, exp, bc = val
-                    val = normalize(sign, MPZ(man), exp, bc, prec, rounding)
-                v = new(cls)
-                v._mpf_ = val
-                return v
-            raise ValueError
+            else:
+                raise ValueError
         else:
-            v = new(cls)
-            v._mpf_ = mpf_pos(cls.mpf_convert_arg(val, prec, rounding), prec, rounding)
-            return v
+            val = cls.mpf_convert_arg(val, prec, rounding)
+        v._mpf_ = mpf_pos(val, prec, rounding)
+        return v
 
     @classmethod
     def mpf_convert_arg(cls, x, prec, rounding):

--- a/mpmath/ctx_mp_python.py
+++ b/mpmath/ctx_mp_python.py
@@ -13,7 +13,7 @@ from .libmp import (MPQ, MPZ, ComplexResult, dps_to_prec, finf, fnan, fninf,
                     mpf_mod, mpf_mul, mpf_mul_int, mpf_neg, mpf_pos, mpf_pow,
                     mpf_pow_int, mpf_rdiv_int, mpf_sub, mpf_sum, normalize,
                     prec_to_dps, round_nearest, to_fixed, to_float, to_int,
-                    to_str)
+                    to_rational, to_str)
 
 
 new = object.__new__
@@ -120,6 +120,9 @@ class _mpf(mpnumeric):
     imag = property(lambda self: self.context.zero)
 
     conjugate = lambda self: self
+
+    def as_integer_ratio(self):
+        return to_rational(self._mpf_)
 
     def __reduce__(self): return self.__class__, (self._mpf_,)
 

--- a/mpmath/libmp/libmpf.py
+++ b/mpmath/libmp/libmpf.py
@@ -1193,7 +1193,8 @@ def str_to_man_exp(x, base=10):
         if a == '':
             a = '0'
         x = a + b
-    x = MPZ(int(x, base))
+    x = x.replace(' ', '').replace('+', '')  # workaround aleaxit/gmpy#381
+    x = MPZ(x, base)
     return x, exp
 
 special_str = {'inf':finf, '+inf':finf, '-inf':fninf, 'nan':fnan}

--- a/mpmath/libmp/libmpf.py
+++ b/mpmath/libmp/libmpf.py
@@ -922,11 +922,11 @@ def mpf_pow_int(s, n, prec, rnd=round_fast):
     if (not man) and exp:
         if s == finf:
             if n > 0: return s
-            if n == 0: return fnan
+            if n == 0: return fone
             return fzero
         if s == fninf:
             if n > 0: return [finf, fninf][n & 1]
-            if n == 0: return fnan
+            if n == 0: return fone
             return fzero
         if n == 0:
             return fone

--- a/mpmath/libmp/libmpf.py
+++ b/mpmath/libmp/libmpf.py
@@ -410,9 +410,9 @@ def to_rational(s):
     if bc == -1:
         raise ValueError("cannot convert %s to a rational number" % man)
     if exp >= 0:
-        return man * (1<<exp), 1
+        return man * (1<<exp), MPZ(1)
     else:
-        return man, 1<<(-exp)
+        return man, MPZ(1)<<(-exp)
 
 def to_fixed(s, prec):
     """Convert a raw mpf to a fixed-point big integer"""

--- a/mpmath/libmp/libmpf.py
+++ b/mpmath/libmp/libmpf.py
@@ -404,11 +404,13 @@ def from_rational(p, q, prec, rnd=round_fast):
 def to_rational(s):
     """Convert a raw mpf to a rational number. Return integers (p, q)
     such that s = p/q exactly."""
+    if s == fnan:
+        raise ValueError("cannot convert nan to a rational number")
+    if s in (finf, fninf):
+        raise OverflowError("cannot convert infinity to a rational number")
     sign, man, exp, bc = s
     if sign:
         man = -man
-    if bc == -1:
-        raise ValueError("cannot convert %s to a rational number" % man)
     if exp >= 0:
         return man * (1<<exp), MPZ(1)
     else:

--- a/mpmath/tests/test_basic_ops.py
+++ b/mpmath/tests/test_basic_ops.py
@@ -101,6 +101,9 @@ def test_pow():
     assert 6 ** mpc(3) == 216.0
     assert 6.0 ** mpc(3) == 216.0
     assert (6+0j) ** mpc(3) == 216.0
+    assert inf ** mpf(0) == mpf(1)
+    assert ninf ** mpf(0) == mpf(1)
+    assert nan ** mpf(0) == mpf(1)
 
 def test_mixed_misc():
     assert 1 + mpf(3) == mpf(3) + 1 == 4

--- a/mpmath/tests/test_basic_ops.py
+++ b/mpmath/tests/test_basic_ops.py
@@ -5,8 +5,8 @@ import random
 import pytest
 
 from mpmath import (ceil, fadd, fdiv, floor, fmul, fneg, fp, frac, fsub, inf,
-                    isinf, isint, isnan, isnormal, monitor, mp, mpc, mpf, mpi,
-                    nan, ninf, nint, nint_distance, pi, iv, workprec)
+                    isinf, isint, isnan, isnormal, iv, monitor, mp, mpc, mpf,
+                    mpi, nan, ninf, nint, nint_distance, pi, workprec)
 from mpmath.libmp import (MPQ, finf, fnan, fninf, fone, from_float, from_int,
                           from_str, mpf_add, mpf_mul, mpf_sub, round_down,
                           round_nearest, round_up, to_int)
@@ -169,6 +169,11 @@ def test_mpf_props():
     assert a.man == 1
     assert a.exp == -1
     assert a.bc == 1
+
+def test_mpf_methods():
+    assert mpf(0.5).as_integer_ratio() == (1, 2)
+    assert mpf('0.3').as_integer_ratio() == (5404319552844595,
+                                             18014398509481984)
 
 def test_mpf_magic():
     assert complex(mpf(0.5)) == complex(0.5)

--- a/mpmath/tests/test_basic_ops.py
+++ b/mpmath/tests/test_basic_ops.py
@@ -154,6 +154,7 @@ def test_mpf_init():
     pytest.raises(TypeError, lambda: mpf(SomethingComplex()))
     assert mpf(mympf()) == mpf(3.5)
     assert mympf() - mpf(0.5) == mpf(3.0)
+    assert mpf(decimal.Decimal('1.5')) == mpf('1.5')
 
 def test_mpc_init():
     class mympc:

--- a/mpmath/tests/test_basic_ops.py
+++ b/mpmath/tests/test_basic_ops.py
@@ -152,6 +152,14 @@ def test_mpf_init():
     assert mpf(mympf()) == mpf(3.5)
     assert mympf() - mpf(0.5) == mpf(3.0)
 
+def test_mpc_init():
+    class mympc:
+        @property
+        def _mpc_(self):
+            return (mpf(7)._mpf_, mpf(-1)._mpf_)
+    assert mpc(3+1j, 7-1j) == mpc(real='4.0', imag='8.0')
+    assert mpc(3+1j, mympc()) == mpc(real='4.0', imag='8.0')
+
 def test_mpf_props():
     a = mpf(0.5)
     assert a.man_exp == (1, -1)

--- a/mpmath/tests/test_convert.py
+++ b/mpmath/tests/test_convert.py
@@ -117,6 +117,10 @@ def test_convert_rational():
     assert from_rational(30, 5, 53, round_nearest) == (0, 3, 1, 2)
     assert from_rational(-7, 4, 53, round_nearest) == (1, 7, -2, 3)
     assert to_rational((0, 1, -1, 1)) == (1, 2)
+    assert to_rational((0, 1, 0, 1)) == (1, 1)
+    pytest.raises(ValueError, lambda: to_rational(mpf('nan')._mpf_))
+    pytest.raises(OverflowError, lambda: to_rational(mpf('inf')._mpf_))
+    pytest.raises(OverflowError, lambda: to_rational(mpf('-inf')._mpf_))
 
 def test_custom_class():
     class mympf:

--- a/mpmath/tests/test_functions2.py
+++ b/mpmath/tests/test_functions2.py
@@ -2363,3 +2363,10 @@ def test_issue_569():
 def test_issue_274():
     with pytest.raises(ValueError):
         mp.fraction(1, 100).func(1000, 0xdead)
+
+def test_issue_523():
+    assert mp.hermite(0, inf) == 1.0
+
+def test_issue_512():
+    assert mp.hyperu(0, 1, inf) == 1.0
+    assert mp.hyperu(0, 2, inf) == 1.0

--- a/mpmath/tests/test_special.py
+++ b/mpmath/tests/test_special.py
@@ -67,11 +67,11 @@ def test_special():
 
 def test_special_powers():
     assert inf**3 == inf
-    assert isnan(inf**0)
+    assert inf**0 == 1
     assert inf**-3 == 0
     assert (-inf)**2 == inf
     assert (-inf)**3 == -inf
-    assert isnan((-inf)**0)
+    assert (-inf)**0 == 1
     assert (-inf)**-2 == 0
     assert (-inf)**-3 == 0
     assert isnan(nan**5)


### PR DESCRIPTION
* remove obsoleted note on upgrade
* rephrase note on gmpy2 detection
* fix mpc() constructor to be compatible with complex(), closes #730
* add note about new int/str conversion limits, closes #716
* avoid extra type-cast (``int`` -> ``MPZ``) in ``str_to_man_exp()``
* fix disagreement fp.pow vs mp.pow, closes #512, closes #523
* add mpf.as_integer_ratio() method, closes #417 
* raise OverflowError for infs in to_rational
* support construction of mpf from Decimal objects
* simplify ``_mpf.__new__()``