### PR TITLE
Misc fixes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -878,7 +878,7 @@ New features:
 
 Bugfixes, speed enhancements, and other improvements:
 * compatibility tests should now pass on systems where Python is
-  compiled to use 80-bit registers for floating point operations
+  compiled to use 80-bit registers for floating-point operations
 * fixed mpmath to work with some versions of Python 2.4 where a
   list indexing bug is present in the Python core
 * better algorithms for various complex elementary functions

--- a/docs/matrices.rst
+++ b/docs/matrices.rst
@@ -293,7 +293,8 @@ using ``lu_solve``::
     [['30.0'],
      ['-20.0']])
 
-If you don't trust the result, use ``residual`` to calculate the residual ||A*x-b||::
+If you don't trust the result, use ``residual`` to calculate
+the residual `||A x-b||`::
 
     >>> residual(A, x, b)
     matrix(

--- a/docs/matrices.rst
+++ b/docs/matrices.rst
@@ -304,7 +304,7 @@ the residual `||A x-b||`::
     '2.22044604925031e-16'
 
 As you can see, the solution is quite accurate. The error is caused by the
-inaccuracy of the internal floating point arithmetic. Though, it's even smaller
+inaccuracy of the internal floating-point arithmetic. Though, it's even smaller
 than the current machine epsilon, which basically means you can trust the
 result.
 

--- a/mpmath/ctx_mp.py
+++ b/mpmath/ctx_mp.py
@@ -904,7 +904,7 @@ maxterms, or set zeroprec."""
             >>> print(fsub(x, y, exact=True) + y)
             2.0
 
-        Exact addition can be inefficient and may be impossible to perform
+        Exact subtraction can be inefficient and may be impossible to perform
         with large magnitude differences::
 
             >>> fsub(1, '1e-100000000000000000000', prec=inf)

--- a/mpmath/ctx_mp_python.py
+++ b/mpmath/ctx_mp_python.py
@@ -1,4 +1,5 @@
 import numbers
+import sys
 
 from . import function_docs
 from .libmp import (MPQ, MPZ, ComplexResult, dps_to_prec, finf, fnan, fninf,
@@ -610,7 +611,7 @@ complex_types = (complex, _mpc)
 
 class PythonMPContext:
     def __init__(ctx):
-        ctx._prec_rounding = [53, round_nearest]
+        ctx._prec_rounding = [sys.float_info.mant_dig, round_nearest]
         ctx.mpf = type('mpf', (_mpf,), {})
         ctx.mpc = type('mpc', (_mpc,), {})
         ctx.mpf._ctxdata = [ctx.mpf, new, ctx._prec_rounding]
@@ -632,8 +633,8 @@ class PythonMPContext:
         return a
 
     def default(ctx):
-        ctx._prec = ctx._prec_rounding[0] = 53
-        ctx._dps = 15
+        ctx._prec = ctx._prec_rounding[0] = sys.float_info.mant_dig
+        ctx._dps = sys.float_info.dig
         ctx.trap_complex = False
 
     def _set_prec(ctx, n):

--- a/mpmath/matrices/eigen.py
+++ b/mpmath/matrices/eigen.py
@@ -86,7 +86,7 @@ def hessenberg_reduce_0(ctx, A, T):
             scale_inv = 1 / scale
 
         if scale == 0 or ctx.isinf(scale_inv):
-            # sadly there are floating point numbers not equal to zero whose reciprocal is infinity
+            # sadly there are floating-point numbers not equal to zero whose reciprocal is infinity
             T[i] = 0
             A[i,i-1] = 0
             continue

--- a/mpmath/matrices/eigen_symmetric.py
+++ b/mpmath/matrices/eigen_symmetric.py
@@ -85,7 +85,7 @@ def r_sy_tridiag(ctx, A, D, E, calc_ev = True):
         if scale != 0:
             scale_inv = 1/scale
 
-        # sadly there are floating point numbers not equal to zero whose reciprocal is infinity
+        # sadly there are floating-point numbers not equal to zero whose reciprocal is infinity
 
         if i == 1 or scale == 0 or ctx.isinf(scale_inv):
             E[i] = A[i-1,i]        # nothing to do
@@ -211,7 +211,7 @@ def c_he_tridiag_0(ctx, A, D, E, T):
         if scale != 0:
             scale_inv = 1 / scale
 
-        # sadly there are floating point numbers not equal to zero whose reciprocal is infinity
+        # sadly there are floating-point numbers not equal to zero whose reciprocal is infinity
 
         if scale == 0 or ctx.isinf(scale_inv):
             E[i] = 0

--- a/mpmath/matrices/linalg.py
+++ b/mpmath/matrices/linalg.py
@@ -32,7 +32,7 @@ If you don't trust the result, use ``residual`` to calculate the residual ||A*x-
     '2.22044604925031e-16'
 
 As you can see, the solution is quite accurate. The error is caused by the
-inaccuracy of the internal floating point arithmetic. Though, it's even smaller
+inaccuracy of the internal floating-point arithmetic. Though, it's even smaller
 than the current machine epsilon, which basically means you can trust the
 result.
 


### PR DESCRIPTION
* fix typo in docs, closes #817
* amend d3c6428 (mp.prec default should match fp.prec)
* consistently use "floating-point"