### PR TITLE
Fix #1002: Raise ValueError when zero matrix is passed to logm()

### DIFF
--- a/mpmath/matrices/calculus.py
+++ b/mpmath/matrices/calculus.py
@@ -433,6 +433,8 @@ class MatrixCalculusMethods:
 
         """
         A = ctx.matrix(A)
+        if ctx.mnorm(A, 'inf') == 0:
+            raise ValueError("The logarithm is undefined for the zero matrix.")
         prec = ctx.prec
         try:
             ctx.prec += 10

--- a/mpmath/tests/test_calculus.py
+++ b/mpmath/tests/test_calculus.py
@@ -3,7 +3,7 @@ import pytest
 from mpmath import (arange, chebyfit, cos, cosm, differint, e, euler, exp,
                     expm, fourier, fourierval, inf, invertlaplace, j, limit,
                     log, matrix, mp, mpf, norm, pade, pi, polyroots, polyval,
-                    sin, sinm, sqrt)
+                    sin, sinm, sqrt, logm)
 
 
 def test_approximation():
@@ -283,3 +283,8 @@ def test_cosm_sinm():
     A = [[1, 0], [0, 1], [0, 0]]
     pytest.raises(ValueError, lambda: cosm(A))
     pytest.raises(ValueError, lambda: sinm(A))
+
+def test_logm():
+    # Test for zero matrix
+    A = [[0, 0], [0, 0]]
+    pytest.raises(ValueError, lambda: logm(A))


### PR DESCRIPTION
Closes #1002 