### PR TITLE
Misc fixes

### DIFF
--- a/mpmath/calculus/polynomials.py
+++ b/mpmath/calculus/polynomials.py
@@ -179,6 +179,7 @@ def polyroots(ctx, coeffs, maxsteps=50, cleanup=True, extraprec=10,
                       "code to use ascending order, asc=True.",
                       DeprecationWarning)
         asc = False
+    if not asc:
         coeffs = coeffs[::-1]
 
     orig = ctx.prec

--- a/mpmath/matrices/matrices.py
+++ b/mpmath/matrices/matrices.py
@@ -749,9 +749,11 @@ class _matrix:
     def __reduce__(self):
         return _make_matrix, (self.tolist(),)
 
-    def __array__(self):
+    def __array__(self, dtype=None, copy=None):
+        if copy is not None and not copy:
+            raise ValueError("`copy=False` isn't supported.  A copy is always created.")
         from numpy import empty
-        r = empty((self.rows, self.cols), object)
+        r = empty((self.rows, self.cols), dtype=dtype)
         for i in range(self.rows):
             for j in range(self.cols):
                 r[i, j] = self[i, j]

--- a/mpmath/tests/test_calculus.py
+++ b/mpmath/tests/test_calculus.py
@@ -54,6 +54,11 @@ def test_polyroots():
     assert polyroots([1], asc=True) == []
     pytest.raises(ValueError, lambda: polyroots([0], asc=True))
 
+def test_polyroots_asc_false():
+    p, q = polyroots([1,2,3], asc=False)
+    assert p.ae(-1 - sqrt(2)*j)
+    assert q.ae(-1 + sqrt(2)*j)
+
 def test_polyroots_deprecated():
     with pytest.deprecated_call():
         p, q = polyroots([1,2,3])

--- a/mpmath/tests/test_matrices.py
+++ b/mpmath/tests/test_matrices.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from mpmath import (convert, diag, extend, eye, fp, hilbert, inf, inverse, iv,
@@ -198,6 +200,10 @@ def test_matrix_numpy():
     assert matrix(l) == matrix(a)
     assert (numpy.array(matrix(l)) == numpy.array(matrix(l).tolist(),
                                                   dtype=object)).all()
+
+    if sys.version_info < (3, 9):
+        pytest.skip("latest numpy dropped support for CPython 3.8")
+    pytest.raises(ValueError, lambda: numpy.array(matrix(l), copy=False))
 
 def test_interval_matrix_scalar_mult():
     """Multiplication of iv.matrix and any scalar type"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ Homepage = 'https://mpmath.org/'
 'Bug Tracker' = 'https://github.com/mpmath/mpmath/issues'
 Documentation = 'http://mpmath.org/doc/current/'
 [project.optional-dependencies]
-tests = ['pytest>=6', 'numpy<2.1; python_version<"3.13"', 'packaging',
+tests = ['pytest>=6', 'numpy; python_version<"3.13"', 'packaging',
          'matplotlib; python_version<"3.13" and platform_python_implementation!="PyPy"',
          'pexpect', 'ipython', 'hypothesis']
 develop = ['mpmath[tests]', 'flake518>=1.5; python_version>="3.9"',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,14 +30,14 @@ Homepage = 'https://mpmath.org/'
 'Bug Tracker' = 'https://github.com/mpmath/mpmath/issues'
 Documentation = 'http://mpmath.org/doc/current/'
 [project.optional-dependencies]
-tests = ['pytest>=6', 'numpy; python_version<"3.13"', 'packaging',
-         'matplotlib; python_version<"3.13" and platform_python_implementation!="PyPy"',
+tests = ['pytest>=6', 'numpy', 'packaging',
+         'matplotlib; platform_python_implementation!="PyPy"',
          'pexpect', 'ipython', 'hypothesis']
 develop = ['mpmath[tests]', 'flake518>=1.5; python_version>="3.9"',
            'pytest-cov', 'wheel', 'build']
 gmpy = ['gmpy2>=2.2; platform_python_implementation!="PyPy"']
 docs = ['sphinx',
-        'matplotlib; python_version<"3.13" and platform_python_implementation!="PyPy"',
+        'matplotlib; platform_python_implementation!="PyPy"',
         'sphinxcontrib-autoprogram']
 ci = ['pytest-xdist', 'diff_cover']
 [tool.setuptools]


### PR DESCRIPTION
* fix DeprecationWarning coming with numpy>=2.1
* numpy/matplotlib now support 3.13, drop pinning
* fix: polyroots() ignored asc=False kwarg value