### PR TITLE
Fallback to fixed precision if prec change is infinite

### DIFF
--- a/mpmath/ctx_mp_python.py
+++ b/mpmath/ctx_mp_python.py
@@ -775,6 +775,8 @@ class PythonMPContext:
         ctx.trap_complex = False
 
     def _set_prec(ctx, n):
+        if not ctx.isfinite(n):
+            return
         ctx._prec = ctx._prec_rounding[0] = max(1, int(n))
         ctx._dps = prec_to_dps(n)
 

--- a/mpmath/functions/hypergeometric.py
+++ b/mpmath/functions/hypergeometric.py
@@ -316,10 +316,8 @@ def _hyp1f1(ctx, a_s, b_s, z, **kwargs):
         return ctx.one+z
     magz = ctx.mag(z)
     if magz >= 7 and not (ctx.isint(a) and ctx.re(a) <= 0):
-        if ctx.isinf(z):
-            if ctx.sign(a) == ctx.sign(b) == ctx.sign(z) == 1:
-                return ctx.inf
-            return ctx.nan * z
+        if ctx.isinf(z) and ctx.sign(a) == ctx.sign(b) == ctx.sign(z) == 1:
+            return ctx.inf
         try:
             try:
                 ctx.prec += magz

--- a/mpmath/tests/test_functions2.py
+++ b/mpmath/tests/test_functions2.py
@@ -85,6 +85,7 @@ def test_bessel():
     assert besselk(0,3+4j).ae(-0.007239051213570155013+0.026510418350267677215j)
     assert besselk(0,j).ae(-0.13863371520405399968-1.20196971531720649914j)
     assert (besselk(3, 10**10) * mpf(10)**4342944824).ae(1.1628981033356187851)
+    assert besselk(1,inf) == 0
     # test for issue 331, bug reported by Michael Hartmann
     for n in range(10,100,10):
         mp.dps = n
@@ -482,6 +483,12 @@ def test_hyper_1f1():
     assert hyp1f1(-2, 1, 10000).ae(49980001)
     # Bug
     assert hyp1f1(1j,fraction(1,3),0.415-69.739j).ae(25.857588206024346592 + 15.738060264515292063j)
+    # issue 522
+    assert hyp1f1(0, 1, +inf) == 1
+    assert hyp1f1(0, 1, -inf) == 1
+    assert hyp1f1(1, 2, -inf) == 0
+    assert hyp1f1(2, 2, -inf) == 0
+    assert hyp1f1(1, 5, -inf) == 0
 
 def test_hyper_2f1():
     v = 1.0652207633823291032


### PR DESCRIPTION
This will leave handling of special numbers to fewer functions, e.g. to hypercomb().

Closes #520
Closes #522