### PR TITLE
Use generic modular transformations to compute jtheta() with |q| ~ 1

### DIFF
--- a/mpmath/function_docs.py
+++ b/mpmath/function_docs.py
@@ -9979,14 +9979,12 @@ Evaluation of derivatives::
 **Possible issues**
 
 For `|q| \ge 1` or `\Im(\tau) \le 0`, :func:`~mpmath.jtheta` raises
-``ValueError``. This exception is also raised for `|q|` extremely
-close to 1 (or equivalently `\tau` very close to 0), since the
-series would converge too slowly::
+``ValueError``::
 
-    >>> jtheta(1, 10, 0.99999999 * exp(0.5*j))
+    >>> jtheta(1, 10, 2)
     Traceback (most recent call last):
       ...
-    ValueError: abs(q) > THETA_Q_LIM = 1.000000
+    ValueError: abs(q) >= 1
 
 """
 

--- a/mpmath/functions/functions.py
+++ b/mpmath/functions/functions.py
@@ -8,11 +8,6 @@ class SpecialFunctions:
     """
     defined_functions = {}
 
-    # The series for the Jacobi theta functions converge for |q| < 1;
-    # in the current implementation they throw a ValueError for
-    # abs(q) > THETA_Q_LIM
-    THETA_Q_LIM = 1 - 10**-7
-
     def __init__(self):
         cls = self.__class__
         for name in cls.defined_functions:

--- a/mpmath/functions/theta.py
+++ b/mpmath/functions/theta.py
@@ -1,4 +1,7 @@
+from mpmath.libmp.libintmath import jacobi_symbol
+
 from .functions import defun, defun_wrapped
+
 
 @defun
 def _djacobi_theta2(ctx, z, q, nd):
@@ -442,6 +445,121 @@ def _djacobi_theta3a(ctx, z, q, nd):
     return (2*ctx.j)**nd * s
 
 @defun
+def _reduce_psl2z(ctx, z):
+    """
+    Returns the cumulative transformation matrix, that reduces a complex
+    number z to the fundamental domain of PSL(2, Z), chosen to be
+    |Re(z)| ≤ 0.5 and |z| ≥ 1.
+    """
+    z = ctx.convert(z)
+    assert z.imag > 0, f"Expected point from upper half-plane, got {ctx.mpc(z)}"
+
+    a = d = 1
+    b = c = 0
+
+    z_orig = z
+    with ctx.extraprec(30):
+        while True:
+            # Translate to center in |Re(z)| ≤ 1/2
+            n = round(z.real)
+            if n:
+                z -= n
+                a -= n*c
+                b -= n*d
+
+            # Maybe apply an inversion
+            if z.real**2 + z.imag**2 < 1:
+                z = -1/z
+                a, c = -c, a
+                b, d = -d, b
+                if abs(z.real) <= 0.5:
+                    break
+            else:
+                break
+
+        # Canonicalize matrix
+        if c < 0 or (c == 0 and d < 0):
+            a, b, c, d = -a, -b, -c, -d
+
+    return a, b, c, d
+
+#
+# General modular transformations for jtheta()
+#
+# References:
+# * Hans Rademacher (1973), "Topics in Analytic Number Theory",
+#   Springer. Section 81.
+# * [DLMF]_, §20.7(viii).
+#
+
+_T_map = {(0, 0): 1, (0, 1): 2, (1, 0): 4, (1, 1): 3}
+
+def _jtheta_permutation(n, a, b, c, d):
+    if n == 2:
+        return _T_map[(c%2, d%2)]
+    if n == 3:
+        return _T_map[((a + c)%2, (b + d)%2)]
+    if n == 4:
+        return _T_map[(a%2, b%2)]
+    return 1
+
+@defun
+def _jtheta_eps(ctx, n, a, b, c, d):
+    if n != 1:
+        if n == 2:
+            phi = (c - 2)*d - 2 + 2*(1 - c)*((d + 1)%2)
+        elif n == 3:
+            phi = (a + c - 2)*(b + d) - 3 + 2*(1 - a - c)*((b + d + 1)%2)
+        else:
+            phi = (a - 2)*b - 4 + 2*(1 - a)*((b + 1)%2)
+        k = ctx._jtheta_eps(1, -d, b, c, -a)
+    else:
+        if c % 2 == 0:
+            phi = d*(b - c - 1) + 2
+            k = jacobi_symbol(c, d)
+        else:
+            phi = c*(a + d + 1) - 3
+            k = jacobi_symbol(d, c)
+    return ctx.expjpi(ctx.convert(phi)/4)/k
+
+@defun
+def _jtheta_needs_modular(ctx, z, q):
+    if not z.imag:
+        return False
+    tau = ctx.taufrom(q=q)
+    assert abs(q) < 1 and tau.imag > 0
+    return abs(tau.real) > 0.5 or tau.real**2 + tau.imag**2 < 1
+
+@defun
+def _jtheta_modular(ctx, g, n, z, q, nd):
+    a, b, c, d = g
+    tau = ctx.taufrom(q=q)
+    v = -1/(c*tau + d)
+    alpha = 1j*v*c/ctx.pi
+
+    assert abs(q) < 1 and tau.imag > 0
+
+    new_n = _jtheta_permutation(n, -d, b, c, -a)
+    new_z = z*v
+    new_tau = (a*tau + b)/(c*tau + d)
+    new_q = ctx.qfrom(tau=new_tau)
+
+    assert abs(new_tau.real) <= 0.5 and new_tau.real**2 + new_tau.imag**2 >= 1
+
+    def terms():
+        Him1, Hi = ctx.zero, ctx.one
+        a2 = alpha*2
+        a2z = a2*z
+        for i in range(nd + 1):
+            yield (ctx.binomial(nd, i) * Hi * v**(nd - i)
+                   * ctx.jtheta(new_n, new_z, new_q, nd - i))
+            Him1, Hi = Hi, a2z*Hi + a2*i*Him1
+
+    C = ctx._jtheta_eps(n, -d, b, c, -a)*ctx.sqrt(v/1j)
+    X = alpha*z**2
+    return C*ctx.exp(X)*sum(terms())
+
+@defun
 def jtheta(ctx, n, z, q, derivative=0):
     n = int(n)
     z = ctx.convert(z)
