### PR TITLE
Add option --int-limits for CLI

### DIFF
--- a/mpmath/__main__.py
+++ b/mpmath/__main__.py
@@ -40,6 +40,9 @@ parser.add_argument('--prec', type=int,
                     help='Set default mpmath precision')
 parser.add_argument('--no-pretty', help='Disable pretty-printing',
                     action='store_true')
+parser.add_argument('--int-limits',
+                    help="Enable string conversion length limitation for int's",
+                    action='store_true')
 
 
 def main():
@@ -48,6 +51,9 @@ def main():
     if args.version:
         print(__version__)
         sys.exit(0)
+
+    if not args.int_limits:
+        sys.set_int_max_str_digits(0)
 
     lines = ['from mpmath import *',
              'from fractions import Fraction']

--- a/mpmath/tests/test_cli.py
+++ b/mpmath/tests/test_cli.py
@@ -15,7 +15,8 @@ if platform.python_implementation() == 'PyPy':
 
 
 def test_bare_console_no_bare_division():
-    c = Console(f'{sys.executable} -m mpmath --no-ipython --no-wrap-floats')
+    c = Console(f'{sys.executable} -m mpmath --no-ipython '
+                '--no-wrap-floats --int-limits')  # for coverage
 
     assert c.expect_exact('>>> ') == 0
     assert c.send('1 + 2\r\n') == 7


### PR DESCRIPTION
This enables *default* Python mechanism for integer string conversion length limitation:
https://docs.python.org/3/library/stdtypes.html#integer-string-conversion-length-limitation

For the mpmath CLI it will be *off* by default.  Usually, it doesn't matter, as these limits not affect the gmpy2/gmp backends and working with mpmath's types (mpf/mpc).  Though, sometimes you want to play with integers in the mpmath console and these limits are really annoying.

I consider this as a bugfix, despite it adds a new option.