### PR TITLE
Test against PyPy nightly builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10', 3.11, 3.12, 3.13, pypy3.8, pypy3.9, pypy3.10]
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12, 3.13, pypy3.9-nightly, pypy3.10-nightly]
         coverage: [false]
         nogmpy: [false]
         default: [false]

--- a/README.rst
+++ b/README.rst
@@ -113,8 +113,8 @@ Release history:
 1. Download & installation
 --------------------------
 
-Mpmath requires Python 3.8 or later versions. It has been tested
-with CPython 3.8 through 3.12 and for PyPy.
+Mpmath requires Python 3.8 or later versions.  It has been tested with CPython
+3.8 through 3.13 and for PyPy 3.9 through 3.10.
 
 The latest release of mpmath can be downloaded from the mpmath
 website and from https://github.com/mpmath/mpmath/releases

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -1,8 +1,8 @@
 Setting up mpmath
 =================
 
-Mpmath requires at least Python 3.8.  It has been tested
-with CPython 3.8 through 3.11 and for PyPy.
+Mpmath requires at least Python 3.8.  It has been tested with CPython 3.8
+through 3.13 and for PyPy 3.9 through 3.10
 
 Download and installation
 -------------------------


### PR DESCRIPTION
This also drops testing against PyPy 3.8 (it's unmaintained).

Closes https://github.com/mpmath/mpmath/issues/762