### PR TITLE
Fix qr_solve() failure on well-conditioned matrices with zero pivot

### DIFF
--- a/mpmath/matrices/linalg.py
+++ b/mpmath/matrices/linalg.py
@@ -371,7 +371,10 @@ class LinearAlgebraMethods:
             s = ctx.fsum(abs(A[i,j])**2 for i in range(j, m))
             if not abs(s) > ctx.eps:
                 raise ValueError('matrix is numerically singular')
-            p.append(-ctx.sign(ctx.re(A[j,j])) * ctx.sqrt(s))
+            sign = ctx.sign(ctx.re(A[j,j]))
+            if sign == 0:
+                sign = ctx.one
+            p.append(-sign * ctx.sqrt(s))
             kappa = ctx.one / (s - p[j] * A[j,j])
             A[j,j] -= p[j]
             for k in range(j+1, n):

--- a/mpmath/tests/test_linalg.py
+++ b/mpmath/tests/test_linalg.py
@@ -201,6 +201,18 @@ def test_solve_overdet_complex():
     b = matrix([1 + j, 2, -j])
     assert norm(residual(A, lu_solve(A, b), b)) < 1.0208
 
+def test_qr_solve_issue_983():
+    A = matrix([[mp.one, -mp.pi / 20, (-mp.pi / 20) ** 2, (-mp.pi / 20) ** 3],
+                [mp.one, mp.zero, mp.zero, mp.zero],
+                [mp.one, mp.pi / 20, (mp.pi / 20) ** 2, (mp.pi / 20) ** 3],
+                [mp.one, mp.pi / 10, (mp.pi / 10) ** 2, (mp.pi / 10) ** 3]])
+    b = matrix([[mp.sin(-mp.pi / 20)],
+                [mp.zero],
+                [mp.sin(mp.pi / 20)],
+                [mp.sin(mp.pi / 20)]])
+    x, _ = qr_solve(A, b)
+    assert norm(residual(A, x, b), inf) < 1e-14
+
 def test_singular():
     A = [[5.6, 1.2], [7./15, .1]]
     B = repr(zeros(2))

--- a/mpmath/tests/test_linalg.py
+++ b/mpmath/tests/test_linalg.py
@@ -202,14 +202,14 @@ def test_solve_overdet_complex():
     assert norm(residual(A, lu_solve(A, b), b)) < 1.0208
 
 def test_qr_solve_issue_983():
-    A = matrix([[mp.one, -mp.pi / 20, (-mp.pi / 20) ** 2, (-mp.pi / 20) ** 3],
-                [mp.one, mp.zero, mp.zero, mp.zero],
-                [mp.one, mp.pi / 20, (mp.pi / 20) ** 2, (mp.pi / 20) ** 3],
-                [mp.one, mp.pi / 10, (mp.pi / 10) ** 2, (mp.pi / 10) ** 3]])
-    b = matrix([[mp.sin(-mp.pi / 20)],
-                [mp.zero],
-                [mp.sin(mp.pi / 20)],
-                [mp.sin(mp.pi / 20)]])
+    A = matrix([[1, -pi/20, (-pi/20)**2, (-pi/20)**3],
+                [1, 0, 0, 0],
+                [1, pi / 20, (pi/20)**2, (pi/20)**3],
+                [1, pi/10, (pi/10)**2, (pi/10)**3]])
+    b = matrix([[mp.sin(-pi/20)],
+                [0],
+                [mp.sin(pi/20)],
+                [mp.sin(pi/20)]])
     x, _ = qr_solve(A, b)
     assert norm(residual(A, x, b), inf) < 1e-14
 


### PR DESCRIPTION
Fixes mpmath/mpmath#983.

## Reproduction

Independent reproduction / analysis: https://aletheia-works.github.io/vivarium/repro/mpmath/983/

```python
from mpmath import mp, pi

A = mp.matrix([[1, -pi/20, (-pi/20)**2, (-pi/20)**3],
               [1, 0, 0, 0],
               [1, pi/20, (pi/20)**2, (pi/20)**3],
               [1, pi/10, (pi/10)**2, (pi/10)**3]])
b = mp.matrix([[mp.sin(-pi/20)], [0],
               [mp.sin(pi/20)], [mp.sin(pi/20)]])

mp.qr_solve(A, b)   # before: ValueError: matrix is numerically singular
                    # after:  solves correctly (matches lu_solve)
```

The matrix is well-conditioned (cond ≈ 695, det ≈ 1.8e-4) and `lu_solve()` handles it without issue.

## Root cause

The issue reporter suspected the singularity guard `if not abs(s) > ctx.eps` in `householder()`. That guard is only the *symptom* — the actual bug is one line below it, in the sign convention used to pick the Householder reflection:

```python
p.append(-ctx.sign(ctx.re(A[j,j])) * ctx.sqrt(s))
```

When `A[j,j]` is exactly zero, `ctx.sign(0) == 0`, so `p[j]` collapses to zero. Then:

```python
kappa = ctx.one / (s - p[j] * A[j,j])   # = 1/s instead of 2/||v||²
```

The Householder reflection is computed with the wrong scaling, the trailing submatrix is corrupted, and a few iterations later the now-noisy column trips the "numerically singular" check.

The issue's matrix triggers this because row 1 is `[1, 0, 0, 0]`: after the j=0 step the second pivot `A[1,1]` lands on exact zero.

## Fix

Default `sign` to `+1` when `Re(A[j,j])` is zero. This matches the convention used by LAPACK's `dlarfg` and other standard QR implementations.

Verified: with the fix, `householder()` produces `p = [-2, -0.351, 0.0493, -0.0052]`, matching `numpy.linalg.qr` exactly.

## Tests

- Added `test_qr_solve_issue_983` using the exact matrix from the issue, asserting `||A x − b||_∞ < 1e-14`.
- All 19 existing tests in `mpmath/tests/test_linalg.py` (including `test_householder`, `test_solve`, `test_singular`) continue to pass.