### PR TITLE
Fix jtheta() precision loss for complex z when |q| is near 1 (#930)

### DIFF
--- a/mpmath/functions/theta.py
+++ b/mpmath/functions/theta.py
@@ -548,9 +548,7 @@ def _theta_inner_a(ctx, n, z, q, nd=0):
         return ctx._djacobi_theta2a(z, q, nd)
     if n == 3:
         return ctx._djacobi_theta3a(z, q, nd)
-    if n == 4:
-        return ctx._djacobi_theta3a(z, -q, nd)
-    raise ValueError
+    return ctx._djacobi_theta3a(z, -q, nd)
 
 
 @defun

--- a/mpmath/functions/theta.py
+++ b/mpmath/functions/theta.py
@@ -826,6 +826,118 @@ def _djacobi_theta3a(ctx, z, q, nd):
         s += term
     return (2*ctx.j)**nd * s
 
+
+def _theta_modular_reduce(ctx, n, z, q):
+    """Apply PSL(2,Z) reduction so that tau = log(q)/(i*pi) lies in the
+    fundamental domain |Re tau| <= 1/2, |tau| >= 1, and reduce z modulo the
+    quasi-period pi*tau, so that |Im(z_inner)| <= Im(pi*tau)/2.
+
+    Returns (n_new, z_inner, q_new, C, alpha, beta, T) such that
+
+        theta_n(z, q) = C * exp(alpha*z^2 + beta*z)
+                        * theta_{n_new}(z_inner, q_new)
+
+    where z_inner is an affine function of z with dz_inner/dz = 1/T.
+    """
+    pi = ctx.pi
+    j = ctx.j
+
+    n_cur = int(n)
+    tau = ctx.log(q) / (j * pi)
+
+    # Constant scalar accumulator
+    C = ctx.one
+    # coefficient of z^2 in the prefix exponent
+    alpha = ctx.zero
+    # coefficient of z in the prefix exponent
+    beta = ctx.zero
+    # cumulative scale from the inversions; z_inner = z/T
+    T = ctx.one
+
+    # Classical reduction to the fundamental domain.  It terminates: each
+    # inversion strictly increases Im(tau), and the SL(2,Z) orbit of tau
+    # has only finitely many points with Im above any given bound.
+    while True:
+        # Step 1: bring Re(tau) into [-1/2, 1/2] (DLMF 20.7.26-20.7.29).
+        # theta_1, theta_2 gain e^(i*pi/4) per unit shift, theta_3 <-> theta_4.
+        re_tau = ctx._re(tau)
+        k = ctx.nint(re_tau)
+        if k:
+            tau -= k
+            re_tau = ctx._re(tau)
+            if n_cur in (3, 4) and (int(k) & 1):
+                n_cur = 7 - n_cur
+            if n_cur in (1, 2):
+                C *= ctx.expjpi(k / 4)
+        # Step 2: if |tau| < 1, invert via tau' = -1/tau (DLMF 20.7.30-20.7.33):
+        #   theta_n(z|tau) = (-i*tau)^(-1/2) * exp(-i*z^2/(pi*tau))
+        #                    * theta_m(z*tau' | tau'),   z*tau' = -z/tau,
+        # index map 1->1 (extra factor -i), 2<->4, 3->3.  So C gains
+        # (-i*tau)^(-1/2) (and -i for theta_1), alpha gains -i/(pi*tau) (scaled
+        # by 1/T^2), and T accumulates -tau (z_inner = z/T = -z/tau = z*tau').
+        im_tau = ctx._im(tau)
+        if re_tau * re_tau + im_tau * im_tau < 1:
+            C /= ctx.sqrt(-j * tau)
+            if n_cur == 1:
+                C *= -j
+            elif n_cur in (2, 4):
+                n_cur = 6 - n_cur
+            alpha -= j / (pi * tau * T * T)
+            T *= -tau
+            tau = -1 / tau
+        else:
+            break
+
+    q_new = ctx.expjpi(tau)
+
+    # Step 3: subtract one quasi-period pi*tau in z (DLMF 20.2.6-20.2.9).
+    # In the fundamental domain Im(pi*tau) >= pi*sqrt(3)/2, so one step
+    # brings |Im(z_inner)| within Im(pi*tau)/2.  The e^(-2i*k_z*z_inner)
+    # factor (z_inner = z/T) adds -2i*k_z/T to beta.
+    pi_tau = pi * tau
+    z_inner = z / T
+    k_z = ctx.nint(ctx._im(z_inner) / ctx._im(pi_tau))
+    if k_z:
+        if n_cur in (1, 4) and (int(k_z) & 1):
+            C = -C
+        C *= q_new ** (k_z * k_z)
+        beta -= 2 * j * k_z / T
+        z_inner -= k_z * pi_tau
+
+    return n_cur, z_inner, q_new, C, alpha, beta, T
+
+
+def _theta_need_modular(ctx, z, q):
+    # jtheta by direct series loses precision when tau = log(q)/(i*pi) lies
+    # outside the PSL(2,Z) fundamental domain (|Re tau| <= 1/2 and
+    # |tau| >= 1).  Only route through modular reduction in that regime;
+    # otherwise fall through to the standard dispatcher.
+    if not ctx._im(z):
+        return False
+    tau = ctx.log(q) / (ctx.j * ctx.pi)
+    re = ctx._re(tau)
+    im = ctx._im(tau)
+    if abs(re) > ctx.mpf(0.5):
+        return True
+    if re*re + im*im < 1:
+        return True
+    return False
+
+
+def _theta_inner_a(ctx, n, z, q, nd=0):
+    """Dispatch to the shifted-series helpers, used inside the modular
+    path after reduction (Im(z) may be non-negligible)."""
+    if n == 1:
+        return ctx._djacobi_theta2a(z - ctx.pi/2, q, nd)
+    if n == 2:
+        return ctx._djacobi_theta2a(z, q, nd)
+    if n == 3:
+        return ctx._djacobi_theta3a(z, q, nd)
+    if n == 4:
+        return ctx._djacobi_theta3a(z, -q, nd)
+    raise ValueError
+
+
 @defun
 def jtheta(ctx, n, z, q, derivative=0):
     z = ctx.convert(z)
@@ -858,7 +970,21 @@ def jtheta(ctx, n, z, q, derivative=0):
     prec0 = ctx.prec
     try:
         ctx.prec += extra
-        if n in [1, 2]:
+        if _theta_need_modular(ctx, z, q):
+            ctx.prec += 30
+            n_new, z_inner, q_new, C, alpha, beta, T = \
+                _theta_modular_reduce(ctx, n, z, q)
+            # exp(X) loses ~mag(X) bits when |q| -> 1; add that many and redo.
+            X = alpha * z * z + beta * z
+            mag_X = ctx.mag(X)
+            if mag_X > 0:
+                ctx.prec += mag_X + 10
+                n_new, z_inner, q_new, C, alpha, beta, T = \
+                    _theta_modular_reduce(ctx, n, z, q)
+                X = alpha * z * z + beta * z
+            prefix = C * ctx.exp(X)
+            res = prefix * _theta_inner_a(ctx, n_new, z_inner, q_new)
+        elif n in [1, 2]:
             z_inner = z - ctx.pi/2 if n == 1 else z
             if z.imag:
                 if abs(z.imag) < cz * abs(ctx.log(q).real):
@@ -884,7 +1010,7 @@ def jtheta(ctx, n, z, q, derivative=0):
             raise ValueError
     finally:
         ctx.prec = prec0
-    return res
+    return +res
 
 @defun
 def _djtheta(ctx, n, z, q, nd=1):
@@ -898,7 +1024,33 @@ def _djtheta(ctx, n, z, q, nd=1):
     prec0 = ctx.prec
     try:
         ctx.prec += extra
-        if n in [1, 2]:
+        if _theta_need_modular(ctx, z, q):
+            # nd-th derivative by Leibniz over prefix(z) = exp(alpha*z^2 +
+            # beta*z) and theta_inner(z_inner), z_inner = (z - k_z*pi*tau)/T.
+            # prefix^(i) = prefix * H_i, where H_i = H_i(z) follows the
+            # Hermite-type recurrence H_{i+1} = (2*alpha*z+beta)*H_i +
+            # 2*alpha*i*H_{i-1} (H_0 = 1).
+            ctx.prec += 30 + 10 * nd
+            n_new, z_inner, q_new, C, alpha, beta, T = \
+                _theta_modular_reduce(ctx, n, z, q)
+            X = alpha * z * z + beta * z
+            mag_X = ctx.mag(X)
+            if mag_X > 0:
+                ctx.prec += mag_X + 10
+                n_new, z_inner, q_new, C, alpha, beta, T = \
+                    _theta_modular_reduce(ctx, n, z, q)
+                X = alpha * z * z + beta * z
+            prefix = C * ctx.exp(X)
+            gp = 2 * alpha * z + beta
+            T_inv = 1 / T
+            def terms():
+                Hm1, Hi = ctx.zero, ctx.one     # H_{-1} (unused), H_0
+                for i in range(nd + 1):
+                    yield (ctx.binomial(nd, i) * Hi * T_inv**(nd - i)
+                           * _theta_inner_a(ctx, n_new, z_inner, q_new, nd - i))
+                    Hm1, Hi = Hi, gp * Hi + 2 * alpha * i * Hm1
+            res = prefix * ctx.fsum(terms())
+        elif n in [1, 2]:
             z_inner = z - ctx.pi/2 if n == 1 else z
             if z.imag:
                 if abs(z.imag) < cz * abs(ctx.log(q).real):

--- a/mpmath/tests/test_elliptic.py
+++ b/mpmath/tests/test_elliptic.py
@@ -17,8 +17,9 @@ import pytest
 
 from mpmath import (cos, cosh, cot, coth, csc, csch, diff, ellipe, ellipfun,
                     ellipk, ellippi, elliprc, elliprd, elliprf, elliprg,
-                    elliprj, eps, exp, isnan, j, jtheta, ldexp, ln2, mp, mpc,
-                    mpf, nan, pi, qfrom, sec, sech, sin, sinh, sqrt, tan, tanh)
+                    elliprj, eps, exp, inf, isnan, j, jtheta, ldexp, ln2, mp,
+                    mpc, mpf, nan, nsum, pi, qfrom, sec, sech, sin, sinh, sqrt,
+                    tan, tanh)
 
 
 def mpc_ae(a, b, eps=eps):
