### PR TITLE
Misc fixes

### DIFF
--- a/mpmath/__main__.py
+++ b/mpmath/__main__.py
@@ -56,6 +56,7 @@ def main():
         sys.set_int_max_str_digits(0)
 
     lines = ['from mpmath import *',
+             'import mpmath',
              'from fractions import Fraction']
 
     if args.prec:

--- a/mpmath/ctx_fp.py
+++ b/mpmath/ctx_fp.py
@@ -194,11 +194,13 @@ class FPContext(StandardBaseContext):
     def _convert_param(ctx, z):
         if type(z) is tuple:
             p, q = z
-            return ctx.mpf(p) / q, 'R'
+            return ctx.mpf(p / q), 'R'
         intz = int(z.real)
         if z == intz:
             return intz, 'Z'
-        return z, 'R'
+        if not z.imag:
+            return ctx.mpf(z), 'R'
+        return ctx.mpc(z), 'C'
 
     def _is_real_type(ctx, z):
         return isinstance(z, float) or isinstance(z, int_types)

--- a/mpmath/functions/factorials.py
+++ b/mpmath/functions/factorials.py
@@ -91,7 +91,7 @@ def barnesg(ctx, z):
         return ctx.nan
     if ctx.isnan(z):
         return z
-    if (not ctx._im(z)) and ctx._re(z) <= 0 and ctx.isint(ctx._re(z)):
+    if ctx.isnpint(z):
         return z*0
     # Account for size (would not be needed if computing log(G))
     if abs(z) > 5:
@@ -146,7 +146,7 @@ def hyperfac(ctx, z):
     else:
         extra = 0
     ctx.prec += extra
-    if not ctx._im(z) and ctx._re(z) < 0 and ctx.isint(ctx._re(z)):
+    if z and ctx.isnpint(z):
         n = int(ctx.re(z))
         h = ctx.hyperfac(-n-1)
         if ((n+1)//2) & 1:

--- a/mpmath/functions/hypergeometric.py
+++ b/mpmath/functions/hypergeometric.py
@@ -316,7 +316,7 @@ def _hyp1f1(ctx, a_s, b_s, z, **kwargs):
     if not z:
         return ctx.one+z
     magz = ctx.mag(z)
-    if magz >= 7 and not (ctx.isint(a) and ctx.re(a) <= 0):
+    if magz >= 7 and not ctx.isnpint(a):
         if ctx.isinf(z) and ctx.sign(a) == ctx.sign(b) == ctx.sign(z) == 1:
             return ctx.inf
         if ctx.isinf(magz):
@@ -406,9 +406,9 @@ def _hyp2f1(ctx, a_s, b_s, z, **kwargs):
     if z == 1:
         # TODO: the following logic can be simplified
         convergent = ctx.re(c-a-b) > 0
-        finite = (ctx.isint(a) and a <= 0) or (ctx.isint(b) and b <= 0)
-        zerodiv = ctx.isint(c) and c <= 0 and not \
-            ((ctx.isint(a) and c <= a <= 0) or (ctx.isint(b) and c <= b <= 0))
+        finite = ctx.isnpint(a) or ctx.isnpint(b)
+        zerodiv = ctx.isnpint(c) and not \
+            ((ctx.isnpint(a) and c <= a) or (ctx.isnpint(b) and c <= b))
         #print "bz", a, b, c, z, convergent, finite, zerodiv
         # Gauss's theorem gives the value if convergent
         if (convergent or finite) and not zerodiv:
@@ -429,9 +429,8 @@ def _hyp2f1(ctx, a_s, b_s, z, **kwargs):
         return ctx.nan
 
     # Hit zero denominator unless numerator goes to 0 first
-    if ctx.isint(c) and c <= 0:
-        if (ctx.isint(a) and c <= a <= 0) or \
-           (ctx.isint(b) and c <= b <= 0):
+    if ctx.isnpint(c):
+        if (ctx.isnpint(a) and c <= a) or (ctx.isnpint(b) and c <= b):
             pass
         else:
             # Pole in series
@@ -442,8 +441,8 @@ def _hyp2f1(ctx, a_s, b_s, z, **kwargs):
     # Fast case: standard series converges rapidly,
     # possibly in finitely many terms
     if ctx.isfinite(z) and (absz <= 0.8 or
-                            (ctx.isint(a) and -1000 <= a <= 0) or
-                            (ctx.isint(b) and -1000 <= b <= 0)):
+                            (ctx.isnpint(a) and -1000 <= a) or
+                            (ctx.isnpint(b) and -1000 <= b)):
         try:
             return ctx.hypsum(2, 1, (atype, btype, ctype), [a, b, c], z, **kwargs)
         except ctx.NoConvergence:
