### PR TITLE
Add ModAB rootfinding algorithm

### DIFF
--- a/docs/calculus/optimization.rst
+++ b/docs/calculus/optimization.rst
@@ -21,3 +21,4 @@ Solvers
 .. autoclass:: mpmath.calculus.optimization.Ridder
 .. autoclass:: mpmath.calculus.optimization.ANewton
 .. autoclass:: mpmath.calculus.optimization.MDNewton
+.. autoclass:: mpmath.calculus.optimization.ModAB

--- a/mpmath/calculus/optimization.py
+++ b/mpmath/calculus/optimization.py
@@ -573,8 +573,8 @@ class ModAB:
     """
     1d-solver generating pairs of approximative root and error.
 
-    Uses the Modified Anderson-Björck (modAB) hybrid method to find 
-    a root of f in [a, b]. It dynamically switches between Bisection 
+    Uses the Modified Anderson-Björck (modAB) hybrid method to find
+    a root of f in [a, b]. It dynamically switches between Bisection
     and False Position (Secant) while correcting for stagnant endpoints.
 
     Pro:
@@ -632,7 +632,7 @@ class ModAB:
             # Evaluate function or handle out-of-bounds secant calculations
             if bisection:
                 fx3 = f(x3)
-                ym = ctx.ldexp(fa + fb, -1) 
+                ym = ctx.ldexp(fa + fb, -1)
 
                 # Check linearity to see if we can switch to secant
                 r = ctx.one - ctx.fabs(ym / (fb - fa)) # Symmetry factor
@@ -659,14 +659,14 @@ class ModAB:
 
             # Update the interval and apply Anderson-Björck adjustments
             if fa*fx3 > 0:
-                if side == 1: 
+                if side == 1:
                     m = ctx.one - (fx3 / fa)
                     fb *= ctx.ldexp(ctx.one, -1) if m <= 0 else m
                 elif not bisection:
                     side = 1
                 a, fa = x3, fx3
             else:
-                if side == -1: 
+                if side == -1:
                     m = ctx.one - (fx3 / fb)
                     fa *= ctx.ldexp(ctx.one, -1) if m <= 0 else m
                 elif not bisection:

--- a/mpmath/calculus/optimization.py
+++ b/mpmath/calculus/optimization.py
@@ -596,7 +596,7 @@ class ModAB:
         self.f = f
 
         # Enforce ordering: self.a as lower bound, self.b as upper bound
-        self.a, self.b = x0[0], x0[1]
+        self.a, self.b = x0
         if self.a > self.b:
             self.a, self.b = self.b, self.a
 

--- a/mpmath/calculus/optimization.py
+++ b/mpmath/calculus/optimization.py
@@ -989,9 +989,6 @@ def findroot(ctx, f, x0, solver='secant', tol=None, verbose=False, verify=True, 
     Usually they converge faster and more reliable. They have however problems
     with multiple roots and usually need a sign change to find a root::
 
-        >>> findroot(lambda x:x**2 - 1, (0, 3), solver='modAB')
-        1.0
-
         >>> findroot(lambda x: x**3, (-1, 1), solver='anderson')
         0.0
 

--- a/mpmath/calculus/optimization.py
+++ b/mpmath/calculus/optimization.py
@@ -584,7 +584,7 @@ class ModAB:
     Contra:
     * Needs an initial sign change bracket
 
-    https://www.mdpi.com/1999-4893/19/5/332
+    https://doi.org/10.3390/a19050332
     """
     maxsteps = 200
 

--- a/mpmath/calculus/optimization.py
+++ b/mpmath/calculus/optimization.py
@@ -569,6 +569,115 @@ class ANewton:
 
 # TODO: add Brent
 
