### PR TITLE
Misc fixes

### DIFF
--- a/mpmath/__main__.py
+++ b/mpmath/__main__.py
@@ -137,8 +137,7 @@ def main():
                 ast.fix_missing_locations(tree)
                 source = ast.unparse(tree)
 
-                source = source.split('\n')
-                source = ';'.join(source)
+                source += "\n"
                 return super().runsource(source, filename=filename, symbol=symbol)
 
         c = MpmathConsole(ast_transformers=ast_transformers,

--- a/mpmath/__main__.py
+++ b/mpmath/__main__.py
@@ -116,6 +116,9 @@ def main():
                 self.source_transformers = source_transformers
 
             def runsource(self, source, filename='<input>', symbol='single'):
+                for t in self.source_transformers:
+                    source = '\n'.join(t(source.splitlines()))
+
                 try:
                     code = self.compile(source, filename, symbol)
                 except (OverflowError, SyntaxError, ValueError):
@@ -128,14 +131,12 @@ def main():
                 if code is None:
                     return True
 
-                for t in self.source_transformers:
-                    source = '\n'.join(t(source.splitlines()))
-
-                tree = ast.parse(source)
-                for t in self.ast_transformers:
-                    tree = t.visit(tree)
-                ast.fix_missing_locations(tree)
-                source = ast.unparse(tree)
+                if self.ast_transformers:
+                    tree = ast.parse(source)
+                    for t in self.ast_transformers:
+                        tree = t.visit(tree)
+                    ast.fix_missing_locations(tree)
+                    source = ast.unparse(tree)
 
                 source += "\n"
                 return super().runsource(source, filename=filename, symbol=symbol)

--- a/mpmath/_interactive.py
+++ b/mpmath/_interactive.py
@@ -34,9 +34,9 @@ def wrap_float_literals(lines):
     g = tokenize.tokenize(io.BytesIO(source.encode()).readline)
     for toknum, tokval, *_ in g:
         if toknum == tokenize.NUMBER:
-            if 'j' in tokval:
-                tokval = f"mpc(0, mpf('{tokval[:-1]}'))"
-            elif '.' in tokval:
+            if any(_ in tokval for _ in ['j', 'J']):
+                tokval = f"mpc(imag=mpf('{tokval[:-1]}'))"
+            elif any(_ in tokval for _ in ['.', 'e', 'E']):
                 tokval = f"mpf('{tokval}')"
         result.append((toknum, tokval, *_))
     return tokenize.untokenize(result).decode().splitlines()

--- a/mpmath/_interactive.py
+++ b/mpmath/_interactive.py
@@ -29,16 +29,14 @@ class IntegerDivisionWrapper(ast.NodeTransformer):
 
 def wrap_float_literals(lines):
     """Wraps all float/complex literals with mpmath classes."""
-    new_lines = []
-    for line in lines:
-        result = []
-        g = tokenize.tokenize(io.BytesIO(line.encode()).readline)
-        for toknum, tokval, _, _, _ in g:
-            if toknum == tokenize.NUMBER:
-                if 'j' in tokval:
-                    tokval = f"mpc(0, mpf('{tokval[:-1]}'))"
-                elif '.' in tokval:
-                    tokval = f"mpf('{tokval}')"
-            result.append((toknum, tokval))
-        new_lines.append(tokenize.untokenize(result).decode())
-    return new_lines
+    result = []
+    source = "\n".join(lines)
+    g = tokenize.tokenize(io.BytesIO(source.encode()).readline)
+    for toknum, tokval, *_ in g:
+        if toknum == tokenize.NUMBER:
+            if 'j' in tokval:
+                tokval = f"mpc(0, mpf('{tokval[:-1]}'))"
+            elif '.' in tokval:
+                tokval = f"mpf('{tokval}')"
+        result.append((toknum, tokval, *_))
+    return tokenize.untokenize(result).decode().splitlines()

--- a/mpmath/calculus/extrapolation.py
+++ b/mpmath/calculus/extrapolation.py
@@ -1,3 +1,5 @@
+import itertools
+
 from .calculus import defun
 
 
@@ -1744,15 +1746,6 @@ def standardize(ctx, f, intervals, options):
             return f(*args)
         return True, g
 
-# backwards compatible itertools.product
-def cartesian_product(args):
-    pools = map(tuple, args)
-    result = [[]]
-    for pool in pools:
-        result = [x+[y] for x in result for y in pool]
-    for prod in result:
-        yield tuple(prod)
-
 def fold_finite(ctx, f, intervals):
     if not intervals:
         return f
@@ -1762,7 +1755,7 @@ def fold_finite(ctx, f, intervals):
     def g(*args):
         args = list(args)
         s = ctx.zero
-        for xs in cartesian_product(ranges):
+        for xs in itertools.product(*ranges):
             for dim, x in zip(indices, xs):
                 args[dim] = ctx.mpf(x)
             s += f(*args)

--- a/mpmath/libmp/libmpf.py
+++ b/mpmath/libmp/libmpf.py
@@ -1474,17 +1474,22 @@ def read_format_spec(format_spec):
             format_dict['rounding'] = _GMPY_ROUND_CHAR_DICT[rounding_char]
 
         if match['zeropad']:
-            if not match['align']:
-                format_dict['align'] = '='
-            if not match['fill_char']:
-                format_dict['fill_char'] = '0'
+            if match['fill_char']:
+                raise ValueError("Fill character conflicts with '0'"
+                                 f" in format specifier: '{format_spec}'")
+            if match['align']:
+                raise ValueError("Alignment conflicts with '0'"
+                                 f" in format specifier: '{format_spec}'")
+            format_dict['align'] = '='
+            format_dict['fill_char'] = '0'
 
-        if format_dict['precision'] < 0 and format_dict['type'].lower() not in ['', 'a', 'b']:
+        if format_dict['precision'] < 0 and (format_dict['type'].lower()
+                                             not in ['', 'a', 'b']):
             format_dict['precision'] = 6
-    else:
-        raise ValueError("Invalid format specifier '{}'".format(format_spec))
 
-    return format_dict
+        return format_dict
+
+    raise ValueError(f"Invalid format specifier '{format_spec}'")
 
 
 def format_fixed(s, precision=6, rounding=round_nearest):

--- a/mpmath/libmp/libmpf.py
+++ b/mpmath/libmp/libmpf.py
@@ -1397,10 +1397,10 @@ _FLOAT_FORMAT_SPECIFICATION_MATCHER = re.compile(r"""
     (?P<sign>[-+ ]?)
     (?P<no_neg_0>z)?
     (?P<alternate>\#)?
-    (?P<zeropad>0(?=0*[1-9]))?
-    (?P<width>[0-9]+)?
+    (?P<zeropad>0(?=[0-9]))?
+    (?P<width>0|[1-9][0-9]*)?
     (?P<thousands_separators>[,_])?
-    (?:\.(?P<precision>[0-9]+)(?P<frac_separators>[,_])?)?
+    (?:\.(?P<precision>0|[1-9][0-9]*)(?P<frac_separators>[,_])?)?
     (?P<rounding>[UDYZN])?
     (?P<type>[aAbeEfFgG%])?
 """, re.DOTALL | re.VERBOSE).fullmatch

--- a/mpmath/libmp/libmpf.py
+++ b/mpmath/libmp/libmpf.py
@@ -1400,7 +1400,11 @@ _FLOAT_FORMAT_SPECIFICATION_MATCHER = re.compile(r"""
     (?P<zeropad>0(?=[0-9]))?
     (?P<width>0|[1-9][0-9]*)?
     (?P<thousands_separators>[,_])?
-    (?:\.(?P<precision>0|[1-9][0-9]*)(?P<frac_separators>[,_])?)?
+    (?:\.
+        (?=[,_0-9])  # lookahead for digit or separator
+        (?P<precision>0|[1-9][0-9]*)?
+        (?P<frac_separators>[,_])?
+    )?
     (?P<rounding>[UDYZN])?
     (?P<type>[aAbeEfFgG%])?
 """, re.DOTALL | re.VERBOSE).fullmatch

--- a/mpmath/tests/test_cli.py
+++ b/mpmath/tests/test_cli.py
@@ -99,7 +99,13 @@ def test_bare_console_wrap_floats():
     assert c.expect_exact('>>> ') == 0
     assert c.send("10.9\r\n") == 6
     assert c.expect_exact("mpf('10.899999999999999999999999999995')\r\n>>> ") == 0
+    assert c.send("1e100\r\n") == 7
+    assert c.expect_exact("mpf('9.9999999999999999999999999999997e+99')\r\n>>> ") == 0
+    assert c.send("1E100\r\n") == 7
+    assert c.expect_exact("mpf('9.9999999999999999999999999999997e+99')\r\n>>> ") == 0
     assert c.send("1+10.9j\r\n") == 9
+    assert c.expect_exact("mpc(real='1.0', imag='10.899999999999999999999999999995')\r\n>>> ") == 0
+    assert c.send("1+10.9J\r\n") == 9
     assert c.expect_exact("mpc(real='1.0', imag='10.899999999999999999999999999995')\r\n>>> ") == 0
     assert c.send('mpf(10.9)\r\n') == 11
     assert c.expect_exact("mpf('10.899999999999999999999999999995')\r\n>>> ") == 0

--- a/mpmath/tests/test_format.py
+++ b/mpmath/tests/test_format.py
@@ -54,9 +54,7 @@ def fmt_str(draw, types='fFeE', for_complex=False):
         skip_thousand_separators = True
 
     # Width
-    res += draw(st.sampled_from(['']*7 + list(map(str, range(1, 40)))
-                                + ([] if for_complex else ['0' + str(_)
-                                                           for _ in range(40)])))
+    res += draw(st.sampled_from(['']*7 + list(map(str, range(1, 40)))))
 
     # grouping character (thousand_separators)
     gchar = draw(st.sampled_from([''] + list(',_')))
@@ -64,8 +62,7 @@ def fmt_str(draw, types='fFeE', for_complex=False):
         res += gchar
 
     # Precision
-    prec = draw(st.sampled_from(['']*7 + list(map(str, range(40)))
-                + ['0' + str(_) for _ in range(40)]))
+    prec = draw(st.sampled_from(['']*7 + list(map(str, range(40)))))
     if prec:
         res += '.' + prec
         # if sys.version_info >= (3, 14):
@@ -477,8 +474,6 @@ def test_mpf_fmt_cpython():
                  allow_infinity=True,
                  allow_subnormal=True))
 @example(fmt='.0g', x=9.995074823339339e-05)  # issue 880