@@ -496,7 +495,7 @@ def _hypq1fq(ctx, p, q, a_s, b_s, z, **kwargs):
     absz = abs(z)
     ispoly = False
     for a in a_s:
-        if ctx.isint(a) and a <= 0:
+        if ctx.isnpint(a):
             ispoly = True
             break
     # Direct summation

--- a/mpmath/functions/zeta.py
+++ b/mpmath/functions/zeta.py
@@ -875,7 +875,7 @@ def secondzeta_prime_term(ctx, s, a, **kwargs):
     return +totsum, err, n
 
 def secondzeta_exp_term(ctx, s, a):
-    if ctx.isint(s) and ctx.re(s) <= 0:
+    if ctx.isnpint(s):
         m = int(round(ctx.re(s)))
         if not m & 1:
             return ctx.mpf('-0.25')**(-m//2)
@@ -1022,7 +1022,7 @@ def secondzeta(ctx, s, a = 0.015, **kwargs):
     s = ctx.convert(s)
     a = ctx.convert(a)
     tol = ctx.eps
-    if ctx.isint(s) and ctx.re(s) <= 1:
+    if ctx.isnpint(s-1):
         if abs(s-1) < tol*1000:
             return ctx.inf
         m = int(round(ctx.re(s)))

--- a/mpmath/libmp/libmpc.py
+++ b/mpmath/libmp/libmpc.py
@@ -809,7 +809,7 @@ def mpc_fibonacci(z, prec, rnd=round_fast):
     re, im = z
     if im == fzero:
         return (mpf_fibonacci(re, prec, rnd), fzero)
-    size = max(abs(re[2]+re[3]), abs(re[2]+re[3]))
+    size = max(abs(re[2]+re[3]), abs(im[2]+im[3]))
     wp = prec + size + 20
     a = mpf_phi(wp)
     b = mpf_add(mpf_shift(a, 1), fnone, wp)

--- a/mpmath/libmp/libmpc.py
+++ b/mpmath/libmp/libmpc.py
@@ -267,7 +267,7 @@ def mpc_pow_int(z, n, prec, rnd=round_fast):
     de = aexp - bexp
     abs_de = abs(de)
     exact_size = n*(abs_de + max(abc, bbc))
-    if exact_size < 10000 and min(abc, bbc) >= 0:
+    if exact_size < 10000 and min(abc, bbc) > 0:
         if de > 0:
             aman <<= de
             aexp = bexp

--- a/mpmath/libmp/libmpf.py
+++ b/mpmath/libmp/libmpf.py
@@ -1102,12 +1102,10 @@ def to_digits_exp(s, dps, base=10):
     return sign, digits, exponent
 
 def round_digits(sign, digits, dps, base, rnd=round_nearest, fixed=False):
-    '''
+    """
     Returns the rounded digits, and the number of places the decimal point was
     shifted.
-
-    Supports three kinds of rounding: up, down, or nearest.
-    '''
+    """
 
     assert len(digits) > dps
     assert rnd in (round_nearest, round_up, round_down, round_ceiling,

--- a/mpmath/tests/test_basic_ops.py
+++ b/mpmath/tests/test_basic_ops.py
@@ -155,7 +155,7 @@ def test_mpf_init():
     assert a1 != a3
     assert str(a1) == '0.300000190734863'
     assert str(a3) == '0.3'
-    pytest.raises(ValueError, lambda: mpf((1, 2, 3)))
+    pytest.raises(ValueError, lambda: mpf((1,)))
     pytest.raises(ValueError, lambda: mpf(mpi(1, 2)))
     pytest.raises(TypeError, lambda: mpf(object()))
     pytest.raises(TypeError, lambda: mpf(1 + 1j))

--- a/mpmath/tests/test_basic_ops.py
+++ b/mpmath/tests/test_basic_ops.py
@@ -121,6 +121,9 @@ def test_pow():
     assert inf ** mpf(0) == mpf(1)
     assert ninf ** mpf(0) == mpf(1)
     assert nan ** mpf(0) == mpf(1)
+    assert mpc(1, -inf)**3 == mpc(-inf, inf)
+    assert mpc(1, -inf)**4 == mpc(inf, inf)
+
 
 def test_mixed_misc():
     assert 1 + mpf(3) == mpf(3) + 1 == 4

--- a/mpmath/tests/test_bitwise.py
+++ b/mpmath/tests/test_bitwise.py
@@ -82,22 +82,22 @@ def test_round_nearest():
 
 def test_rounding_bugs():
     # 1 less than power-of-two cases
-    assert from_man_exp(MPZ(72057594037927935), -56, 53, round_up) == (0, 1, 0, 1)
-    assert from_man_exp(MPZ(73786976294838205979), -65, 53, round_nearest) == (0, 1, 1, 1)
-    assert from_man_exp(MPZ(31), 0, 4, round_up) == (0, 1, 5, 1)
-    assert from_man_exp(MPZ(-31), 0, 4, round_floor) == (1, 1, 5, 1)
-    assert from_man_exp(MPZ(255), 0, 7, round_up) == (0, 1, 8, 1)
-    assert from_man_exp(MPZ(-255), 0, 7, round_floor) == (1, 1, 8, 1)
+    assert from_man_exp(MPZ(72057594037927935), -56, 53, round_up)[:3] == (0, 1, 0)
+    assert from_man_exp(MPZ(73786976294838205979), -65, 53, round_nearest)[:3] == (0, 1, 1)
+    assert from_man_exp(MPZ(31), 0, 4, round_up)[:3] == (0, 1, 5)
+    assert from_man_exp(MPZ(-31), 0, 4, round_floor)[:3] == (1, 1, 5)
+    assert from_man_exp(MPZ(255), 0, 7, round_up)[:3] == (0, 1, 8)
+    assert from_man_exp(MPZ(-255), 0, 7, round_floor)[:3] == (1, 1, 8)
 
 def test_rounding_issue_200():
     a = from_man_exp(MPZ(9867),-100)
     b = from_man_exp(MPZ(9867),-200)
     c = from_man_exp(MPZ(-1),0)
-    z = (1, 1023, -10, 10)
-    assert mpf_add(a, c, 10, 'd') == z
-    assert mpf_add(b, c, 10, 'd') == z
-    assert mpf_add(c, a, 10, 'd') == z
-    assert mpf_add(c, b, 10, 'd') == z
+    z = (1, 1023, -10)
+    assert mpf_add(a, c, 10, 'd')[:3] == z
+    assert mpf_add(b, c, 10, 'd')[:3] == z
+    assert mpf_add(c, a, 10, 'd')[:3] == z
+    assert mpf_add(c, b, 10, 'd')[:3] == z
 
 def test_perturb():
     a = fone

--- a/mpmath/tests/test_convert.py
+++ b/mpmath/tests/test_convert.py
@@ -137,10 +137,10 @@ def test_str_prec0():
     assert to_str(from_float(-1e+15), 0) == '-.0e+15'
 
 def test_convert_rational():
-    assert from_rational(30, 5, 53, round_nearest) == (0, 3, 1, 2)
-    assert from_rational(-7, 4, 53, round_nearest) == (1, 7, -2, 3)
-    assert to_rational((0, 1, -1, 1)) == (1, 2)
-    assert to_rational((0, 1, 0, 1)) == (1, 1)
+    assert from_rational(30, 5, 53, round_nearest)[:3] == (0, 3, 1)
+    assert from_rational(-7, 4, 53, round_nearest)[:3] == (1, 7, -2)
+    assert to_rational(mpf('0.5')._mpf_) == (1, 2)
+    assert to_rational(mpf('1')._mpf_) == (1, 1)
     pytest.raises(ValueError, lambda: to_rational(mpf('nan')._mpf_))
     pytest.raises(OverflowError, lambda: to_rational(mpf('inf')._mpf_))
     pytest.raises(OverflowError, lambda: to_rational(mpf('-inf')._mpf_))


### PR DESCRIPTION
* Amend docstring for round_digits()
* Use ctx.isnpint()
* Correct fp._convert_param() to properly handle real and complex types
* Add 'import mpmath' to default imports in CLI
* Amend 5ac8dcda
* Ignore bc field of mpf's in few tests
* Fix typo in mpc_fibonacci()
* Adapt test for a "wrong" tuple for mpf constructor