+class ModAB:
+    """
+    1d-solver generating pairs of approximative root and error.
+
+    Uses the Modified Anderson-Björck (modAB) hybrid method to find 
+    a root of f in [a, b]. It dynamically switches between Bisection 
+    and False Position (Secant) while correcting for stagnant endpoints.
+
+    Pro:
+    * Robust and guaranteed to converge (like Bisection)
+    * Fast convergence on smooth functions (like Secant)
+
+    Contra:
+    * Needs an initial sign change bracket
+
+    https://www.mdpi.com/1999-4893/19/5/332
+    """
+    maxsteps = 200
+
+    def __init__(self, ctx, f, x0, **kwargs):
+        self.ctx = ctx
+        if len(x0) != 2:
+            raise ValueError('expected interval of 2 points, got %i' % len(x0))
+
+        self.f = f
+
+        # Enforce ordering: self.a as lower bound, self.b as upper bound
+        x1, x2 = x0[0], x0[1]
+        if x1 > x2:
+            self.a, self.b = x2, x1
+        else:
+            self.a, self.b = x1, x2
+
+    def __iter__(self):
+        ctx = self.ctx
+        f = self.f
+
+        a = self.a
+        b = self.b
+        fa = f(a)
+        fb = f(b)
+
+        # Check for initial bracketing
+        if fa*fb > 0:
+            raise ValueError("Function must have opposite signs at interval boundaries.")
+
+        bisection = True
+        side = 0 # -1 for left moved last, 1 for right, 0 for none
+        threshold = b - a
+        C = ctx.mpf(16) # Safety factor threshold scaling constant
+
+        while True:
+            if bisection:
+                x3 = ctx.ldexp(a + b, -1)
+            else:
+                x3 = (a * fb - b * fa) / (fb - fa)
+
+            # Yield the current best guess and the remaining interval length (error)
+            yield x3, abs(b - a)
+
+            # Evaluate function or handle out-of-bounds secant calculations
+            if bisection:
+                fx3 = f(x3)
+                ym = ctx.ldexp(fa + fb, -1) 
+
+                # Check linearity to see if we can switch to secant
+                r = ctx.one - ctx.fabs(ym / (fb - fa)) # Symmetry factor
+                k = r * r                              # Deviation factor
+
+                if ctx.fabs(ym - fx3) < k * (ctx.fabs(fx3) + ctx.fabs(ym)):
+                    bisection = False
+                    threshold = (b - a) * C
+            else:
+                # Clamp secant point safely within the bounds to handle floating-point rounding
+                if x3 <= a:
+                    x3, fx3 = a, fa
+                elif x3 >= b:
+                    x3, fx3 = b, fb
+                else:
+                    fx3 = f(x3)
+
+                threshold *= 0.5
+
+            # Check for exact root convergence
+            if fx3 == ctx.zero:
+                yield x3, ctx.zero
+                return
+
+            # Update the interval and apply Anderson-Björck adjustments
+            if fa*fx3 > 0:
+                if side == 1: 
+                    m = ctx.one - (fx3 / fa)
+                    fb *= ctx.ldexp(ctx.one, -1) if m <= 0 else m
+                elif not bisection:
+                    side = 1
+                a, fa = x3, fx3
+            else:
+                if side == -1: 
+                    m = ctx.one - (fx3 / fb)
+                    fa *= ctx.ldexp(ctx.one, -1) if m <= 0 else m
+                elif not bisection:
+                    side = -1
+                b, fb = x3, fx3
+
+            # Fallback check: If progress is too slow, force a bisection step next time
+            if (b - a) > threshold:
+                bisection = True
+                side = 0
+
 ############################
 # MULTIDIMENSIONAL SOLVERS #
 ############################
