### PR TITLE
Fix the comparison in test_compatibility for NumPy 2.0.0

### DIFF
--- a/mpmath/tests/test_convert.py
+++ b/mpmath/tests/test_convert.py
@@ -254,7 +254,10 @@ def test_compatibility():
         # Handle the weird types
         try: diff = np.abs(type(np.sqrt(x))(sqrt(x)) - np.sqrt(x))
         except: continue
-        assert diff < 2.0**-53
+        # we need to explicitly specify a sufficiently precise type
+        # for 2.0**-53, as otherwise numpy may convert it to LHS type
+        # that is not precise enough (e.g. float16)
+        assert diff < np.float64(2.0**-53)
     assert mpf(np.float64('inf')) == inf
     assert isnan(mp.npconvert(np.float64('nan')))
     if hasattr(np, "float128"):


### PR DESCRIPTION
The comparison in `mpmath/tests/test_convert.py::test_compatibility` failed for `np.float16` in NumPy 2.0.0 since `2.0**-53` cannot be represented in half-precision floating point type.  Convert the LHS to `np.float64` to ensure that the comparison is done in sufficiently precise type.

This fixes the actual test failure from #815 but the deprecation warning remains.