### PR TITLE
Change integral path of the lerchphi() to use Laplace transform integral

### DIFF
--- a/mpmath/functions/zeta.py
+++ b/mpmath/functions/zeta.py
@@ -1164,13 +1164,45 @@ def lerchphi(ctx, z, s, a):
         return zpow * ctx.lerchphi(z,s, a+m) + v
     if abs(z) < 0.5:
         return ctx.nsum(lambda k: z**k/(a+k)**s, [0, ctx.inf])
-    g = ctx.ln(z)
-    v = 1/(2*a**s) + ctx.gammainc(1-s, -a*g) * (-g)**(s-1) / z**a
-    h = s / 2
-    r = 2*ctx.pi
-    f = lambda t: ctx.sin(s*ctx.atan(t/a)-t*g) / \
-        ((a**2+t**2)**h * ctx.expm1(r*t))
-    v += 2*ctx.quad(f, [0, ctx.inf])
-    if not ctx.im(z) and not ctx.im(s) and not ctx.im(a) and ctx.re(z) < 1:
-        v = ctx.chop(v)
-    return v
+    g = lambda t: t**(s - 1)*ctx.exp(-a*t)/(1 - z*ctx.exp(-t))
+    h = lambda t: (-t)**(s - 1)*ctx.exp(-a*t)/(1 - z*ctx.exp(-t))
+    L = ctx.log(z)
+    if ctx.isint(s) and s.real >= 1:
+        if abs(L.imag) < 0.25 and L.real >= 0:
+            if z.imag <= 0:
+                I = ctx.quad(g, [0, +1j, +1j + abs(L) + 1, abs(L) + 1, ctx.inf])
+            else:
+                I = ctx.quad(g, [0, -1j, -1j + abs(L) + 1, abs(L) + 1, ctx.inf])
+        else:
+            I = ctx.quad(g, [0, ctx.inf])
+        return ctx.rgamma(s)*I
+    if L.real < -0.5:
+        residue = 0
+        c = min(abs(L.real)/2, 1)
+        left = right = top = c
+    elif abs(L.imag) > 0.5:
+        residue = 0
+        c = min(abs(L.imag)/2, 1)
+        left = right = top = c
+    else:
+        residue = (-L)**s/L/z**a
+        left = max(0, -L.real) + 1
+        top = abs(L.imag) + 1
+        right = abs(L) + 1
+    isreal = not z.imag and z.real < 1 and not s.imag and not a.imag and a.real > 0
+    w = ctx.mpc(-1)**(s - 1)
+    I = 0
+    if isreal:
+        I += 2j*ctx.im(ctx.quad(g, [right, right + top*1j]) / w)
+        I += 2j*ctx.im(ctx.quad(g, [right + top*1j, -left + top*1j]) / w)
+        I += 2j*ctx.im(ctx.quad(h, [-left + top*1j, -left]))
+        I += ctx.quad(g, [right, ctx.inf]) * (w - 1/w)
+    else:
+        I += ctx.quad(g, [right, right + top*1j])/w
+        I += ctx.quad(g, [right + top*1j, -left + top*1j])/w
+        I += ctx.quad(h, [-left + top*1j, -left - top*1j])
+        I += ctx.quad(g, [-left - top*1j, right - top*1j])*w
+        I += ctx.quad(g, [right - top*1j, right])*w
+        I += ctx.quad(g, [right, ctx.inf])*(w - 1/w)
+    I = I/(2*ctx.pi*1j) + residue
+    return -ctx.gamma(1 - s)*I

--- a/mpmath/tests/test_functions2.py
+++ b/mpmath/tests/test_functions2.py
@@ -2507,3 +2507,25 @@ def test_issue_1099():
     r1 = lerchphi(z, 2, a)
     r2 = extradps(100)(lerchphi)(z, 2, a)
     assert r1.ae(r2)
+
+
+def test_issue_252():
+    z, s, a = 2.5, 1.5, 4
+    e = 1/mpf(10**10)
+    # N[LerchPhi[5/2, 3/2, 4-10^-10], 17]
+    assert lerchphi(z, s,
+                    a - e).ae(mpc('-0.16723817353102306-0.08686834435129020j'))
+    # N[LerchPhi[5/2, 3/2, 4+10^-10], 17]
+    assert lerchphi(z, s,
+                    a + e).ae(mpc('-0.16723817351940769-0.08686834433537087j'))
+    # N[LerchPhi[5/2, 3/2, 4], 17]
+    assert lerchphi(z, s,
+                    a).ae(mpc('-0.16723817352521537-0.08686834434333054j'))
+    # N[LerchPhi[5/2+I/4, 2, 4], 17]
+    assert lerchphi(2.5+0.25j, 2,
+                    4).ae(mpc('-0.066397419699793568+0.076201248010951803j'))
+    # N[LerchPhi[1/4+I/2, 5/2, 4], 17]
+    assert lerchphi(0.25+0.5j, 2.5,
+                    4).ae(mpc('0.032357329026949928+0.010945877309574764j'))
+    # N[LerchPhi[3/4, 5/2, 4], 17]
+    assert lerchphi(0.75, 2.5, 4).ae(mpf('0.058457869546642472'))


### PR DESCRIPTION
Current formula ignores some constraints: https://dlmf.nist.gov/25.14#E6

Implementation follows to lerch_hankel(): https://fredrikj.net/blog/2022/02/computing-the-lerch-transcendent/#section6

Closes #252