### PR TITLE
BUG: polyval ignored 'asc=False'

### DIFF
--- a/mpmath/calculus/polynomials.py
+++ b/mpmath/calculus/polynomials.py
@@ -39,10 +39,11 @@ def polyval(ctx, coeffs, x, derivative=False, asc=None):
         return ctx.zero
     if asc is None:
         warnings.warn("Descending (wrt powers) order of polynomial "
-                      "coefficients is deprecated, please adapt you "
+                      "coefficients is deprecated, please adapt your "
                       "code to use ascending order, asc=True.",
                       DeprecationWarning)
         asc = False
+    if not asc:
         coeffs = coeffs[::-1]
     p = ctx.convert(coeffs[-1])
     q = ctx.zero

--- a/mpmath/tests/test_calculus.py
+++ b/mpmath/tests/test_calculus.py
@@ -36,6 +36,9 @@ def test_polyval():
     assert polyval(p,4,asc=True) == 253
     assert polyval(p,4,derivative=True,asc=True) == (253, 190)
 
+def test_polyval_asc_false():
+    assert polyval([1, 2, 3], 2, asc=False) == 11
+
 def test_polyval_deprecated():
     with pytest.deprecated_call():
         p = [4, 0, -2, 5]


### PR DESCRIPTION
I noticed this bug in 1.4.0a1 and the master branch, where `asc=False` is ignored by `polyval`:

```
In [1]: import mpmath

In [2]: mpmath.__version__
Out[2]: '1.4.0a2.dev79+gd5c8e0c.d20240820'

In [3]: from mpmath import mp

In [4]: c = [1, 2, 3]

In [5]: mp.polyval(c, 2.0, asc=True)
Out[5]: mpf('17.0')

In [6]: mp.polyval(c, 2.0, asc=False)
Out[6]: mpf('17.0')
```
