### PR TITLE
Misc fixes

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,9 @@ build:
     os: ubuntu-22.04
     tools:
         python: "3"
+    jobs:
+        post_checkout:
+            - git fetch --unshallow
 python:
     install:
         - method: pip

--- a/README.rst
+++ b/README.rst
@@ -145,7 +145,7 @@ are human-readable, but can be compiled to prettier HTML using
 
 The most recent documentation is also available in HTML format:
 
-https://mpmath.org/doc/current/
+https://mpmath.readthedocs.io/
 
 3. Running tests
 ----------------

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -84,7 +84,7 @@ Python interpreter and do the following::
 Using gmpy (optional)
 ---------------------
 
-If `gmpy <https://github.com/aleaxit/gmpy>`_ version 2.2.0rc1 or later is
+If `gmpy <https://github.com/aleaxit/gmpy>`_ version 2.2.0 or later is
 installed on your system, mpmath will automatically detect it and transparently
 use gmpy integers instead of Python integers.  This makes mpmath much faster,
 especially at high precision (approximately above 100 digits).

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -17,7 +17,7 @@ of the Mpmath with pip::
 
 or some specific version with::
 
-    pip install mpmath==0.19
+    pip install mpmath==1.3.0
 
 You can install also extra dependencies, e.g. `gmpy
 <https://github.com/aleaxit/gmpy>`_ support::


### PR DESCRIPTION
* unshallow git clone on RTD build (correct shown version)
* update version in pip install example
* correct minimal gmpy2 version
* point to https://mpmath.readthedocs.io/ for recent docs
