### PR TITLE
Misc fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10', 3.11, 3.12, 3.13, pypy3.9, pypy3.10]
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12, 3.13, 3.14, pypy3.9, pypy3.10]
         coverage: [false]
         nogmpy: [false]
         default: [false]
@@ -36,6 +36,9 @@ jobs:
       run: |
         sudo apt update
         sudo apt install latexmk texlive-xetex
+    - name: Install gmpy2 deps
+      if: matrix.python-version == 3.14
+      run: sudo apt install libmpc-dev
     - name: Install dependencies
       run: |
         pip install --upgrade setuptools pip

--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,7 @@ Release history:
 --------------------------
 
 Mpmath requires Python 3.8 or later versions.  It has been tested with CPython
-3.8 through 3.13 and for PyPy 3.9 through 3.10.
+3.8 through 3.14 and for PyPy 3.9 through 3.10.
 
 The latest release of mpmath can be downloaded from the mpmath
 website and from https://github.com/mpmath/mpmath/releases

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -2,7 +2,7 @@ Setting up mpmath
 =================
 
 Mpmath requires at least Python 3.8.  It has been tested with CPython 3.8
-through 3.13 and for PyPy 3.9 through 3.10
+through 3.14 and for PyPy 3.9 through 3.10
 
 Download and installation
 -------------------------

--- a/mpmath/ctx_mp_python.py
+++ b/mpmath/ctx_mp_python.py
@@ -79,9 +79,6 @@ class _mpf(mpnumeric):
         if isinstance(x, int_types): return from_int(x)
         if isinstance(x, float): return from_float(x)
         if isinstance(x, cls.context.constant): return x.func(prec, rounding)
-        if isinstance(x, numbers.Rational): return from_rational(x.numerator,
-                                                                 x.denominator,
-                                                                 prec, rounding)
         if hasattr(x, '_mpf_'): return x._mpf_
         if hasattr(x, '_mpmath_'):
             t = cls.context.convert(x._mpmath_(prec, rounding))
@@ -92,6 +89,9 @@ class _mpf(mpnumeric):
             if a == b:
                 return a
             raise ValueError("can only create mpf from zero-width interval")
+        if isinstance(x, numbers.Rational): return from_rational(x.numerator,
+                                                                 x.denominator,
+                                                                 prec, rounding)
         if type(x).__module__ == 'decimal':
             return from_Decimal(x, prec, rounding)
         raise TypeError("cannot create mpf from " + repr(x))
@@ -724,6 +724,10 @@ class PythonMPContext:
             return ctx.make_mpc((from_float(x.real), from_float(x.imag)))
         if type(x).__module__ == 'numpy': return ctx.npconvert(x)
         prec, rounding = ctx._prec_rounding
+        if hasattr(x, '_mpf_'): return ctx.make_mpf(x._mpf_)
+        if hasattr(x, '_mpc_'): return ctx.make_mpc(x._mpc_)
+        if hasattr(x, '_mpmath_'):
+            return ctx.convert(x._mpmath_(prec, rounding))
         if isinstance(x, numbers.Rational):
             p, q = x.numerator, x.denominator
             return ctx.make_mpf(from_rational(p, q, prec, rounding))
@@ -733,10 +737,6 @@ class PythonMPContext:
                 return ctx.make_mpf(_mpf_)
             except ValueError:
                 pass
-        if hasattr(x, '_mpf_'): return ctx.make_mpf(x._mpf_)
-        if hasattr(x, '_mpc_'): return ctx.make_mpc(x._mpc_)
-        if hasattr(x, '_mpmath_'):
-            return ctx.convert(x._mpmath_(prec, rounding))
         if type(x).__module__ == 'decimal':
             return ctx.make_mpf(from_Decimal(x, prec, rounding))
         return ctx._convert_fallback(x, strings)

--- a/mpmath/functions/orthogonal.py
+++ b/mpmath/functions/orthogonal.py
@@ -444,12 +444,16 @@ def legenq(ctx, n, m, z, type=2, **kwargs):
 def chebyt(ctx, n, x, **kwargs):
     if (not x) and ctx.isint(n) and int(ctx._re(n)) % 2 == 1:
         return x * 0
+    if kwargs.get('force_series') is None:
+        kwargs['force_series'] = True
     return ctx.hyp2f1(-n,n,(1,2),(1-x)/2, **kwargs)
 
 @defun_wrapped
 def chebyu(ctx, n, x, **kwargs):
     if (not x) and ctx.isint(n) and int(ctx._re(n)) % 2 == 1:
         return x * 0
+    if kwargs.get('force_series') is None:
+        kwargs['force_series'] = True
     return (n+1) * ctx.hyp2f1(-n, n+2, (3,2), (1-x)/2, **kwargs)
 
 @defun

--- a/mpmath/tests/test_functions2.py
+++ b/mpmath/tests/test_functions2.py
@@ -13,7 +13,7 @@ from mpmath import (agm, airyai, airybi, appellf1, bei, ber, besseli, besselj,
                     mpf, nan, ncdf, npdf, nthroot, pi, qp, quadts, shi, si,
                     spherharm, sqrt, struveh, struvel, upper_gamma, whitm,
                     whitw, zeta)
-from mpmath.libmp import BACKEND
+from mpmath.libmp import BACKEND, NoConvergence
 
 
 def test_bessel():
@@ -706,6 +706,9 @@ def test_orthpoly():
     assert chebyt(3,2) == 26
     assert chebyu(5,inf) == inf  # issue 469
     assert chebyt(5,inf) == inf
+    assert chebyt(10**3, 1j, force_series=False) == chebyt(10**3, 1j)
+    pytest.raises(NoConvergence, lambda: chebyt(10**6, 1j))  # issue 852
+    assert chebyu(10**3, 1j, force_series=False) == chebyu(10**3, 1j)
     assert legendre(3.5,-1) == inf
     assert legendre(4.5,-1) == -inf
     assert legendre(3.5+1j,-1) == mpc(inf,inf)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ classifiers = ['License :: OSI Approved :: BSD License',
                'Programming Language :: Python :: 3.10',
                'Programming Language :: Python :: 3.11',
                'Programming Language :: Python :: 3.12',
+               'Programming Language :: Python :: 3.13',
+               'Programming Language :: Python :: 3.14',
                'Programming Language :: Python :: Implementation :: CPython',
                'Programming Language :: Python :: Implementation :: PyPy']
 dynamic = ['version']


### PR DESCRIPTION
* reorder hasattr() checks in mpf.mpf_convert_arg() and mp.convert()
* enable testing on 3.14
* claim support for CPython 3.13 and 3.14
* use force_series=True per default for chebyt/chebyu, closes #852