@@ -686,7 +795,7 @@ class MDNewton:
 str2solver = {'newton':Newton, 'secant':Secant, 'mnewton':MNewton,
               'halley':Halley, 'muller':Muller, 'bisect':Bisection,
               'illinois':Illinois, 'pegasus':Pegasus, 'anderson':Anderson,
-              'ridder':Ridder, 'anewton':ANewton, 'mdnewton':MDNewton}
+              'ridder':Ridder, 'anewton':ANewton, 'mdnewton':MDNewton, 'modAB':ModAB}
 
 def findroot(ctx, f, x0, solver='secant', tol=None, verbose=False, verify=True, **kwargs):
     r"""
@@ -739,7 +848,7 @@ def findroot(ctx, f, x0, solver='secant', tol=None, verbose=False, verify=True, 
     expected to be positive).
     You can use the following string aliases:
     'secant', 'mnewton', 'halley', 'muller', 'illinois', 'pegasus', 'anderson',
-    'ridder', 'anewton', 'bisect'
+    'ridder', 'anewton', 'bisect', 'modAB'
 
     See mpmath.calculus.optimization for their documentation.
 

--- a/mpmath/calculus/optimization.py
+++ b/mpmath/calculus/optimization.py
@@ -655,7 +655,6 @@ class ModAB:
             # Check for exact root convergence
             if fx3 == ctx.zero:
                 yield x3, ctx.zero
-                return
 
             # Update the interval and apply Anderson-Björck adjustments
             if fa*fx3 > 0:

--- a/mpmath/calculus/optimization.py
+++ b/mpmath/calculus/optimization.py
@@ -985,9 +985,12 @@ def findroot(ctx, f, x0, solver='secant', tol=None, verbose=False, verify=True, 
     **Intersection methods**
 
     When you need to find a root in a known interval, it's highly recommended to
-    use an intersection-based solver like ``'anderson'`` or ``'ridder'``.
+    use an intersection-based solver like ```'modAB'``` or ``'anderson'`` or ``'ridder'``.
     Usually they converge faster and more reliable. They have however problems
     with multiple roots and usually need a sign change to find a root::
+
+        >>> findroot(lambda x:x**2 - 1, (0, 3), solver='modAB')
+        1.0
 
         >>> findroot(lambda x: x**3, (-1, 1), solver='anderson')
         0.0

--- a/mpmath/calculus/optimization.py
+++ b/mpmath/calculus/optimization.py
@@ -596,11 +596,9 @@ class ModAB:
         self.f = f
 
         # Enforce ordering: self.a as lower bound, self.b as upper bound
-        x1, x2 = x0[0], x0[1]
-        if x1 > x2:
-            self.a, self.b = x2, x1
-        else:
-            self.a, self.b = x1, x2
+        self.a, self.b = x0[0], x0[1]
+        if self.a > self.b:
+            self.a, self.b = self.b, self.a
 
     def __iter__(self):
         ctx = self.ctx

--- a/mpmath/tests/test_rootfinding.py
+++ b/mpmath/tests/test_rootfinding.py
@@ -5,7 +5,7 @@ from mpmath import (cos, eps, findroot, fp, inf, iv, jacobian, matrix, mnorm,
                     workprec)
 from mpmath.calculus.optimization import (Anderson, ANewton, Bisection,
                                           Illinois, MDNewton, MNewton, Muller,
-                                          Newton, Pegasus, Ridder, Secant)
+                                          Newton, Pegasus, Ridder, Secant, ModAB)
 
 
 def test_findroot():
@@ -21,7 +21,7 @@ def test_findroot():
         assert abs(f(x)) < eps
     # test all solvers with interval of 2 points
     for solver in [Secant, Muller, Bisection, Illinois, Pegasus, Anderson,
-                   Ridder]:
+                   Ridder, ModAB]:
         x = findroot(f, (1., 2.), solver=solver)
         assert abs(f(x)) < eps
     # test types

--- a/mpmath/tests/test_rootfinding.py
+++ b/mpmath/tests/test_rootfinding.py
@@ -66,22 +66,22 @@ def test_muller():
     assert abs(f(x)) < eps
 
 def test_modAB():
-    assert findroot(lambda x: x**2-1, (0, 2),solver='modAB') == 1
+    assert findroot(lambda x: x**2 - 1, (0, 2), solver='modAB') == 1
 
     # test ordering
-    assert findroot(lambda x: x**2-1, (2, 0),solver='modAB') == 1
+    assert findroot(lambda x: x**2 - 1, (2, 0), solver='modAB') == 1
 
     with pytest.raises(ValueError, match="expected interval of 2 points"):
-        findroot(lambda x: x**2-1, (0,), solver='modAB')
+        findroot(lambda x: x**2 - 1, (0,), solver='modAB')
 
     with pytest.raises(ValueError, match="Function must have opposite signs"):
-        findroot(lambda x: x**2-1, (2, 4), solver='modAB')
+        findroot(lambda x: x**2 - 1, (2, 4), solver='modAB')
 
     # test exact zero hit
     assert findroot(lambda x: x, (-1, 1), solver='modAB') == 0.0
 
     # test bisection to secant switch for a purely linear function
-    f_linear = lambda x: 2 * x - 4
+    f_linear = lambda x: 2*x - 4
     assert mp.almosteq(findroot(f_linear, (0, 5), solver='modAB'), 2.0)
 
     f_convex = lambda x: x**10 - 1

--- a/mpmath/tests/test_rootfinding.py
+++ b/mpmath/tests/test_rootfinding.py
@@ -67,6 +67,8 @@ def test_muller():
 
 def test_modAB():
     assert findroot(lambda x: x**2-1, (0, 2),solver='modAB') == 1
+
+    # test ordering
     assert findroot(lambda x: x**2-1, (2, 0),solver='modAB') == 1
 
     with pytest.raises(ValueError, match="expected interval of 2 points"):
@@ -75,10 +77,26 @@ def test_modAB():
     with pytest.raises(ValueError, match="Function must have opposite signs"):
         findroot(lambda x: x**2-1, (2, 4), solver='modAB')
 
+    # test exact zero hit
     assert findroot(lambda x: x, (-1, 1), solver='modAB') == 0.0
 
+    # test bisection to secant switch for a purely linear function
     f_linear = lambda x: 2 * x - 4
     assert mp.almosteq(findroot(f_linear, (0, 5), solver='modAB'), 2.0)
+
+    f_convex = lambda x: x**10 - 1
+    assert mp.almosteq(findroot(f_convex, (0.1, 2.0), solver='modAB'), 1.0)
+
+    f_concave = lambda x: 1 - x**10
+    assert mp.almosteq(findroot(f_concave, (2.0, 0.1), solver='modAB'), 1.0)
+
+    f_cubic_inflection = lambda x: x**3 - 3*x + 3
+    root = findroot(f_cubic_inflection, (-3, 2), solver='modAB')
+    assert abs(f_cubic_inflection(root)) < eps
+
+    # test reset to Bisection if the interval width exceeds the threshold
+    f_step = lambda x: mp.sin(x) if x > 1 else x - 1
+    assert mp.almosteq(findroot(f_step, (0.4, 3.0), solver='modAB'), 1.0)
 
 def test_multiplicity():
     for i in range(1, 5):

--- a/mpmath/tests/test_rootfinding.py
+++ b/mpmath/tests/test_rootfinding.py
@@ -65,6 +65,21 @@ def test_muller():
     x = findroot(f, 1., solver=Muller)
     assert abs(f(x)) < eps
 
+def test_modAB():
+    assert findroot(lambda x: x**2-1, (0, 2),solver='modAB') == 1
+    assert findroot(lambda x: x**2-1, (2, 0),solver='modAB') == 1
+
+    with pytest.raises(ValueError, match="expected interval of 2 points"):
+        findroot(lambda x: x**2-1, (0,), solver='modAB')
+
+    with pytest.raises(ValueError, match="Function must have opposite signs"):
+        findroot(lambda x: x**2-1, (2, 4), solver='modAB')
+
+    assert findroot(lambda x: x, (-1, 1), solver='modAB') == 0.0
+
+    f_linear = lambda x: 2 * x - 4
+    assert mp.almosteq(findroot(f_linear, (0, 5), solver='modAB'), 2.0)
+
 def test_multiplicity():
     for i in range(1, 5):
         assert multiplicity(lambda x: (x - 1)**i, 1) == i


### PR DESCRIPTION
closes #1075 
- I read the algorithm and translated the given C# code in python while following mpmath's standards.
- Updated `findroot()` to allow users to call `modAB` algorithm as a solver.
- Added `ModAB` in `test_findroot()`

Let me know if any changes are required.