### PR TITLE
Speedup removal trailing zeros in _normalize/from_man_exp()

### DIFF
--- a/mpmath/libmp/__init__.py
+++ b/mpmath/libmp/__init__.py
@@ -27,7 +27,7 @@ from .libhyper import (NoConvergence, make_hyp_summator, mpc_agm, mpc_agm1,
 from .libintmath import (bin_to_radix, eulernum, gcd, giant_steps, ifac, ifib,
                          isprime, isqrt, isqrt_fast, isqrt_small, list_primes,
                          moebius, numeral, sqrt_fixed, sqrtrem, stirling1,
-                         stirling2, trailing)
+                         stirling2)
 from .libmpc import (complex_int_pow, mpc_abs, mpc_acos, mpc_acosh, mpc_add,
                      mpc_add_mpf, mpc_arg, mpc_asin, mpc_asinh, mpc_atan,
                      mpc_atanh, mpc_cbrt, mpc_ceil, mpc_conjugate, mpc_cos,

--- a/mpmath/libmp/libintmath.py
+++ b/mpmath/libmp/libintmath.py
@@ -13,10 +13,6 @@ from functools import lru_cache
 from .backend import MPZ, MPZ_ONE, MPZ_ZERO, gmpy
 
 
-small_trailing = [0] * 256
-for j in range(1,8):
-    small_trailing[1<<j::1<<(j+1)] = [j] * (1<<(7-j))
-
 def giant_steps(start, target, n=2):
     """
     Return a list of integers ~=
@@ -57,24 +53,13 @@ def lshift(x, n):
 
 def trailing(n):
     """Count the number of trailing zero bits in abs(n)."""
-    if not n:
-        return 0
-    low_byte = n & 0xff
-    if low_byte:
-        return small_trailing[low_byte]
-    t = 8
-    n >>= 8
-    while not n & 0xff:
-        n >>= 8
-        t += 8
-    return t + small_trailing[n & 0xff]
+    return MPZ((n & (-n)).bit_length() - 1 if n else 0)
 
 if gmpy and hasattr(MPZ, 'bit_scan1'):
     def trailing(n):
         return MPZ(n).bit_scan1() if n else MPZ(0)
 
 # Used to avoid slow function calls as far as possible
-trailtable = [trailing(n) for n in range(256)]
 bctable = [n.bit_length() for n in range(1024)]
 
 # TODO: speed up for bases 2, 4, 8, 16, ...

--- a/mpmath/libmp/libmpf.py
+++ b/mpmath/libmp/libmpf.py
@@ -9,7 +9,7 @@ import sys
 
 from .backend import BACKEND, MPZ, MPZ_FIVE, MPZ_ONE, MPZ_ZERO, gmpy, int_types
 from .libintmath import (bctable, bin_to_radix, isqrt, numeral, sqrtrem,
-                         stddigits, trailtable)
+                         stddigits, trailing)
 
 
 class ComplexResult(ValueError):
@@ -153,13 +153,7 @@ def _normalize(sign, man, exp, bc, prec, rnd):
         bc = prec
     # Strip trailing bits
     if not man & 1:
-        t = trailtable[man & 255]
-        if not t:
-            while not man & 255:
-                man >>= 8
-                exp += 8
-                bc -= 8
-            t = trailtable[man & 255]
+        t = trailing(man)
         man >>= t
         exp += t
         bc -= t
@@ -169,7 +163,7 @@ def _normalize(sign, man, exp, bc, prec, rnd):
     # so this is easy to check for.
     if man == 1:
         bc = 1
-    return sign, man, exp, bc
+    return sign, man, int(exp), int(bc)
 
 _exp_types = (int,)
 
@@ -207,19 +201,9 @@ def from_man_exp(man, exp, prec=0, rnd=round_fast):
         if not man:
             return fzero
         if not man & 1:
-            if man & 2:
-                return (sign, man >> 1, exp + 1, bc - 1)
-            t = trailtable[man & 255]
-            if not t:
-                while not man & 255:
-                    man >>= 8
-                    exp += 8
-                    bc -= 8
-                t = trailtable[man & 255]
-            man >>= t
-            exp += t
-            bc -= t
-        return (sign, man, exp, bc)
+            t = trailing(man)
+            return sign, man >> t, int(exp + t), int(bc - t)
+        return sign, man, exp, bc
     return normalize(sign, man, exp, bc, prec, rnd)
 
 int_cache = dict((n, from_man_exp(n, 0)) for n in range(-10, 257))

--- a/mpmath/tests/test_basic_ops.py
+++ b/mpmath/tests/test_basic_ops.py
@@ -183,6 +183,8 @@ def test_mpf_init():
     assert mpf('0x1.4ace478p+33') == mpf(11100000000.0)
     assert mpf('0x1.4ace478p+33', base=0) == mpf(11100000000.0)
     assert mpf('1.4ace478p+33', base=16) == mpf(11100000000.0)
+    assert mpf((1, 17813873926281399, -78, 54), prec=5,
+               rounding='u') == mpf('-5.9604644775390625e-8')
 
     assert mpf(float('+inf')) == +inf
     assert mpf(float('-inf')) == -inf

--- a/mpmath/tests/test_bitwise.py
+++ b/mpmath/tests/test_bitwise.py
@@ -6,7 +6,8 @@ from mpmath import eps, fadd, ldexp, mp, mpc, mpf
 from mpmath.libmp import (MPZ, fone, from_float, from_man_exp, fzero, mpf_add,
                           mpf_neg, mpf_perturb, mpf_sub, round_ceiling,
                           round_down, round_floor, round_nearest, round_up,
-                          to_float, trailing)
+                          to_float)
+from mpmath.libmp.libintmath import trailing
 
 
 def test_trailing():

--- a/mpmath/tests/test_division.py
+++ b/mpmath/tests/test_division.py
@@ -3,7 +3,8 @@ from random import choice, randint, seed
 from mpmath import mpf
 from mpmath.libmp import (from_int, from_str, mpf_div, mpf_mul, mpf_rdiv_int,
                           round_ceiling, round_down, round_floor,
-                          round_nearest, round_up, trailing)
+                          round_nearest, round_up)
+from mpmath.libmp.libintmath import trailing
 
 
 def test_div_1_3():
@@ -83,7 +84,7 @@ def test_tight_integer_division():
         a = from_int(a); b = from_int(b); p = from_int(p)
         for mode in [round_floor, round_ceiling, round_down,
                      round_up, round_nearest]:
-            assert mpf_div(p, a, width, mode) == b
+            assert mpf_div(p, a, int(width), mode) == b
 
 
 def test_epsilon_rounding():


### PR DESCRIPTION
| Benchmark      | ref     | patch                   |
|----------------|:-------:|:-----------------------:|
| 2              | 404 ns  | 398 ns: 1.01x faster    |
| 2**3           | 403 ns  | 398 ns: 1.01x faster    |
| 2**10          | 1.96 us | 1.91 us: 1.03x faster   |
| 2**100         | 6.21 us | 2.52 us: 2.47x faster   |
| 2**10000       | 1.04 ms | 5.90 us: 175.48x faster |
| Geometric mean | (ref)   | 2.78x faster            |

Benchmark hidden because not significant (1): 2**10000 + 1

```
$ cat bench.py
import pyperf
from mpmath.libmp import from_int
runner = pyperf.Runner()
for s in ['2', '2**3', '2**10', '2**100',
          '2**10000', '2**10000 + 1']:
    i = eval(s)
    runner.bench_func(s, from_int, i)
```

Closes #1073