### PR TITLE
Update README.rst - Add monthly downloads badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 mpmath
 ======
 
-|pypi version| |Build status| |Code coverage status| |Zenodo Badge|
+|pypi version| |Build status| |Code coverage status| |Zenodo Badge| |Monthly Downloads Badge|
 
 .. |pypi version| image:: https://img.shields.io/pypi/v/mpmath.svg
    :target: https://pypi.python.org/pypi/mpmath
@@ -11,6 +11,9 @@ mpmath
    :target: https://codecov.io/gh/mpmath/mpmath
 .. |Zenodo Badge| image:: https://zenodo.org/badge/2934512.svg
    :target: https://zenodo.org/badge/latestdoi/2934512
+.. |Monthly Downloads Badge| image:: https://assets.piptrends.com/get-last-month-downloads-badge/mpmath.svg
+   :target: https://piptrends.com/package/mpmath
+   :alt: mpmath Downloads Last Month by pip Trends
 
 A Python library for arbitrary-precision floating-point arithmetic.
 


### PR DESCRIPTION
Just a suggestion. I have been working on building a badge system for python packages to display some stats like monthly downloads etc. You can view them here at - https://piptrends.com/package/mpmath

We are trying to build a learning forum at pip Trends, where developers can find everything they need to get started with python and python packages. 

The badge links to mpmath's pip Trends page, where we display some stats and documentation. Soon we plan on adding simple getting started articles etc. as well to this page.(These are open to contributions)
If required, this link can be removed. This PR is only to share the badge we have built.