### PR TITLE
Fix #1003: sinm and cosm can accept list as arguments, similar to expm and other functions

### DIFF
--- a/mpmath/matrices/calculus.py
+++ b/mpmath/matrices/calculus.py
@@ -110,16 +110,19 @@ class MatrixCalculusMethods:
             42.0927851137247
 
         """
+        A = ctx.matrix(A)
+        if(A.rows != A.cols):
+            raise ValueError("expected square matrix")  
+        
         if method == 'pade':
             prec = ctx.prec
             try:
-                A = ctx.matrix(A)
                 ctx.prec += 2*A.rows
                 res = ctx._exp_pade(A)
             finally:
                 ctx.prec = prec
             return res
-        A = ctx.matrix(A)
+        
         prec = ctx.prec
         j = int(max(1, ctx.mag(ctx.mnorm(A,'inf'))))
         j += int(0.5*prec**0.5)
@@ -168,6 +171,10 @@ class MatrixCalculusMethods:
             [                                     0.0               (1.54308063481524 + 0.0j)]
         """
         A = ctx.matrix(A)
+
+        if(A.rows != A.cols):
+            raise ValueError("expected square matrix")  
+        
         B = 0.5 * (ctx.expm(A*ctx.j) + ctx.expm(A*(-ctx.j)))
         if not sum(A.apply(ctx.im).apply(abs)):
             B = B.apply(ctx.re)
@@ -198,6 +205,10 @@ class MatrixCalculusMethods:
             [                                    0.0                  (0.0 - 1.1752011936438j)]
         """
         A = ctx.matrix(A)
+
+        if(A.rows != A.cols):
+            raise ValueError("expected square matrix")  
+        
         B = (-0.5j) * (ctx.expm(A*ctx.j) - ctx.expm(A*(-ctx.j)))
         if not sum(A.apply(ctx.im).apply(abs)):
             B = B.apply(ctx.re)

--- a/mpmath/matrices/calculus.py
+++ b/mpmath/matrices/calculus.py
@@ -111,8 +111,6 @@ class MatrixCalculusMethods:
 
         """
         A = ctx.matrix(A)
-        if(A.rows != A.cols):
-            raise ValueError("expected square matrix")
 
         if method == 'pade':
             prec = ctx.prec
@@ -171,10 +169,6 @@ class MatrixCalculusMethods:
             [                                     0.0               (1.54308063481524 + 0.0j)]
         """
         A = ctx.matrix(A)
-
-        if(A.rows != A.cols):
-            raise ValueError("expected square matrix")
-
         B = 0.5 * (ctx.expm(A*ctx.j) + ctx.expm(A*(-ctx.j)))
         if not sum(A.apply(ctx.im).apply(abs)):
             B = B.apply(ctx.re)
@@ -205,10 +199,6 @@ class MatrixCalculusMethods:
             [                                    0.0                  (0.0 - 1.1752011936438j)]
         """
         A = ctx.matrix(A)
-
-        if(A.rows != A.cols):
-            raise ValueError("expected square matrix")
-
         B = (-0.5j) * (ctx.expm(A*ctx.j) - ctx.expm(A*(-ctx.j)))
         if not sum(A.apply(ctx.im).apply(abs)):
             B = B.apply(ctx.re)

--- a/mpmath/matrices/calculus.py
+++ b/mpmath/matrices/calculus.py
@@ -112,8 +112,8 @@ class MatrixCalculusMethods:
         """
         A = ctx.matrix(A)
         if(A.rows != A.cols):
-            raise ValueError("expected square matrix")  
-        
+            raise ValueError("expected square matrix")
+
         if method == 'pade':
             prec = ctx.prec
             try:
@@ -122,7 +122,7 @@ class MatrixCalculusMethods:
             finally:
                 ctx.prec = prec
             return res
-        
+
         prec = ctx.prec
         j = int(max(1, ctx.mag(ctx.mnorm(A,'inf'))))
         j += int(0.5*prec**0.5)
@@ -173,8 +173,8 @@ class MatrixCalculusMethods:
         A = ctx.matrix(A)
 
         if(A.rows != A.cols):
-            raise ValueError("expected square matrix")  
-        
+            raise ValueError("expected square matrix")
+
         B = 0.5 * (ctx.expm(A*ctx.j) + ctx.expm(A*(-ctx.j)))
         if not sum(A.apply(ctx.im).apply(abs)):
             B = B.apply(ctx.re)
@@ -207,8 +207,8 @@ class MatrixCalculusMethods:
         A = ctx.matrix(A)
 
         if(A.rows != A.cols):
-            raise ValueError("expected square matrix")  
-        
+            raise ValueError("expected square matrix")
+
         B = (-0.5j) * (ctx.expm(A*ctx.j) - ctx.expm(A*(-ctx.j)))
         if not sum(A.apply(ctx.im).apply(abs)):
             B = B.apply(ctx.re)

--- a/mpmath/matrices/calculus.py
+++ b/mpmath/matrices/calculus.py
@@ -167,6 +167,7 @@ class MatrixCalculusMethods:
             [(0.833730025131149 - 0.988897705762865j)  (1.07485840848393 - 0.17192140544213j)]
             [                                     0.0               (1.54308063481524 + 0.0j)]
         """