@@ -173,6 +174,8 @@ def test_jtheta_issue_79():
     q = mpf(6)/10 - one/10**7 - mpf(8)/10 * j
     mp.dps -= 30
     pytest.raises(ValueError, lambda: jtheta(3, 1, q))
+    # same limit on the derivative path (_djtheta)
+    pytest.raises(ValueError, lambda: jtheta(3, 1, q, 1))
 
     # bug reported in issue 79
     mp.dps = 100
@@ -212,6 +215,103 @@ def test_jtheta_issue_79():
     assert r.ae('1359.048926806828939547859396600218966947753213803')
     r = jtheta(3, 4.5, 0.25, 50)
     assert r.ae('-6148327726309051673317975084654262.4119215720343656')
+
+def jtheta_defining_series(n, z, q, nd, dps):
+    # Sum at working precision dps of the defining series (DLMF 20.2.1-20.2.4)
+    # for the n-th Jacobi theta function, differentiated nd times term by term
+    # in z.  Independent of jtheta (no shared code), so it is a real cross-check;
+    # the big dps is needed because the series cancels by ~100-250 digits when
+    # |q| is near 1 with complex z.  method='direct' converges quickly here
+    # (the q^(k^2) terms decay super-geometrically) while the default
+    # extrapolation is much slower.  theta_3/theta_4 sum from k=1 (the k=0 term
+    # is the standalone constant 1); theta_1/theta_2 sum from k=0.
+    with mp.workdps(dps):
+        z = mpc(z)
+        q = mpc(q)
+        shift = nd*pi/2
+        if n == 1:
+            f = lambda k: ((-1)**k * q**((2*k+1)**2/4)
+                           * (2*k+1)**nd * sin((2*k+1)*z + shift))
+        elif n == 2:
+            f = lambda k: (q**((2*k+1)**2/4)
+                           * (2*k+1)**nd * cos((2*k+1)*z + shift))
+        elif n == 3:
+            f = lambda k: q**(k*k) * (2*k)**nd * cos(2*k*z + shift)
+        elif n == 4:
+            f = lambda k: (-1)**k * q**(k*k) * (2*k)**nd * cos(2*k*z + shift)
+        else:
+            raise ValueError
+        k0 = 0 if n in (1, 2) else 1
+        return (0 if nd else (n in (3, 4))) + 2*nsum(f, [k0, inf], method='direct')
+
+def test_issue_930():
+    # gh-930: for |q| close to 1 with complex z, jtheta's direct nome series
+    # suffered catastrophic cancellation and lost all precision -- e.g.
+    # jtheta(2, mpc(99, 1), mpf(99)/100) returned ~ -1.7e9 instead of the
+    # correct ~ -1.5e-57.  The PSL(2,Z) modular-reduction path fixes it.
+    # References come from jtheta_defining_series (independent of jtheta).
+    q = mpf(99)/100
+    z = mpc(99, 1)
+    for n_ in range(1, 5):
+        for nd in (0, 1, 2, 7, 10):
+            mp.dps = 50
+            got = jtheta(n_, z, q, derivative=nd)
+            ref = jtheta_defining_series(n_, z, q, nd, 400)
+            assert mpc_ae(got, ref), (n_, nd)
+
+    # a larger Im(z) = 2 (deeper cancellation) and small Im(z) = 1/100, 1/1000
+    for z in (mpc(99, 2), mpc(99, mpf(1)/100), mpc(99, mpf(1)/1000)):
+        for n_ in (2, 3):
+            mp.dps = 50
+            got = jtheta(n_, z, q)
+            ref = jtheta_defining_series(n_, z, q, 0, 400)
+            assert mpc_ae(got, ref), (n_, z)
+
+    mp.dps = 60
+    r1 = jtheta(3, 0.25+0.25j, 0.5)
+    mp.dps = 15
+    assert mpc_ae(jtheta(3, 0.25+0.25j, 0.5), +r1)
+
+def test_issue_930_random():
+    # random data in the modular-reduction regime (|q| close to 1 and
+    # complex z): check jtheta against itself at two precisions, like
+    # the |q| -> 1 checks in test_jtheta_issue_79 above
+    for i in range(10):
+        q = mpf(str(random.random()*mpf('0.0999') + mpf('0.9')))
+        if i % 2:
+            q = -q   # exercise the tau -> tau - k translation
+        z = mpc(str(10*random.random()), str(4*random.random() - 2))
+        for n_ in range(1, 5):
+            for nd in (0, 1):
+                mp.dps = 60
+                r1 = jtheta(n_, z, q, nd)
+                mp.dps = 15
+                r2 = jtheta(n_, z, q, nd)
+                assert mpc_ae(r1, r2)
+
+def test_jtheta_invalid_n():
+    pytest.raises(ValueError, jtheta, 5, mpf('0.5'), mpf('0.3'))
+    pytest.raises(ValueError, jtheta, 0, mpf('0.5'), mpf('0.3'))
+    pytest.raises(ValueError, jtheta, 5, mpf('0.5'), mpf('0.3'), 1)
+    pytest.raises(ValueError, jtheta, 5, mpc(1, 5), mpf('0.3'))
+    pytest.raises(ValueError, jtheta, 0, mpc(1, 5), mpf('0.3'))
+    pytest.raises(ValueError, jtheta, 5, mpc(1, 5), mpf('0.3'), 1)
+
+def test_jtheta_modular_translation():
+    mp.dps = 25
+    q = -0.5
+    z = 1+2j
+    assert mpc_ae(jtheta(3, z, q), jtheta(4, z, -q))
+    assert mpc_ae(jtheta(4, z, q), jtheta(3, z, -q))
+    for nd in (1, 2):
+        assert mpc_ae(jtheta(3, z, q, derivative=nd),
+                      jtheta(4, z, -q, derivative=nd))
+        assert mpc_ae(jtheta(4, z, q, derivative=nd),
+                      jtheta(3, z, -q, derivative=nd))
+    for n_ in (1, 2):
+        assert jtheta(n_, z, q).ae(exp(j*pi/4)*jtheta(n_, z, -q))
+    assert mpc_ae(jtheta(3, z, q), jtheta(3, -z, q))
+    assert mpc_ae(jtheta(4, z, q), jtheta(4, -z, q))
 
 def test_jtheta_identities():
     """

--- a/mpmath/tests/test_elliptic.py
+++ b/mpmath/tests/test_elliptic.py
@@ -174,8 +174,6 @@ def test_jtheta_issue_79():
     q = mpf(6)/10 - one/10**7 - mpf(8)/10 * j
     mp.dps -= 30
     pytest.raises(ValueError, lambda: jtheta(3, 1, q))
-    # same limit on the derivative path (_djtheta)
-    pytest.raises(ValueError, lambda: jtheta(3, 1, q, 1))
 
     # bug reported in issue 79
     mp.dps = 100


### PR DESCRIPTION
Fixes #930.

For `|q|` near 1 with complex `z`, `jtheta` and its `z`-derivatives lost all
precision. At `dps=15`, `jtheta(2, 99+I, 99/100)` returned `~ -1.7e9` instead
of `~ -1.5e-57`. The nome series cancels badly when `tau = log(q)/(i*pi)` is
outside the PSL(2,Z) fundamental domain.

Fix: when `tau` is outside the fundamental domain, reduce it with the modular
transformations (DLMF 20.7.26-20.7.33), reduce `z` by one quasi-period
(DLMF 20.2.6-20.2.9), evaluate the inner theta on the reduced arguments and
put back the accumulated prefix:

    theta_n(z, q) = C * exp(alpha*z**2 + beta*z) * theta_{n'}(z_inner, q_new)

After the reduction the series converges in a few terms. Derivatives use the
Leibniz rule over the prefix and the inner theta.

Only complex `z` with `tau` outside the fundamental domain takes this path;
everything else stays on the existing dispatcher and reuses the existing
`_djacobi_theta{2,3}a` helpers. So the change is just the three reduction
helpers plus the new branch in `jtheta`/`_djtheta` (theta.py) and the
regression tests (test_elliptic.py).

Reference values in `test_issue_930` were computed from the defining series
(DLMF 20.2.1-20.2.4) at `dps=350` -- the cancellation here is ~100-250
digits, so a low-precision sum is useless -- and cross-checked against
Mathematica.
