### PR TITLE
Reduce memory usage for QuadratureRule cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: test
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 2'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/mpmath/calculus/quadrature.py
+++ b/mpmath/calculus/quadrature.py
@@ -17,17 +17,13 @@ class QuadratureRule:
 
     def __init__(self, ctx):
         self.ctx = ctx
-        self.standard_cache = {}
         self.transformed_cache = {}
-        self.interval_count = {}
 
     def clear(self):
         """
         Delete cached node data.
         """
-        self.standard_cache = {}
         self.transformed_cache = {}
-        self.interval_count = {}
 
     def calc_nodes(self, degree, prec, verbose=False):
         r"""
@@ -57,17 +53,16 @@ class QuadratureRule:
         try:
             self.ctx.prec = prec+20
             # Get nodes on standard interval
-            if (degree, prec) in self.standard_cache:
-                nodes = self.standard_cache[degree, prec]
+            stdkey = (-1, 1, degree, prec)
+            if stdkey in self.transformed_cache:
+                nodes = self.transformed_cache[stdkey]
             else:
                 nodes = self.calc_nodes(degree, prec, verbose)
-                self.standard_cache[degree, prec] = nodes
+                self.transformed_cache[stdkey] = nodes
             # Transform to general interval
             nodes = self.transform_nodes(nodes, a, b, verbose)
-            if key in self.interval_count:
+            if key not in self.transformed_cache:
                 self.transformed_cache[key] = nodes
-            else:
-                self.interval_count[key] = True
         finally:
             self.ctx.prec = orig
         return nodes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ Homepage = 'https://mpmath.org/'
 'Bug Tracker' = 'https://github.com/mpmath/mpmath/issues'
 Documentation = 'http://mpmath.org/doc/current/'
 [project.optional-dependencies]
-tests = ['pytest>=6', 'numpy; python_version<"3.13"',
+tests = ['pytest>=6', 'numpy<2; python_version<"3.13"',
          'matplotlib; python_version<"3.13"', 'pexpect', 'ipython']
 develop = ['mpmath[tests]', 'flake518>=1.5; python_version>="3.9"',
            'pytest-cov', 'wheel', 'build']


### PR DESCRIPTION
The interval_count seems to be redundant, transformed_cache has entries from the standard_cache...  So, I believe a single dict is enough.

See #811.  This partially address mentioned issue.