@@ -452,6 +570,16 @@ def jtheta(ctx, n, z, q, derivative=0):
         raise ValueError("First argument expected to be 1, 2, 3 or 4")
     if abs(q) > ctx.THETA_Q_LIM:
         raise ValueError(f"abs(q) > THETA_Q_LIM = {ctx.THETA_Q_LIM}")
+
+    if ctx._jtheta_needs_modular(z, q):
+        tau = ctx.taufrom(q=q)
+        g = ctx._reduce_psl2z(tau)
+
+        # Estimate exponential factor
+        c, d = g[2:]
+        extra = 10*(nd + 1) + max(0, ctx.mag(c/(c*tau + d)*z**2))
+
+        return ctx.extraprec(extra, True)(ctx._jtheta_modular)(g, n, z, q, nd)
 
     # Implementation note
     # If ctx._im(z) is close to zero, _jacobi_theta2 and _jacobi_theta3

--- a/mpmath/functions/theta.py
+++ b/mpmath/functions/theta.py
@@ -568,8 +568,8 @@ def jtheta(ctx, n, z, q, derivative=0):
 
     if n not in range(1, 5):
         raise ValueError("First argument expected to be 1, 2, 3 or 4")
-    if abs(q) > ctx.THETA_Q_LIM:
-        raise ValueError(f"abs(q) > THETA_Q_LIM = {ctx.THETA_Q_LIM}")
+    if abs(q) >= 1:
+        raise ValueError(f"abs(q) >= 1")
 
     if ctx._jtheta_needs_modular(z, q):
         tau = ctx.taufrom(q=q)

--- a/mpmath/tests/test_elliptic.py
+++ b/mpmath/tests/test_elliptic.py
@@ -17,8 +17,9 @@ import pytest
 
 from mpmath import (cos, cosh, cot, coth, csc, csch, diff, ellipe, ellipfun,
                     ellipk, ellippi, elliprc, elliprd, elliprf, elliprg,
-                    elliprj, eps, exp, isnan, j, jtheta, ldexp, ln2, mp, mpc,
-                    mpf, nan, pi, qfrom, sec, sech, sin, sinh, sqrt, tan, tanh)
+                    elliprj, eps, exp, inf, isnan, j, jtheta, ldexp, ln2, mp,
+                    mpc, mpf, nan, nsum, pi, qfrom, sec, sech, sin, sinh, sqrt,
+                    tan, tanh)
 
 
 def mpc_ae(a, b, eps=eps):
