### PR TITLE
Correct formatting for `round_up` rounding mode

### DIFF
--- a/mpmath/libmp/libmpf.py
+++ b/mpmath/libmp/libmpf.py
@@ -1121,7 +1121,7 @@ def round_digits(digits, dps, base, rounding=round_nearest):
     elif rounding == round_nearest:
         rnd_digs = stddigits[(base//2 + base % 2):base]
     else:
-        rnd_digs = stddigits[:base]
+        rnd_digs = stddigits[1:base]
 
     tie_up = False
 

--- a/mpmath/tests/test_format.py
+++ b/mpmath/tests/test_format.py
@@ -645,33 +645,69 @@ def test_mpf_fmt():
         assert f"{mp.mpf('-123.456'):.5Ng}" == "-123.46"
 
         num = mp.mpf('0.1')
-        assert f"{-num:=.2Df}" == "-0.10"
-        assert f"{-num:=.3Df}" == "-0.100"
-        assert f"{-num:=.4Df}" == "-0.1000"
-        assert f"{-num:=.5Df}" == "-0.10000"
-        assert f"{-num:=.6Df}" == "-0.100000"
-        assert f"{-num:=.7Df}" == "-0.1000000"
+        assert f"{-num:=.2Df}" == "-0.11"
+        assert f"{-num:=.3Df}" == "-0.101"
+        assert f"{-num:=.4Df}" == "-0.1001"
+        assert f"{-num:=.5Df}" == "-0.10001"
+        assert f"{-num:=.6Df}" == "-0.100001"
+        assert f"{-num:=.7Df}" == "-0.1000001"
 
-        assert f"{-num:=.2De}" == "-1.00e-01"
-        assert f"{-num:=.3De}" == "-1.000e-01"
-        assert f"{-num:=.4De}" == "-1.0000e-01"
-        assert f"{-num:=.5De}" == "-1.00000e-01"
-        assert f"{-num:=.6De}" == "-1.000000e-01"
-        assert f"{-num:=.7De}" == "-1.0000000e-01"
+        assert f"{-num:=.2De}" == "-1.01e-01"
+        assert f"{-num:=.3De}" == "-1.001e-01"
+        assert f"{-num:=.4De}" == "-1.0001e-01"
+        assert f"{-num:=.5De}" == "-1.00001e-01"
+        assert f"{-num:=.6De}" == "-1.000001e-01"
+        assert f"{-num:=.7De}" == "-1.0000001e-01"
 
-        assert f"{num:=.2Uf}" == "0.10"
-        assert f"{num:=.3Uf}" == "0.100"
-        assert f"{num:=.4Uf}" == "0.1000"
-        assert f"{num:=.5Uf}" == "0.10000"
-        assert f"{num:=.6Uf}" == "0.100000"
-        assert f"{num:=.7Uf}" == "0.1000000"
+        assert f"{num:=.2Uf}" == "0.11"
+        assert f"{num:=.3Uf}" == "0.101"
+        assert f"{num:=.4Uf}" == "0.1001"
+        assert f"{num:=.5Uf}" == "0.10001"
+        assert f"{num:=.6Uf}" == "0.100001"
+        assert f"{num:=.7Uf}" == "0.1000001"
 
-        assert f"{num:=.2Ue}" == "1.00e-01"
-        assert f"{num:=.3Ue}" == "1.000e-01"
-        assert f"{num:=.4Ue}" == "1.0000e-01"
-        assert f"{num:=.5Ue}" == "1.00000e-01"
-        assert f"{num:=.6Ue}" == "1.000000e-01"
-        assert f"{num:=.7Ue}" == "1.0000000e-01"
+        assert f"{num:=.2Ue}" == "1.01e-01"
+        assert f"{num:=.3Ue}" == "1.001e-01"
+        assert f"{num:=.4Ue}" == "1.0001e-01"
+        assert f"{num:=.5Ue}" == "1.00001e-01"
+        assert f"{num:=.6Ue}" == "1.000001e-01"
+        assert f"{num:=.7Ue}" == "1.0000001e-01"
+
+        num = mp.mpf('0.25')
+        assert f"{-num:=.2Df}" == "-0.25"
+        assert f"{-num:=.3Df}" == "-0.250"
+        assert f"{-num:=.4Df}" == "-0.2500"
+        assert f"{-num:=.5Df}" == "-0.25000"
+        assert f"{-num:=.6Df}" == "-0.250000"
+        assert f"{-num:=.7Df}" == "-0.2500000"
+
+        assert f"{-num:=.2De}" == "-2.50e-01"
+        assert f"{-num:=.3De}" == "-2.500e-01"
+        assert f"{-num:=.4De}" == "-2.5000e-01"
+        assert f"{-num:=.5De}" == "-2.50000e-01"
+        assert f"{-num:=.6De}" == "-2.500000e-01"
+        assert f"{-num:=.7De}" == "-2.5000000e-01"
+
+        assert f"{num:=.2Uf}" == "0.25"
+        assert f"{num:=.3Uf}" == "0.250"
+        assert f"{num:=.4Uf}" == "0.2500"
+        assert f"{num:=.5Uf}" == "0.25000"
+        assert f"{num:=.6Uf}" == "0.250000"
+        assert f"{num:=.7Uf}" == "0.2500000"
+
+        assert f"{num:=.2Ue}" == "2.50e-01"
+        assert f"{num:=.3Ue}" == "2.500e-01"
+        assert f"{num:=.4Ue}" == "2.5000e-01"
+        assert f"{num:=.5Ue}" == "2.50000e-01"
+        assert f"{num:=.6Ue}" == "2.500000e-01"
+        assert f"{num:=.7Ue}" == "2.5000000e-01"
+
+        # Changing the work precision changes the number printed (This is
+        # expected behavior)
+        with mp.workdps(20):
+            assert f"{mp.mpf('0.1'):=.4Uf}" == "0.1000"
+            assert f"{mp.mpf('-0.1'):=.4Df}" == "-0.1000"
+
 
 def test_errors():
     with pytest.raises(ValueError):

--- a/mpmath/tests/test_format.py
+++ b/mpmath/tests/test_format.py
@@ -644,6 +644,34 @@ def test_mpf_fmt():
         assert f"{mp.mpf('-123.456'):.5Zg}" == "-123.45"
         assert f"{mp.mpf('-123.456'):.5Ng}" == "-123.46"
 
+        num = mp.mpf('0.1')
+        assert f"{-num:=.2Df}" == "-0.10"
+        assert f"{-num:=.3Df}" == "-0.100"
+        assert f"{-num:=.4Df}" == "-0.1000"
+        assert f"{-num:=.5Df}" == "-0.10000"
+        assert f"{-num:=.6Df}" == "-0.100000"
+        assert f"{-num:=.7Df}" == "-0.1000000"
+
+        assert f"{-num:=.2De}" == "-1.00e-01"
+        assert f"{-num:=.3De}" == "-1.000e-01"
+        assert f"{-num:=.4De}" == "-1.0000e-01"
+        assert f"{-num:=.5De}" == "-1.00000e-01"
+        assert f"{-num:=.6De}" == "-1.000000e-01"
+        assert f"{-num:=.7De}" == "-1.0000000e-01"
+
+        assert f"{num:=.2Uf}" == "0.10"
+        assert f"{num:=.3Uf}" == "0.100"
+        assert f"{num:=.4Uf}" == "0.1000"
+        assert f"{num:=.5Uf}" == "0.10000"
+        assert f"{num:=.6Uf}" == "0.100000"
+        assert f"{num:=.7Uf}" == "0.1000000"
+
+        assert f"{num:=.2Ue}" == "1.00e-01"
+        assert f"{num:=.3Ue}" == "1.000e-01"
+        assert f"{num:=.4Ue}" == "1.0000e-01"
+        assert f"{num:=.5Ue}" == "1.00000e-01"
+        assert f"{num:=.6Ue}" == "1.000000e-01"
+        assert f"{num:=.7Ue}" == "1.0000000e-01"
 
 def test_errors():
     with pytest.raises(ValueError):


### PR DESCRIPTION
This PR improves the code in `round_digits`: now the first digit in the `stddigits` list is excluded from the list of digits that must be rounded up when the `round_up` rounding mode is used. When rounding to a 0 digit, all the digits following it are looked up, and if one of them is different from 0, the 0 is rounded up.

This fixes some wrongfully formatted floats as, for example, when running the following code in the master branch
```python
>>> from gmpy2 import mpfr
>>> from mpmath import mp
>>> print('{:.2Uf}'.format(mpfr('0.25')))
0.25
>>> print('{:.2Uf}'.format(mp.mpf('0.25')))
0.26
>>>
```
