### PR TITLE
Revert "improved hypsum non-convergence behaviour"

### DIFF
--- a/mpmath/ctx_mp.py
+++ b/mpmath/ctx_mp.py
@@ -692,7 +692,7 @@ maxterms, or set zeroprec."""
             max_total_jump += abs(d)
         while 1:
             if extraprec > maxprec:
-                raise ctx.NoConvergence(ctx._hypsum_msg % (prec, prec+extraprec))
+                raise ValueError(ctx._hypsum_msg % (prec, prec+extraprec))
             wp = prec + extraprec
             if magnitude_check:
                 mag_dict = dict((n,None) for n in magnitude_check)

--- a/mpmath/functions/hypergeometric.py
+++ b/mpmath/functions/hypergeometric.py
@@ -443,11 +443,7 @@ def _hyp2f1(ctx, a_s, b_s, z, **kwargs):
     if ctx.isfinite(z) and (absz <= 0.8 or
                             (ctx.isnpint(a) and -1000 <= a) or
                             (ctx.isnpint(b) and -1000 <= b)):
-        try:
-            return ctx.hypsum(2, 1, (atype, btype, ctype), [a, b, c], z, **kwargs)
-        except ctx.NoConvergence:
-            if kwargs.get('force_series', False):
-                raise
+        return ctx.hypsum(2, 1, (atype, btype, ctype), [a, b, c], z, **kwargs)
 
     orig = ctx.prec
     try:

--- a/mpmath/functions/orthogonal.py
+++ b/mpmath/functions/orthogonal.py
@@ -452,16 +452,12 @@ def legenq(ctx, n, m, z, type=2, **kwargs):
 def chebyt(ctx, n, x, **kwargs):
     if (not x) and ctx.isint(n) and int(ctx._re(n)) % 2 == 1:
         return x * 0
-    if kwargs.get('force_series') is None:
-        kwargs['force_series'] = True
     return ctx.hyp2f1(-n,n,(1,2),(1-x)/2, **kwargs)
 
 @defun_wrapped
 def chebyu(ctx, n, x, **kwargs):
     if (not x) and ctx.isint(n) and int(ctx._re(n)) % 2 == 1:
         return x * 0
-    if kwargs.get('force_series') is None:
-        kwargs['force_series'] = True
     return (n+1) * ctx.hyp2f1(-n, n+2, (3,2), (1-x)/2, **kwargs)
 
 @defun

--- a/mpmath/tests/test_functions2.py
+++ b/mpmath/tests/test_functions2.py
@@ -1399,11 +1399,8 @@ def test_hyper_param_accuracy():
     assert hyp2f1(-5, 10, 3, 0.5, zeroprec=500) == 0
     assert (hyp1f1(-10000, 1000, 100)*10**424).ae(-3.1046080515824859974)
     assert (hyp2f1(1000,1.5,-3.5,-0.75,maxterms=100000)*10**231).ae(-4.0534790813913998643)
-    assert (hyp2f1(1000,1.5,-3.5,-0.75,maxterms=10000)*10**231).ae(-4.0534790813913998643)
-    pytest.raises(mp.NoConvergence, lambda: mp.hyp2f1(1000,1.5,-3.5,-0.75,maxterms=10000,force_series=True))
-    pytest.raises(fp.NoConvergence, lambda: fp.hyp2f1(1000,1.5,-3.5,-0.75,maxterms=10000,force_series=True))
     assert legenp(2, 3, 0.25) == 0
-    pytest.raises(mp.NoConvergence, lambda: hypercomb(lambda a: [([],[],[],[],[a],[-a],0.5)], [3]))
+    pytest.raises(ValueError, lambda: hypercomb(lambda a: [([],[],[],[],[a],[-a],0.5)], [3]))
     assert hypercomb(lambda a: [([],[],[],[],[a],[-a],0.5)], [3], infprec=200) == inf
     assert meijerg([[],[]],[[0,0,0,0],[]],0.1).ae(1.5680822343832351418)
     assert (besselk(400,400)*10**94).ae(1.4387057277018550583)


### PR DESCRIPTION
This reverts commit 91b0cecf2bc1ccb9126d57627025433d1a7b6822.

This partially reverts commit 51514a0.

Closes #1046