### PR TITLE
Do not build depend on pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['pip>=20.3', 'setuptools>=61', 'wheel',
+requires = ['setuptools>=61', 'wheel',
             'setuptools_scm[toml]>=6.0']
 build-backend = 'setuptools.build_meta'
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
-requires = ['setuptools>=61', 'wheel',
-            'setuptools_scm[toml]>=6.0']
+requires = ['setuptools>=61', 'setuptools_scm[toml]>=6.0']
 build-backend = 'setuptools.build_meta'
 [project]
 name = 'mpmath'


### PR DESCRIPTION
It seems to me that pip is not necessary to build.

In fact, I succesfully built 1.4.0a0 without pip, passing `--skip-dependency-check` option to `python -m build` so it won't complain.