-@example(fmt='.016f', x=0.1)  # issue 915
-@example(fmt='0030f', x=0.3)
 @example(fmt='0=13,f', x=1.1)  # issue 917
 @example(fmt='013,f', x=1.1)
 @example(fmt='013,.0%', x=1.1)

--- a/mpmath/tests/test_format.py
+++ b/mpmath/tests/test_format.py
@@ -618,8 +618,8 @@ def test_mpf_fmt():
 
         # Tests for = alignment
         assert f"{mp.mpf('0.24'):=+20.2f}" == '+               0.24'
-        assert f"{mp.mpf('0.24'):=+020.2e}" == '+000000000002.40e-01'
-        assert f"{mp.mpf('0.24'):=+020.2g}" == '+0000000000000000.24'
+        assert f"{mp.mpf('0.24'):0=+20.2e}" == '+000000000002.40e-01'
+        assert f"{mp.mpf('0.24'):0=+20.2g}" == '+0000000000000000.24'
 
         # Tests for different kinds of rounding
         num = mp.mpf('-1.23456789999901234567')
@@ -815,6 +815,13 @@ def test_errors():
 
     with pytest.raises(ValueError, match="Invalid format specifier '12.3 E '"):
         f"{mp.mpf('4'):12.3 E }"
+
+    with pytest.raises(ValueError, match="Fill character conflicts"):
+        f"{mp.mpf('4'):q<03f}"
+    with pytest.raises(ValueError, match="Alignment conflicts"):
+        f"{mp.mpf('4'):=03f}"
+    with pytest.raises(ValueError, match="Fill character conflicts"):
+        f"{mp.mpf('4'): =03f}"
 
 
 @settings(max_examples=10000)

--- a/mpmath/tests/test_format.py
+++ b/mpmath/tests/test_format.py
@@ -823,6 +823,11 @@ def test_errors():
     with pytest.raises(ValueError, match="Fill character conflicts"):
         f"{mp.mpf('4'): =03f}"
 
+    with pytest.raises(ValueError):
+        f"{mp.mpf(1):.f}"
+    with pytest.raises(ValueError):
+        f"{mp.mpf(1):._6f}"
+
 
 @settings(max_examples=10000)
 @given(st.floats(allow_nan=True, allow_infinity=True,


### PR DESCRIPTION
* use `itertools.product()` in calculus
* CLI fixes for multi-line input
* revert 849e185e and (partially) f4cef9c8 (same for with field)
* test formatting with digit separators in the fractional part
* revert rest of f4cef9c8
* amend 950d654a (support '._f'-like cases, i.e. with default precision)
* move source transformations up in runsource()
* fix wrap_float_literals() to detect all float/complex literals