### PR TITLE
Raise ValueError when same sign at interval boundaries in bisection rootfinding algorithm

### DIFF
--- a/mpmath/calculus/optimization.py
+++ b/mpmath/calculus/optimization.py
@@ -283,7 +283,6 @@ class Muller:
             error = abs(x2 - x1)
             yield x2, error
 
-# TODO: consider raising a ValueError when there's no sign change in a and b
 class Bisection:
     """
     1d-solver generating pairs of approximative root and error.
@@ -311,13 +310,19 @@ class Bisection:
         self.b = x0[1]
 
     def __iter__(self):
+        ctx = self.ctx
         f = self.f
         a = self.a
         b = self.b
         l = b - a
+        fa = f(a)
         fb = f(b)
+
+        if ctx.sign(fa) == ctx.sign(fb):
+            raise ValueError("Function must have opposite signs at interval boundaries.")
+        
         while True:
-            m = self.ctx.ldexp(a + b, -1)
+            m = ctx.ldexp(a + b, -1)
             fm = f(m)
             sign = fm * fb
             if sign < 0:
@@ -326,7 +331,7 @@ class Bisection:
                 b = m
                 fb = fm
             else:
-                yield m, self.ctx.zero
+                yield m, ctx.zero
             l /= 2
             yield (a + b)/2, abs(l)
 

--- a/mpmath/calculus/optimization.py
+++ b/mpmath/calculus/optimization.py
@@ -318,7 +318,7 @@ class Bisection:
         fa = f(a)
         fb = f(b)
 
-        if ctx.sign(fa) == ctx.sign(fb):
+        if fa*fb > 0:
             raise ValueError("Function must have opposite signs at interval boundaries.")
 
         while True:

--- a/mpmath/calculus/optimization.py
+++ b/mpmath/calculus/optimization.py
@@ -320,7 +320,7 @@ class Bisection:
 
         if ctx.sign(fa) == ctx.sign(fb):
             raise ValueError("Function must have opposite signs at interval boundaries.")
-        
+
         while True:
             m = ctx.ldexp(a + b, -1)
             fm = f(m)

--- a/mpmath/function_docs.py
+++ b/mpmath/function_docs.py
@@ -7092,9 +7092,10 @@ Since the Z-function is real-valued on the critical line
 investigating the zeros of the Riemann zeta function.
 For example, one can use a root-finding algorithm based
 on sign changes::
-
-    >>> findroot(siegelz, [100, 200], solver='bisect')
-    176.4414342977104188888926
+    >>> g10 = grampoint(10)
+    >>> g11 = grampoint(11)
+    >>> findroot(siegelz, [g10, g11], solver='bisect')
+    56.44624769706339480436776
 
 To locate roots, Gram points `g_n` which can be computed
 by :func:`~mpmath.grampoint` are useful. If `(-1)^n Z(g_n)` is

--- a/mpmath/function_docs.py
+++ b/mpmath/function_docs.py
@@ -7092,6 +7092,7 @@ Since the Z-function is real-valued on the critical line
 investigating the zeros of the Riemann zeta function.
 For example, one can use a root-finding algorithm based
 on sign changes::
+
     >>> findroot(siegelz, [176, 177], solver='bisect')
     176.4414342977104188888926
 

--- a/mpmath/function_docs.py
+++ b/mpmath/function_docs.py
@@ -7092,10 +7092,8 @@ Since the Z-function is real-valued on the critical line
 investigating the zeros of the Riemann zeta function.
 For example, one can use a root-finding algorithm based
 on sign changes::
-    >>> g10 = grampoint(10)
-    >>> g11 = grampoint(11)
-    >>> findroot(siegelz, [g10, g11], solver='bisect')
-    56.44624769706339480436776
+    >>> findroot(siegelz, [176, 177], solver='bisect')
+    176.4414342977104188888926
 
 To locate roots, Gram points `g_n` which can be computed
 by :func:`~mpmath.grampoint` are useful. If `(-1)^n Z(g_n)` is

--- a/mpmath/tests/test_rootfinding.py
+++ b/mpmath/tests/test_rootfinding.py
@@ -52,7 +52,7 @@ def test_bisection():
 
 def test_bisection2():
     with pytest.raises(ValueError):
-        findroot(lambda x: x**2-1,(4,2),solver='bisect') == 1
+        findroot(lambda x: x**2-1, (4, 2), solver='bisect') == 1
 
 def test_mnewton():
     f = lambda x: polyval([1, 3, 3, 1], x)

--- a/mpmath/tests/test_rootfinding.py
+++ b/mpmath/tests/test_rootfinding.py
@@ -50,7 +50,6 @@ def test_bisection():
     # issue 273
     assert findroot(lambda x: x**2-1,(0,2),solver='bisect') == 1
 
-def test_bisection2():
     with pytest.raises(ValueError):
         findroot(lambda x: x**2-1, (4, 2), solver='bisect') == 1
 

--- a/mpmath/tests/test_rootfinding.py
+++ b/mpmath/tests/test_rootfinding.py
@@ -50,6 +50,10 @@ def test_bisection():
     # issue 273
     assert findroot(lambda x: x**2-1,(0,2),solver='bisect') == 1
 
+def test_bisection2():
+    with pytest.raises(ValueError):
+        findroot(lambda x: x**2-1,(4,2),solver='bisect') == 1
+
 def test_mnewton():
     f = lambda x: polyval([1, 3, 3, 1], x)
     x = findroot(f, -0.9, solver='mnewton')


### PR DESCRIPTION
While working on #1075, I came across this TODO in the codebase. 
- Implemented the requirement
- Added unit test for the same