### PR TITLE
Misc fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --upgrade setuptools pip
-        pip install --upgrade .[develop,gmpy,docs,ci]
+        pip install --upgrade .[develop,gmpy2,docs,ci]
     - name: Remove gmpy (for coverage tests)
       if: matrix.nogmpy
       run: pip uninstall -y gmpy2

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -19,10 +19,10 @@ or some specific version with::
 
     pip install mpmath==1.3.0
 
-You can install also extra dependencies, e.g. `gmpy
+You can install also extra dependencies, e.g. `gmpy2
 <https://github.com/aleaxit/gmpy>`_ support::
 
-    pip install mpmath[gmpy]
+    pip install mpmath[gmpy2]
 
 .. tip::
 
@@ -81,18 +81,18 @@ Python interpreter and do the following::
        python -m mpmath
 
 
-Using gmpy (optional)
----------------------
+Using gmpy2 (optional)
+----------------------
 
-If `gmpy <https://github.com/aleaxit/gmpy>`_ version 2.2.0 or later is
+If `gmpy2 <https://github.com/aleaxit/gmpy>`_ version 2.2.0 or later is
 installed on your system, mpmath will automatically detect it and transparently
-use gmpy integers instead of Python integers.  This makes mpmath much faster,
+use gmpy2 integers instead of Python integers.  This makes mpmath much faster,
 especially at high precision (approximately above 100 digits).
 
-To verify that mpmath uses gmpy, check the internal variable ``BACKEND`` is
+To verify that mpmath uses gmpy2, check the internal variable ``BACKEND`` is
 equal to 'gmpy'.
 
-Using the gmpy backend can be disabled by setting the ``MPMATH_NOGMPY``
+Using the gmpy2 backend can be disabled by setting the ``MPMATH_NOGMPY``
 environment variable.  Note that the mode cannot be switched during runtime;
 mpmath must be re-imported for this change to take effect.
 

--- a/mpmath/calculus/optimization.py
+++ b/mpmath/calculus/optimization.py
@@ -1038,10 +1038,11 @@ def steffensen(f):
     Let's try Steffensen's method:
 
     >>> f = lambda x: x**2
+    >>> from mpmath import mp
     >>> from mpmath.calculus.optimization import steffensen
     >>> F = steffensen(f)
     >>> for x in [0.5, 0.9, 2.0]:
-    ...     fx = Fx = x
+    ...     fx = Fx = mp.mpf(x)
     ...     for i in range(9):
     ...         try:
     ...             fx = f(fx)
@@ -1051,16 +1052,16 @@ def steffensen(f):
     ...             Fx = F(Fx)
     ...         except ZeroDivisionError:
     ...             pass
-    ...         print('%20g  %20g' % (fx, Fx))
+    ...         print(f'{fx:20g}  {Fx:20g}')
                     0.25                  -0.5
                   0.0625                   0.1
               0.00390625            -0.0011236
              1.52588e-05           1.41691e-09
              2.32831e-10          -2.84465e-27
              5.42101e-20           2.30189e-80
-             2.93874e-39          -1.2197e-239
-             8.63617e-78                     0
-            7.45834e-155                     0
+             2.93874e-39         -1.21971e-239
+             8.63617e-78          1.81455e-717
+            7.45834e-155        -5.97459e-2151
                     0.81               1.02676
                   0.6561               1.00134
                 0.430467                     1

--- a/mpmath/ctx_mp_python.py
+++ b/mpmath/ctx_mp_python.py
@@ -704,7 +704,7 @@ class PythonMPContext:
         import numpy as np
         if isinstance(x, np.ndarray) and x.ndim == 0: x = x.item()
         if isinstance(x, (np.integer, int)): return ctx.make_mpf(from_int(int(x)))
-        if isinstance(x, (np.floating, float)): return ctx.make_mpf(from_npfloat(x))
+        if isinstance(x, (np.floating, float)): return ctx.mpf(from_npfloat(x))
         if isinstance(x, (np.complexfloating, complex)):
             return ctx.make_mpc((from_npfloat(x.real), from_npfloat(x.imag)))
         raise TypeError("cannot create mpf from " + repr(x))

--- a/mpmath/functions/zeta.py
+++ b/mpmath/functions/zeta.py
@@ -288,6 +288,10 @@ def bernpoly(ctx, n, z):
     n = int(n)
     if n < 0:
         raise ValueError("Bernoulli polynomials only defined for n >= 0")
+    if ctx.isinf(z):
+        return z ** n
+    if ctx.isnan(z):
+        return z
     if n <= 3:
         if n == 0: return z ** 0
         if n == 1: return z - 0.5
@@ -297,10 +301,6 @@ def bernpoly(ctx, n, z):
         return ctx.bernoulli(n)
     if z == 0.5:
         return (ctx.ldexp(1,1-n)-1)*ctx.bernoulli(n)
-    if ctx.isinf(z):
-        return z ** n
-    if ctx.isnan(z):
-        return z
     if abs(z) > 2:
         def terms():
             t = ctx.one

--- a/mpmath/libmp/libmpc.py
+++ b/mpmath/libmp/libmpc.py
@@ -260,7 +260,7 @@ def mpc_pow_int(z, n, prec, rnd=round_fast):
     de = aexp - bexp
     abs_de = abs(de)
     exact_size = n*(abs_de + max(abc, bbc))
