### PR TITLE
mpf.__round__() returns mpf

### DIFF
--- a/mpmath/ctx_mp_python.py
+++ b/mpmath/ctx_mp_python.py
@@ -412,8 +412,13 @@ class _mpf(mpnumeric):
     def to_fixed(self, prec):
         return to_fixed(self._mpf_, prec)
 
-    def __round__(self, *args):
-        return round(float(self), *args)
+    def __round__(self, ndigits=0):
+        ctx = self.context
+        if ctx.isfinite(self):
+            frac = MPQ(*self.as_integer_ratio())
+            res = round(frac, ndigits)
+            return ctx.convert(res)
+        return self
 
 
 class _constant(_mpf):


### PR DESCRIPTION
Probably this will look non-intuitive, but underlying floating-point arithmetic is binary, not decimal.  Thus, round(x, n) sometimes will pick up a decimal representation with more than n digits.  This is something common for CPython < 2.7 and < 3.1:
```pycon
Python 2.6.6 (r266:84292, Aug 12 2014, 07:57:07) [GCC 4.4.5] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> round(0.42754287856598971, 2)
0.42999999999999999
```
And with this patch as well:
```pycon
Python 3.12.5+ (heads/3.12:0181aa2e3e, Aug 29 2024, 14:55:08) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from mpmath import *
>>> round(mp.mpf(0.42754287856598971), 2)
mpf('0.42999999999999999')
>>> mp.pretty = True
>>> round(mp.mpf(0.42754287856598971), 2)
0.43
```

See also https://github.com/python/cpython/issues/45921

Closes #455