### PR TITLE
Only check for NumPy array copy ValueError w/ NumPy >= 2.0

### DIFF
--- a/mpmath/tests/test_matrices.py
+++ b/mpmath/tests/test_matrices.py
@@ -203,7 +203,8 @@ def test_matrix_numpy():
 
     if sys.version_info < (3, 9):
         pytest.skip("latest numpy dropped support for CPython 3.8")
-    pytest.raises(ValueError, lambda: numpy.array(matrix(l), copy=False))
+    if numpy.__version__ >= '2':
+        pytest.raises(ValueError, lambda: numpy.array(matrix(l), copy=False))
 
 def test_interval_matrix_scalar_mult():
     """Multiplication of iv.matrix and any scalar type"""


### PR DESCRIPTION
No such error is raised when using NumPy < 2.0 since the [`copy` keyword changes](https://numpy.org/devdocs/release/2.0.0-notes.html#copy-keyword-changes-2-0) hadn't appeared yet.

For example, when running the tests on Debian unstable (where the Debian numpy package is at version 1.26.4), we get the following test failure:

```python
=================================== FAILURES ===================================
______________________________ test_matrix_numpy _______________________________
    def test_matrix_numpy():
        numpy = pytest.importorskip("numpy")
        l = [[1, 2], [3, 4], [5, 6]]
        a = numpy.array(l)
        assert matrix(l) == matrix(a)
        assert (numpy.array(matrix(l)) == numpy.array(matrix(l).tolist(),
                                                      dtype=object)).all()
    
        if sys.version_info < (3, 9):
            pytest.skip("latest numpy dropped support for CPython 3.8")
>       pytest.raises(ValueError, lambda: numpy.array(matrix(l), copy=False))
E       Failed: DID NOT RAISE <class 'ValueError'>
mpmath/tests/test_matrices.py:206: Failed
```

Indeed, running this code raises no errors:

```python
>>> numpy.array(matrix(l), copy=False)
array([[mpf('1.0'), mpf('2.0')],
       [mpf('3.0'), mpf('4.0')],
       [mpf('5.0'), mpf('6.0')]], dtype=object)
```

