### PR TITLE
Revert dcc591c

### DIFF
--- a/mpmath/ctx_mp_python.py
+++ b/mpmath/ctx_mp_python.py
@@ -774,8 +774,6 @@ class PythonMPContext:
         ctx.trap_complex = False
 
     def _set_prec(ctx, n):
-        if ctx.isinf(n):
-            return
         ctx._prec = ctx._prec_rounding[0] = max(1, int(n))
         ctx._dps = prec_to_dps(n)
 

--- a/mpmath/functions/bessel.py
+++ b/mpmath/functions/bessel.py
@@ -169,7 +169,8 @@ def besselk(ctx, n, z, derivative=0, **kwargs):
     # for large real z
     # Instead represent in terms of 2F0
     else:
-        ctx.prec += M
+        if ctx.isfinite(M):
+            ctx.prec += M
         def h(n):
             return [([ctx.pi/2, z, ctx.exp(-z)], [0.5,-0.5,1], [], [], \
                 [n+0.5, 0.5-n], [], -1/(2*z))]

--- a/mpmath/functions/hypergeometric.py
+++ b/mpmath/functions/hypergeometric.py
@@ -318,6 +318,8 @@ def _hyp1f1(ctx, a_s, b_s, z, **kwargs):
     if magz >= 7 and not (ctx.isint(a) and ctx.re(a) <= 0):
         if ctx.isinf(z) and ctx.sign(a) == ctx.sign(b) == ctx.sign(z) == 1:
             return ctx.inf
+        if ctx.isinf(magz):
+            magz = 0
         try:
             try:
                 ctx.prec += magz


### PR DESCRIPTION
This uses per-function workarounds to fall through to ctx.hypercomb()