-    if exact_size < 10000:
+    if exact_size < 10000 and min(abc, bbc) >= 0:
         if de > 0:
             aman <<= de
             aexp = bexp

--- a/mpmath/libmp/libmpf.py
+++ b/mpmath/libmp/libmpf.py
@@ -3,14 +3,10 @@ Low-level functions for arbitrary-precision floating-point arithmetic.
 """
 
 import math
+import random
 import re
 import sys
 import warnings
-
-
-# Importing random is slow
-#from random import getrandbits
-getrandbits = None
 
 from .backend import BACKEND, MPZ, MPZ_FIVE, MPZ_ONE, MPZ_ZERO, gmpy
 from .libintmath import (bctable, bin_to_radix, isqrt, numeral, sqrtrem,
@@ -444,11 +440,7 @@ def to_fixed(s, prec):
 def mpf_rand(prec):
     """Return a raw mpf chosen randomly from [0, 1), with prec bits
     in the mantissa."""
-    global getrandbits
-    if not getrandbits:
-        import random
-        getrandbits = random.getrandbits
-    return from_man_exp(getrandbits(prec), -prec, prec, round_floor)
+    return from_man_exp(random.getrandbits(prec), -prec, prec, round_floor)
 
 def mpf_eq(s, t):
     """Test equality of two raw mpfs. This is simply tuple comparison

--- a/mpmath/libmp/libmpi.py
+++ b/mpmath/libmp/libmpi.py
@@ -2,11 +2,12 @@
 Computational functions for interval arithmetic.
 
 """
+from .backend import MPZ_ONE
 from .gammazeta import mpc_loggamma, mpf_gamma, mpf_loggamma, mpf_rgamma
 from .libelefun import (mod_pi2, mpf_atan, mpf_atan2, mpf_cos_sin, mpf_exp,
                         mpf_log, mpf_pi, mpf_sqrt)
-from .libmpf import (MPZ_ONE, dps_to_prec, fhalf, finf, fnan, fninf, fnone,
-                     fone, from_float, from_int, from_man_exp, from_str, fzero,
+from .libmpf import (dps_to_prec, fhalf, finf, fnan, fninf, fnone, fone,
+                     from_float, from_int, from_man_exp, from_str, fzero,
                      mpf_abs, mpf_add, mpf_div, mpf_ge, mpf_gt, mpf_le, mpf_lt,
                      mpf_min_max, mpf_mul, mpf_neg, mpf_pos, mpf_pow_int,
                      mpf_shift, mpf_sign, mpf_sub, prec_to_dps, round_ceiling,

--- a/mpmath/tests/test_convert.py
+++ b/mpmath/tests/test_convert.py
@@ -263,9 +263,9 @@ def test_compatibility():
     assert mpf(np.float64('inf')) == inf
     assert isnan(mp.npconvert(np.float64('nan')))
     if hasattr(np, "float128"):
-        mp.prec = 113
+        mp.prec = 64
         assert (mp.npconvert(np.float128('0.841470984807896506652502321630298954')) ==
-                mpf('0.841470984807896506664590813295845351'))
+                mpf('0.841470984807896506653'))
     mp.prec = 53
     # issues 382 and 539
     assert mp.sqrt(np.int64(1)) == mpf('1.0')

--- a/mpmath/tests/test_gammazeta.py
+++ b/mpmath/tests/test_gammazeta.py
@@ -694,3 +694,7 @@ def test_issue_471():
     assert bernpoly(4, inf) == inf
     assert bernpoly(4, mpc(inf, 0)) == mpc(inf, 0)
     assert isnan(bernpoly(4, nan))
+
+def test_issue_472():
+    assert bernpoly(4, mpc(inf, 1e-50)) == mpc(inf, 0)
+    assert mpc(inf, 2)**4 == mpc(inf, 0)

--- a/mpmath/tests/test_gammazeta.py
+++ b/mpmath/tests/test_gammazeta.py
@@ -689,3 +689,8 @@ def test_issue_723():
     mp.dps = 16
     assert zeta(-0.01 + 1000j).ae(-8.971459529241107 + 8.732179332810066j)
     mp.dps = 15
+
+def test_issue_471():
+    assert bernpoly(4, inf) == inf
+    assert bernpoly(4, mpc(inf, 0)) == mpc(inf, 0)
+    assert isnan(bernpoly(4, nan))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ Homepage = 'https://mpmath.org/'
 'Bug Tracker' = 'https://github.com/mpmath/mpmath/issues'
 Documentation = 'http://mpmath.org/doc/current/'
 [project.optional-dependencies]
-tests = ['pytest>=6', 'numpy; python_version<"3.13"', 'packaging',
+tests = ['pytest>=6', 'numpy<2.1; python_version<"3.13"', 'packaging',
          'matplotlib; python_version<"3.13" and platform_python_implementation!="PyPy"',
          'pexpect', 'ipython', 'hypothesis']
 develop = ['mpmath[tests]', 'flake518>=1.5; python_version>="3.9"',


### PR DESCRIPTION
* drop special import for random
* fix MPZ_ONE import
* normalize mpf in mp.npconvert() and lower precision in tests, closes #836
* use mpf's in steffensen() doctest, closes #838
* move up special cases in bernpoly(), closes #471
* skip special case in mpc_pow_int() for special numbers, closes #472
* clarify gmpy2 support, closes #840
* pin numpy (<2.1)