@@ -218,6 +219,106 @@ def test_jtheta_invalid_n():
     pytest.raises(ValueError, jtheta, 0, 0.5, 0.3)
     pytest.raises(ValueError, jtheta, 5, 0.5, 0.3)
     pytest.raises(ValueError, jtheta, 0, 0.5, 0.3)
+
+def test_issue_930():
+    # for |q| close to 1 with complex z, jtheta's direct nome series
+    # suffered catastrophic cancellation and lost all precision.
+    # The PSL(2, Z) modular-reduction path fixes it.
+    #
+    mp.dps = 70
+    q = mpf(99)/100
+    z = 99+1j
+    mp.dps = 50
+    eps1 = 100*eps
+    # Reference values computed with:
+    # N[N[Derivative[0, nd, 0][EllipticTheta][n, 99+I, 99/100], 300], 50].
+    ref = {  # jtheta(n, 99+I, q, derivative=nd)
+        (1, 0): mpc('1.779258740399125063008605585919688748246270941962e43+2.4531552106585761829132327656277889232764080000082e44j'),
+        (2, 0): mpc('-1.4988039420376218477379546959304839688561560327952e-57+1.126724649309213092636325219160375156534138267338e-58j'),
+        (3, 0): mpc('-1.4988039419916629783968527738038480059854883969519e-57+1.126724649277094787663809804454822463406493776515e-58j'),
+        (4, 0): mpc('-1.779258740399125063008605585919688748246270941962e43-2.4531552106585761829132327656277889232764080000082e44j'),
+        (1, 1): mpc('4.8676346890955099082032405931623721782101881475052e46-5.485160172971341958206637770436412266629883709382e45j'),
+        (2, 1): mpc('-4.3420315824972909797400114725699377626910985932552e-55+3.3258620549120325016554512103625432300841517973459e-55j'),
+        (3, 1): mpc('-4.3420315826509862620149131749487142244793486272826e-55+3.3258620548308694307995377047445340481881823181686e-55j'),
+        (4, 1): mpc('-4.8676346890955099082032405931623721782101881475052e46+5.485160172971341958206637770436412266629883709382e45j'),
+        (1, 2): mpc('-1.4809058110492439979937435179858838426773452717825e48-9.6918513863888705669477095057488664706217962565546e48j'),
+        (2, 2): mpc('-6.580173968678905306210609222130658781889044450531e-53+1.8770881118790176343351463096530497188645552821989e-52j'),
+        (3, 2): mpc('-6.5801739683487208669817955792020573096817453981375e-53+1.8770881119356228857428818901066687299013630001154e-53j'),
+        (4, 2): mpc('1.4809058110492439979937435179858838426773452717825e48+9.6918513863888705669477095057488664706217962565546e48j'),
+    }
+    for (n_, nd), r in ref.items():
+        assert mpc_ae(jtheta(n_, z, q, derivative=nd), r, eps1), (n_, nd)
+
+    # larger Im(z): N[EllipticTheta[n, 99+2I, 99/100], 300], 50]
+    ref_z2 = {
+        2: mpc('6.4249758037350518725606864570348600840795103250997e72'
+               '-9.714841891170799887220046736000777198237616535325e71j'),
+        3: mpc('6.4249758039322926903898883193670191561073076453307e72'
+               '-9.714841891447835957536206094692144086296486157276e71j'),
+    }
+    for n_, r in ref_z2.items():
+        assert mpc_ae(jtheta(n_, 99 + 2j, q), r, eps1)
+
+    # small Im(z):
+    mp.dps = 70
+    z1 = 99 + j/100
+    z2 = 99 + j/1000
+    mp.dps = 50
+    # N[EllipticTheta[n, 99+I/100, 99/100], 300], 50]
+    assert mpc_ae(jtheta(2, z1, q),
+                  mpc('-9.2766223348824196728753370062221747173794042129425e-101'
+                      '+8.839222869333177347710982216539973334987056177494e-102j'))
+    # N[EllipticTheta[n, 99+2I, 99/1000], 300], 50]
+    assert mpc_ae(jtheta(2, z2, q),
+                  mpc('8.8023727531603529839604538627814233285505151260344e-101'
+                      '+2.7678970233217267414786149238410133410022311980703e-101j'))
+
+    mp.dps = 15
+    r1 = mp.extradps(45)(jtheta)(3, 0.25+0.25j, 0.5)
+    assert mpc_ae(jtheta(3, 0.25+0.25j, 0.5), +r1)
+
+    z = 1+0.5j
+    # N[EllipticTheta[1, 1 + I/2, 99*Exp[Pi*I/4]/100], 17]
+    with mp.extraprec(10):
+        q = 99*mp.nthroot(1, 8, 1)/100
+    assert mpc_ae(jtheta(1, z, q),
+                  mpc('2.0519200161807602e10-1.2299274570292357e10j'))
+    # N[EllipticTheta[1, 1 + I/2, 99*Exp[3*Pi*I/4]/100], 17]
+    with mp.extraprec(10):
+        q = 99*mp.nthroot(1, 8, 3)/100
+    assert mpc_ae(jtheta(1, z, q),
+                  mpc('1.4250540444836117e10-1.9215405987536610e10j'))
+
+def test_issue_930_random():
+    # random data in the modular-reduction regime (|q| close to 1 and
+    # complex z): check jtheta against itself at two precisions, like
+    # the |q| -> 1 checks in test_jtheta_issue_79 above
+    for i in range(10):
+        q = mpf(str(random.random()*mpf('0.0999') + mpf('0.9')))
+        if i % 2:
+            q = -q   # exercise the tau -> tau - k translation
+        z = mpc(str(10*random.random()), str(4*random.random() - 2))
+        for n_ in range(1, 5):
+            for nd in (0, 1, 2, 5, 8, 10):
+                r1 = mp.extradps(45)(jtheta)(n_, z, q, nd)
+                r2 = jtheta(n_, z, q, nd)
+                assert mpc_ae(r1, r2), (n_, z, q, nd)
+
+def test_jtheta_modular_translation():
+    mp.dps = 25
+    q = -0.5
+    z = 1+2j
+    assert mpc_ae(jtheta(3, z, q), jtheta(4, z, -q))
+    assert mpc_ae(jtheta(4, z, q), jtheta(3, z, -q))
+    for nd in (1, 2):
+        assert mpc_ae(jtheta(3, z, q, derivative=nd),
+                      jtheta(4, z, -q, derivative=nd))
+        assert mpc_ae(jtheta(4, z, q, derivative=nd),
+                      jtheta(3, z, -q, derivative=nd))
+    for n_ in (1, 2):
+        assert jtheta(n_, z, q).ae(exp(j*pi/4)*jtheta(n_, z, -q))
+    assert mpc_ae(jtheta(3, z, q), jtheta(3, -z, q))
+    assert mpc_ae(jtheta(4, z, q), jtheta(4, -z, q))
 
 def test_jtheta_identities():
     """

--- a/mpmath/tests/test_elliptic.py
+++ b/mpmath/tests/test_elliptic.py
@@ -169,11 +169,19 @@ def test_jtheta_issue_79():
     res = mpf('32.0031009628901652627099524264') + \
           mpf('16.6153027998236087899308935624') * j
     result = jtheta(3, 1, q)
-    # check that for abs(q) > Q_LIM a ValueError exception is raised
     mp.dps += 30
     q = mpf(6)/10 - one/10**7 - mpf(8)/10 * j
     mp.dps -= 30
-    pytest.raises(ValueError, lambda: jtheta(3, 1, q))
+    # N[EllipticTheta[3, 1, 6/10 - 10^-7 - 8/10 I], 30]
+    # with $MaxExtraPrecision = 10000
+    assert mpc_ae(jtheta(3, 1, q),
+                  mpc('1.19143507322246897676014934229'
+                      '+1.07603569085504321033898492583j'),
+                  100*eps)
+
+    # check that for abs(q) >= 1 a ValueError exception is raised
+    pytest.raises(ValueError, lambda: jtheta(3, 1, 1))
+    pytest.raises(ValueError, lambda: jtheta(3, 1, 2))
 
     # bug reported in issue 79
     mp.dps = 100


### PR DESCRIPTION
See https://fungrim.org/topic/Lattice_transformations_for_Jacobi_theta_functions/#General_modular_transformations

Closes #930

N.B. this uses tests from #1084.