+        A = ctx.matrix(A)
         B = 0.5 * (ctx.expm(A*ctx.j) + ctx.expm(A*(-ctx.j)))
         if not sum(A.apply(ctx.im).apply(abs)):
             B = B.apply(ctx.re)
@@ -196,6 +197,7 @@ class MatrixCalculusMethods:
             [(1.29845758141598 + 0.634963914784736j)  (-1.96751511930922 + 0.314700021761367j)]
             [                                    0.0                  (0.0 - 1.1752011936438j)]
         """
+        A = ctx.matrix(A)
         B = (-0.5j) * (ctx.expm(A*ctx.j) - ctx.expm(A*(-ctx.j)))
         if not sum(A.apply(ctx.im).apply(abs)):
             B = B.apply(ctx.re)

--- a/mpmath/tests/test_calculus.py
+++ b/mpmath/tests/test_calculus.py
@@ -2,7 +2,7 @@ import pytest
 
 from mpmath import (arange, chebyfit, cos, differint, e, euler, exp, fourier,
                     fourierval, inf, invertlaplace, j, limit, log, matrix, mp,
-                    mpf, pade, pi, polyroots, polyval, sin, sqrt)
+                    mpf, pade, pi, polyroots, polyval, sin, sqrt, expm, cosm, sinm)
 
 
 def test_approximation():
@@ -236,3 +236,53 @@ def test_invlap():
     assert invertlaplace(fp,t,method='stehfest').ae(ftt)
     assert invertlaplace(fp,t,method='dehoog').ae(ftt)
     assert invertlaplace(fp,t,method='cohen').ae(ftt)
+
+def test_expm():
+    
+    #  Simple tests with known exact results
+    A = matrix([[2, 0], [0, 1]])
+    A = expm(A)
+    B = matrix([[e**2, 0], [0, e]])
+    for i in range(2):
+        for j in range(2):
+            assert abs(A[i,j] - B[i,j]) < 1e-15
+
+    A = matrix([[0, -pi], [pi, 0]])
+    A = expm(A)
+    B = matrix([[-1, 0], [0, -1]])
+    for i in range(2):
+        for j in range(2):
+            assert abs(A[i,j] - B[i,j]) < 1e-15
+     
+    # Test with input as list of lists
+    A = [[1, 0], [0, 2]]
+    A = expm(A)
+    B = matrix([[e, 0], [0, e**2]])
+    for i in range(2):
+        for j in range(2):
+            assert abs(A[i,j] - B[i,j]) < 1e-15
+    
+def test_cosm_sinm():
+
+    # Simple test with known exact result
+    A = matrix([[-pi, 0], [0, pi]])
+    C = cosm(A)
+    S = sinm(A)
+    C_exact = matrix([[cos(-pi), 0], [0, cos(pi)]])
+    S_exact = matrix([[0, 0], [0, 0]])
+    for i in range(2):
+        for j in range(2):
+            assert abs(C[i,j] - C_exact[i,j]) < 1e-15
+            assert abs(S[i,j] - S_exact[i,j]) < 1e-15
+
+    # Test with input as list of lists
+    A = [[-pi, 0], [0, pi]]
+    C = cosm(A)
+    S = sinm(A)
+    C_exact = matrix([[cos(-pi), 0], [0, cos(pi)]])
+    S_exact = matrix([[0, 0], [0, 0]])
+    for i in range(2):
+        for j in range(2):
+            assert abs(C[i,j] - C_exact[i,j]) < 1e-15
+            assert abs(S[i,j] - S_exact[i,j]) < 1e-15
+

--- a/mpmath/tests/test_calculus.py
+++ b/mpmath/tests/test_calculus.py
@@ -1,8 +1,9 @@
 import pytest
 
-from mpmath import (arange, chebyfit, cos, differint, e, euler, exp, fourier,
-                    fourierval, inf, invertlaplace, j, limit, log, matrix, mp,
-                    mpf, pade, pi, polyroots, polyval, sin, sqrt, expm, cosm, sinm)
+from mpmath import (arange, chebyfit, cos, cosm, differint, e, euler, exp,
+                    expm, fourier, fourierval, inf, invertlaplace, j, limit,
+                    log, matrix, mp, mpf, norm, pade, pi, polyroots, polyval,
+                    sin, sinm, sqrt)
 
 
 def test_approximation():
@@ -238,46 +239,36 @@ def test_invlap():
     assert invertlaplace(fp,t,method='cohen').ae(ftt)
 
 def test_expm():
-
     #  Simple tests with known exact results
     A = matrix([[2, 0], [0, 1]])
     A = expm(A)
     B = matrix([[e**2, 0], [0, e]])
-    for i in range(2):
-        for j in range(2):
-            assert abs(A[i,j] - B[i,j]) < 1e-15
+    assert norm(A-B, inf) < 1e-15
 
     A = matrix([[0, -pi], [pi, 0]])
     A = expm(A)
     B = matrix([[-1, 0], [0, -1]])
-    for i in range(2):
-        for j in range(2):
-            assert abs(A[i,j] - B[i,j]) < 1e-15
+    assert norm(A-B, inf) < 1e-15
 
     # Test with input as list of lists
     A = [[1, 0], [0, 2]]
     A = expm(A)
     B = matrix([[e, 0], [0, e**2]])
-    for i in range(2):
-        for j in range(2):
-            assert abs(A[i,j] - B[i,j]) < 1e-15
+    assert norm(A-B, inf) < 1e-15
 
     # Test non-square matrix input
     A = [[1, 0], [0, 1], [0, 0]]
     pytest.raises(ValueError, lambda: expm(A))
 
 def test_cosm_sinm():
-
     # Simple test with known exact result
     A = matrix([[-pi, 0], [0, pi]])
     C = cosm(A)
     S = sinm(A)
     C_exact = matrix([[cos(-pi), 0], [0, cos(pi)]])
     S_exact = matrix([[0, 0], [0, 0]])
-    for i in range(2):
-        for j in range(2):
-            assert abs(C[i,j] - C_exact[i,j]) < 1e-15
-            assert abs(S[i,j] - S_exact[i,j]) < 1e-15
+    assert norm(C-C_exact, inf) < 1e-15
+    assert norm(S-S_exact, inf) < 1e-15
 
     # Test with input as list of lists
     A = [[-pi, 0], [0, pi]]
@@ -285,10 +276,8 @@ def test_cosm_sinm():
     S = sinm(A)
     C_exact = matrix([[cos(-pi), 0], [0, cos(pi)]])
     S_exact = matrix([[0, 0], [0, 0]])
-    for i in range(2):
-        for j in range(2):
-            assert abs(C[i,j] - C_exact[i,j]) < 1e-15
-            assert abs(S[i,j] - S_exact[i,j]) < 1e-15
+    assert norm(C-C_exact, inf) < 1e-15
+    assert norm(S-S_exact, inf) < 1e-15
 
     # Test non-square matrix input
     A = [[1, 0], [0, 1], [0, 0]]

--- a/mpmath/tests/test_calculus.py
+++ b/mpmath/tests/test_calculus.py
@@ -261,6 +261,10 @@ def test_expm():
     for i in range(2):
         for j in range(2):
             assert abs(A[i,j] - B[i,j]) < 1e-15
+
+    # Test non-square matrix input
+    A = [[1, 0], [0, 1], [0, 0]]
+    pytest.raises(ValueError, lambda: expm(A))
     
 def test_cosm_sinm():
 
@@ -286,3 +290,7 @@ def test_cosm_sinm():
             assert abs(C[i,j] - C_exact[i,j]) < 1e-15
             assert abs(S[i,j] - S_exact[i,j]) < 1e-15
 
+    # Test non-square matrix input
+    A = [[1, 0], [0, 1], [0, 0]]
+    pytest.raises(ValueError, lambda: cosm(A))
+    pytest.raises(ValueError, lambda: sinm(A))

--- a/mpmath/tests/test_calculus.py
+++ b/mpmath/tests/test_calculus.py
@@ -238,7 +238,7 @@ def test_invlap():
     assert invertlaplace(fp,t,method='cohen').ae(ftt)
 
 def test_expm():
-    
+
     #  Simple tests with known exact results
     A = matrix([[2, 0], [0, 1]])
     A = expm(A)
@@ -253,7 +253,7 @@ def test_expm():
     for i in range(2):
         for j in range(2):
             assert abs(A[i,j] - B[i,j]) < 1e-15
-     
+
     # Test with input as list of lists
     A = [[1, 0], [0, 2]]
     A = expm(A)
@@ -265,7 +265,7 @@ def test_expm():
     # Test non-square matrix input
     A = [[1, 0], [0, 1], [0, 0]]
     pytest.raises(ValueError, lambda: expm(A))
-    
+
 def test_cosm_sinm():
 
     # Simple test with known exact result


### PR DESCRIPTION
- fix #1003 
- While solving this issue, I came across a very subtle problem, that when the input matrix to `expm()`, `cosm()` and `sinm()` is a non-square matrix, the error is thrown from the `expm()` when it calls the `__pow__()` inside it, which is not very readable and also exposes the inner working of `expm()`. I have fixed this too, by having a separate check for non-square matrix.   
- Add test case for the same