### PR TITLE
Address #634

### DIFF
--- a/mpmath/functions/zeta.py
+++ b/mpmath/functions/zeta.py
@@ -482,7 +482,7 @@ def polylog(ctx, s, z):
         return z/(1-z)**2
     if abs(z) <= 0.75 or (not ctx.isint(s) and abs(z) < 0.9):
         return polylog_series(ctx, s, z)
-    if abs(z) >= 1.4 and ctx.isint(s):
+    if abs(z) >= 1.4 and ctx.isint(s) or abs(s - int(s)) < 10e-6:
         return (-1)**(s+1)*polylog_series(ctx, s, 1/z) + polylog_continuation(ctx, int(ctx.re(s)), z)
     if ctx.isint(s):
         return polylog_unitcircle(ctx, int(ctx.re(s)), z)


### PR DESCRIPTION
This modification attempts to resolve the precision error in the polylogarithm function when abs(z) > 1 and s is near an integer

Through empirical testing, I have observed that the decimal precision error arises when abs(s - int(s)) < 10e-6.

No additional tests have been implemented; please advise if they are required.