### PR TITLE
Use sys.executable instead of "python" for test_cli

### DIFF
--- a/mpmath/tests/test_cli.py
+++ b/mpmath/tests/test_cli.py
@@ -5,7 +5,7 @@ import time
 
 import pexpect
 import pytest
-
+import sys
 
 if platform.python_implementation() == 'PyPy':
     pytest.skip("Don't run CLI tests on PyPy.",
@@ -26,7 +26,7 @@ class Console(pexpect.spawn):
 
 
 def test_bare_console_no_bare_division():
-    c = Console('python -m mpmath --no-ipython --no-wrap-floats')
+    c = Console(f'{sys.executable} -m mpmath --no-ipython --no-wrap-floats')
 
     assert c.expect_exact('>>> ') == 0
     assert c.send('1 + 2\r\n') == 7
@@ -44,7 +44,7 @@ def test_bare_console_no_bare_division():
 
 
 def test_bare_console_bare_division():
-    c = Console('python -m mpmath --no-ipython --no-wrap-division '
+    c = Console(f'{sys.executable} -m mpmath --no-ipython --no-wrap-division '
                 '--no-wrap-floats')
 
     assert c.expect_exact('>>> ') == 0
@@ -60,7 +60,7 @@ def test_bare_console_without_ipython():
     except ImportError:
         pass
 
-    c = Console('python -m mpmath')
+    c = Console(f'{sys.executable} -m mpmath')
 
     assert c.expect_exact('>>> ') == 0
     assert c.send('1 + 2\r\n') == 7
@@ -72,7 +72,7 @@ def test_bare_console_without_ipython():
 def test_ipython_console_bare_division_noauto():
     pytest.importorskip('IPython')
 
-    c = Console('python -m mpmath --simple-prompt --no-wrap-floats '
+    c = Console(f'{sys.executable} -m mpmath --simple-prompt --no-wrap-floats '
                 "--no-wrap-division --colors 'NoColor' ")
 
     assert c.expect_exact('\r\nIn [1]: ') == 0
@@ -83,7 +83,7 @@ def test_ipython_console_bare_division_noauto():
 def test_ipython_console_wrap_floats():
     pytest.importorskip('IPython')
 
-    c = Console('python -m mpmath --simple-prompt --prec 100 '
+    c = Console(f'{sys.executable} -m mpmath --simple-prompt --prec 100 '
                 "--colors 'NoColor'")
 
     assert c.expect_exact('\r\nIn [1]: ') == 0
@@ -92,7 +92,7 @@ def test_ipython_console_wrap_floats():
 
 
 def test_bare_console_wrap_floats():
-    c = Console('python -m mpmath --simple-prompt --no-ipython --prec 100 '
+    c = Console(f'{sys.executable} -m mpmath --simple-prompt --no-ipython --prec 100 '
                 "--colors 'NoColor'")
 
     assert c.expect_exact('>>> ') == 0
@@ -105,7 +105,7 @@ def test_bare_console_wrap_floats():
 
 
 def test_bare_console_pretty():
-    c = Console('python -m mpmath --simple-prompt --no-ipython --prec 100 '
+    c = Console(f'{sys.executable} -m mpmath --simple-prompt --no-ipython --prec 100 '
                 "--colors 'NoColor' --pretty")
 
     assert c.expect_exact('>>> ') == 0
@@ -114,7 +114,7 @@ def test_bare_console_pretty():
 
 
 def test_mpmath_version():
-    c = Console('python -m mpmath --version')
+    c = Console(f'{sys.executable} -m mpmath --version')
 
     assert c.expect(pexpect.EOF) == 0
     assert c.before.startswith('1.')

--- a/mpmath/tests/test_cli.py
+++ b/mpmath/tests/test_cli.py
@@ -1,11 +1,12 @@
 """Tests for the Command-Line Interface."""
 
 import platform
+import sys
 import time
 
 import pexpect
 import pytest
-import sys
+
 
 if platform.python_implementation() == 'PyPy':
     pytest.skip("Don't run CLI tests on PyPy.",


### PR DESCRIPTION
According to [PEP 394](https://peps.python.org/pep-0394/), the `python3` command is expected to be installed on Unix-like systems.  Distributors have the option of providing the `python` command or not.

For example, on Debian/Ubuntu systems, there is no `python` command by default, and `test_cli` fails on these systems.

For example:

```python
$ python3 -m pytest mpmath/tests/test_cli.py 
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-6.2.5, py-1.10.0, pluggy-0.13.0
mpmath backend: gmpy
mpmath mp class: <mpmath.ctx_mp.MPContext object at 0x77cdb5d62020>
mpmath version: 0.0.0
Python version: 3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
rootdir: /home/dtorrance/src/mpmath/mpmath, configfile: pyproject.toml
collected 8 items                                                              

mpmath/tests/test_cli.py FFsFFException ignored in: <function Console.__del__ at 0x77cdb5ca9900>
Traceback (most recent call last):
  File "/home/dtorrance/src/mpmath/mpmath/mpmath/tests/test_cli.py", line 22, in __del__
    self.send('exit()\r\n')
  File "/usr/lib/python3/dist-packages/pexpect/pty_spawn.py", line 569, in send
    return os.write(self.child_fd, b)
OSError: [Errno 9] Bad file descriptor
FFF                                        [100%]

=================================== FAILURES ===================================
______________________ test_bare_console_no_bare_division ______________________

Exception ignored in: <function Console.__del__ at 0x77cdb5ca9900>
Traceback (most recent call last):
  File "/home/dtorrance/src/mpmath/mpmath/mpmath/tests/test_cli.py", line 22, in __del__
    self.send('exit()\r\n')
  File "/usr/lib/python3/dist-packages/pexpect/pty_spawn.py", line 569, in send
    return os.write(self.child_fd, b)
OSError: [Errno 9] Bad file descriptor
Exception ignored in: <function Console.__del__ at 0x77cdb5ca9900>
Traceback (most recent call last):
  File "/home/dtorrance/src/mpmath/mpmath/mpmath/tests/test_cli.py", line 22, in __del__
    self.send('exit()\r\n')
  File "/usr/lib/python3/dist-packages/pexpect/pty_spawn.py", line 569, in send
    return os.write(self.child_fd, b)
OSError: [Errno 9] Bad file descriptor
Exception ignored in: <function Console.__del__ at 0x77cdb5ca9900>
Traceback (most recent call last):
  File "/home/dtorrance/src/mpmath/mpmath/mpmath/tests/test_cli.py", line 22, in __del__
    self.send('exit()\r\n')
  File "/usr/lib/python3/dist-packages/pexpect/pty_spawn.py", line 569, in send
    return os.write(self.child_fd, b)
OSError: [Errno 9] Bad file descriptor
    def test_bare_console_no_bare_division():
>       c = Console('python -m mpmath --no-ipython --no-wrap-floats')

mpmath/tests/test_cli.py:29: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
mpmath/tests/test_cli.py:19: in __init__
    super().__init__(command, timeout=timeout, encoding='utf-8')
/usr/lib/python3/dist-packages/pexpect/pty_spawn.py:205: in __init__
    self._spawn(command, args, preexec_fn, dimensions)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <mpmath.tests.test_cli.Console object at 0x77cdb5b3e860>
command = 'python -m mpmath --no-ipython --no-wrap-floats', args = []
preexec_fn = None, dimensions = None

    def _spawn(self, command, args=[], preexec_fn=None, dimensions=None):
        '''This starts the given command in a child process. This does all the
        fork/exec type of stuff for a pty. This is called by __init__. If args
        is empty then command will be parsed (split on spaces) and args will be
        set to parsed arguments. '''
    
        # The pid and child_fd of this object get set by this method.
        # Note that it is difficult for this method to fail.
        # You cannot detect if the child process cannot start.
        # So the only way you can tell if the child process started
        # or not is to try to read from the file descriptor. If you get
        # EOF immediately then it means that the child is already dead.
        # That may not necessarily be bad because you may have spawned a child
        # that performs some task; creates no stdout output; and then dies.
    
        # If command is an int type then it may represent a file descriptor.
        if isinstance(command, type(0)):
            raise ExceptionPexpect('Command is an int type. ' +
                    'If this is a file descriptor then maybe you want to ' +
                    'use fdpexpect.fdspawn which takes an existing ' +
                    'file descriptor instead of a command string.')
    
        if not isinstance(args, type([])):
            raise TypeError('The argument, args, must be a list.')
    
        if args == []:
            self.args = split_command_line(command)
            self.command = self.args[0]
        else:
            # Make a shallow copy of the args list.
            self.args = args[:]
            self.args.insert(0, command)
            self.command = command
    
        command_with_path = which(self.command, env=self.env)
        if command_with_path is None:
>           raise ExceptionPexpect('The command was not found or was not ' +
                    'executable: %s.' % self.command)
E           pexpect.exceptions.ExceptionPexpect: The command was not found or was not executable: python.

/usr/lib/python3/dist-packages/pexpect/pty_spawn.py:276: ExceptionPexpect
```