### PR TITLE
Switch to taylor series logarithm when cancellation > precision

### DIFF
--- a/mpmath/libmp/libelefun.py
+++ b/mpmath/libmp/libelefun.py
@@ -49,7 +49,7 @@ cos_sin_cache = {}
 MAX_LOG_INT_CACHE = 2000
 log_int_cache = {}
 
-LOG_TAYLOR_PREC = 2500  # Use Taylor series with caching or no caching up to this prec
+LOG_TAYLOR_PREC = 2500  # Use Taylor series with caching up to this prec
 LOG_TAYLOR_SHIFT = 9    # Cache log values in steps of size 2^-N
 log_taylor_cache = {}
 # prec/size ratio of x for fastest convergence in AGM formula
@@ -699,7 +699,7 @@ def mpf_log(x, prec, rnd=round_fast):
         # even in the AGM precision range, since the Taylor series
         # converges rapidly
         if cancellation > 15:
-            if wp <= LOG_TAYLOR_PREC:
+            if wp <= 10000:
                 a = to_fixed(x, wp)
                 s = log_taylor(a, wp)
                 return from_man_exp(s, -wp, prec, rnd)

--- a/mpmath/libmp/libelefun.py
+++ b/mpmath/libmp/libelefun.py
@@ -701,7 +701,7 @@ def mpf_log(x, prec, rnd=round_fast):
         # Taylor = AGM when O~(prec) = O~(prec^2/cancellation) where cancellation
         # is greater than or equal to precision
         wpb = wp.bit_length()
-        if wpb <= cancellation: #possibly include constant (big integer operations)
+        if wpb <= cancellation:  # possibly include constant (big integer operations)
             a = to_fixed(x, wp)
             s = log_taylor(a, wp)
             return from_man_exp(s, -wp, prec, rnd)

--- a/mpmath/libmp/libelefun.py
+++ b/mpmath/libmp/libelefun.py
@@ -702,7 +702,7 @@ def mpf_log(x, prec, rnd=round_fast):
         else:
             tfixed = to_fixed(x, wp) - (MPZ_ONE << wp)
         threshold = (1 << wp) // 1000
-        if (tfixed <= threshold):
+        if tfixed <= threshold:
             s = log_taylor(to_fixed(x, wp), wp)
             sb = s.bit_length()
             rman = s << (sb)

--- a/mpmath/libmp/libelefun.py
+++ b/mpmath/libmp/libelefun.py
@@ -49,7 +49,7 @@ cos_sin_cache = {}
 MAX_LOG_INT_CACHE = 2000
 log_int_cache = {}
 
-LOG_TAYLOR_PREC = 2500  # Use Taylor series with caching up to this prec
+LOG_TAYLOR_PREC = 2500  # Use Taylor series with caching or no caching up to this prec
 LOG_TAYLOR_SHIFT = 9    # Cache log values in steps of size 2^-N
 log_taylor_cache = {}
 # prec/size ratio of x for fastest convergence in AGM formula
@@ -695,19 +695,14 @@ def mpf_log(x, prec, rnd=round_fast):
         else:
             wp += cancellation
 
-        # if close enough to 1, use Taylor series
-        # since Taylor series converges rapidly
-        if tsign:
-            tfixed = (MPZ_ONE << wp) - to_fixed(x,wp)
-        else:
-            tfixed = to_fixed(x, wp) - (MPZ_ONE << wp)
-        threshold = (1 << wp) // 1000
-        if tfixed <= threshold:
-            s = log_taylor(to_fixed(x, wp), wp)
-            sb = s.bit_length()
-            rman = s << (sb)
-            rexp = -(sb+wp)
-            return from_man_exp(rman, rexp, prec, rnd)
+        # If close enough to 1, use Taylor series
+        # even in the AGM precision range, since the Taylor series
+        # converges rapidly
+        if cancellation > 15:
+            if wp <= LOG_TAYLOR_PREC:
+                a = to_fixed(x, wp)
+                s = log_taylor(a, wp)
+                return from_man_exp(s, -wp, prec, rnd)
 
     #------------------------------------------------------------------
     # Another special case:

--- a/mpmath/libmp/libelefun.py
+++ b/mpmath/libmp/libelefun.py
@@ -694,7 +694,7 @@ def mpf_log(x, prec, rnd=round_fast):
             return mpf_perturb(t, tsign, prec, rnd)
         else:
             wp += cancellation
-            
+
         # if close enough to 1, use Taylor series
         # since Taylor series converges rapidly
         if tsign:
@@ -708,7 +708,7 @@ def mpf_log(x, prec, rnd=round_fast):
             rman = s << (sb)
             rexp = -(sb+wp)
             return from_man_exp(rman, rexp, prec, rnd)
-        
+
     #------------------------------------------------------------------
     # Another special case:
     # n*log(2) is a good enough approximation

--- a/mpmath/libmp/libelefun.py
+++ b/mpmath/libmp/libelefun.py
@@ -697,12 +697,14 @@ def mpf_log(x, prec, rnd=round_fast):
 
         # If close enough to 1, use Taylor series
         # even in the AGM precision range, since the Taylor series
-        # converges rapidly
-        if cancellation > 15:
-            if wp <= 10000:
-                a = to_fixed(x, wp)
-                s = log_taylor(a, wp)
-                return from_man_exp(s, -wp, prec, rnd)
+        # converges rapidly. 
+        # Taylor = AGM when O~(prec) = O~(prec^2/cancellation) where cancellation
+        # is greater than or equal to precision
+        wpb = wp.bit_length()
+        if wpb <= cancellation: #possibly include constant (big integer operations)
+            a = to_fixed(x, wp)
+            s = log_taylor(a, wp)
+            return from_man_exp(s, -wp, prec, rnd)
 
     #------------------------------------------------------------------
     # Another special case:

--- a/mpmath/libmp/libelefun.py
+++ b/mpmath/libmp/libelefun.py
@@ -697,7 +697,7 @@ def mpf_log(x, prec, rnd=round_fast):
 
         # If close enough to 1, use Taylor series
         # even in the AGM precision range, since the Taylor series
-        # converges rapidly. 
+        # converges rapidly.
         # Taylor = AGM when O~(prec) = O~(prec^2/cancellation) where cancellation
         # is greater than or equal to precision
         wpb = wp.bit_length()

--- a/mpmath/libmp/libelefun.py
+++ b/mpmath/libmp/libelefun.py
@@ -694,9 +694,21 @@ def mpf_log(x, prec, rnd=round_fast):
             return mpf_perturb(t, tsign, prec, rnd)
         else:
             wp += cancellation
-        # TODO: if close enough to 1, we could use Taylor series
-        # even in the AGM precision range, since the Taylor series
-        # converges rapidly
+            
+        # if close enough to 1, use Taylor series
+        # since Taylor series converges rapidly
+        if tsign:
+            tfixed = (MPZ_ONE << wp) - to_fixed(x,wp)
+        else:
+            tfixed = to_fixed(x, wp) - (MPZ_ONE << wp)
+        threshold = (1 << wp) // 1000
+        if (tfixed <= threshold):
+            s = log_taylor(to_fixed(x, wp), wp)
+            sb = s.bit_length()
+            rman = s << (sb)
+            rexp = -(sb+wp)
+            return from_man_exp(rman, rexp, prec, rnd)
+        
     #------------------------------------------------------------------
     # Another special case:
     # n*log(2) is a good enough approximation

--- a/mpmath/tests/test_functions.py
+++ b/mpmath/tests/test_functions.py
@@ -209,6 +209,10 @@ def test_log():
     assert (log(-1j-1e-8).real*10**16).ae(0.5)
     assert (log(1+1e-40j).real*10**80).ae(0.5)
     assert (log(1j+1e-40).real*10**80).ae(0.5)
+    # Taylor series
+    assert (log(0.99999)).ae(-1.0000050000287824e-5)
+    assert (log(1.00001)).ae(9.9999500003988414e-6)
+
     # Huge
     assert log(ldexp(1.234,10**20)).ae(log(2)*1e20)
     assert log(ldexp(1.234,10**200)).ae(log(2)*1e200)

--- a/mpmath/tests/test_functions.py
+++ b/mpmath/tests/test_functions.py
@@ -210,8 +210,8 @@ def test_log():
     assert (log(1+1e-40j).real*10**80).ae(0.5)
     assert (log(1j+1e-40).real*10**80).ae(0.5)
     # Taylor series
-    assert (log(0.99999)).ae(-1.0000050000287824e-5)
-    assert (log(1.00001)).ae(9.9999500003988414e-6)
+    assert log(0.99999).ae(-1.0000050000287824e-5)
+    assert log(1.00001).ae(9.9999500003988414e-6)
 
     # Huge
     assert log(ldexp(1.234,10**20)).ae(log(2)*1e20)


### PR DESCRIPTION
This current change modifies the logarithm implementation for cases where taylor series is more optimal (cancellation >= working precision).

This provides a faster path for low precision cases depending on how close input is to 1.