### PR TITLE
Add Weierstrass elliptic functions

### DIFF
--- a/docs/functions/elliptic.rst
+++ b/docs/functions/elliptic.rst
@@ -46,6 +46,18 @@ Jacobi elliptic functions
 .. autofunction:: mpmath.ellipfun
 
 
+Weierstrass elliptic functions
+..............................
+
+.. autofunction:: mpmath.w_invariants
+.. autofunction:: mpmath.w_half_periods
+.. autofunction:: mpmath.wp
+.. autofunction:: mpmath.wpprime
+.. autofunction:: mpmath.wsigma
+.. autofunction:: mpmath.wzeta
+.. autofunction:: mpmath.invwp
+
+
 Modular functions
 .................
 

--- a/docs/functions/elliptic.rst
+++ b/docs/functions/elliptic.rst
@@ -49,13 +49,13 @@ Jacobi elliptic functions
 Weierstrass elliptic functions
 ..............................
 
-.. autofunction:: mpmath.w_invariants
-.. autofunction:: mpmath.w_half_periods
-.. autofunction:: mpmath.wp
-.. autofunction:: mpmath.wpprime
-.. autofunction:: mpmath.wsigma
-.. autofunction:: mpmath.wzeta
-.. autofunction:: mpmath.invwp
+.. autofunction:: mpmath.weierinvariants
+.. autofunction:: mpmath.weierhalfperiods
+.. autofunction:: mpmath.weierp
+.. autofunction:: mpmath.weierpprime
+.. autofunction:: mpmath.weiersigma
+.. autofunction:: mpmath.weierzeta
+.. autofunction:: mpmath.weierpinv
 
 
 Modular functions

--- a/mpmath/__init__.py
+++ b/mpmath/__init__.py
@@ -48,6 +48,15 @@ jtheta = mp.jtheta
 kleinj = mp.kleinj
 eta = mp.eta
 
+# Weierstrass elliptic functions
+w_invariants = mp.w_invariants
+w_half_periods = mp.w_half_periods
+wp = mp.wp
+wpprime = mp.wpprime
+wsigma = mp.wsigma
+wzeta = mp.wzeta
+invwp = mp.invwp
+
 qp = mp.qp
 qhyper = mp.qhyper
 qgamma = mp.qgamma

--- a/mpmath/__init__.py
+++ b/mpmath/__init__.py
@@ -49,13 +49,13 @@ kleinj = mp.kleinj
 eta = mp.eta
 
 # Weierstrass elliptic functions
-w_invariants = mp.w_invariants
-w_half_periods = mp.w_half_periods
-wp = mp.wp
-wpprime = mp.wpprime
-wsigma = mp.wsigma
-wzeta = mp.wzeta
-invwp = mp.invwp
+weierinvariants = mp.weierinvariants
+weierhalfperiods = mp.weierhalfperiods
+weierp = mp.weierp
+weierpprime = mp.weierpprime
+weiersigma = mp.weiersigma
+weierzeta = mp.weierzeta
+weierpinv = mp.weierpinv
 
 qp = mp.qp
 qhyper = mp.qhyper

--- a/mpmath/functions/elliptic.py
+++ b/mpmath/functions/elliptic.py
@@ -1767,7 +1767,7 @@ def _wzeta_from_tau_omega(ctx, z, omega1, tau_or_omega2):
 # ============================================================================
 
 @defun
-def weierinvariants(ctx, omega1, omega2=None):
+def weierinvariants(ctx, omega):
     r"""
     Returns the Weierstrass invariants `(g_2, g_3)` corresponding to
     the half-periods `(\omega_1, \omega_2)`::
@@ -1775,24 +1775,17 @@ def weierinvariants(ctx, omega1, omega2=None):
         >>> from mpmath import mp, chop, weierinvariants
         >>> mp.dps = 15
         >>> mp.pretty = True
-        >>> g2, g3 = weierinvariants(1, 0.5j)
+        >>> g2, g3 = weierinvariants((1, 0.5j))
         >>> chop(g2)
         129.987495088848
         >>> chop(g3)
         -284.355330876541
 
-    The half-periods may also be passed as a single pair::
-
-        >>> weierinvariants((1, 0.5j))[1]
-        (-284.355330876541 + 0.0j)
-
     """
-    if omega2 is None:
-        try:
-            omega1, omega2 = omega1
-        except (TypeError, ValueError):
-            raise ValueError("weierinvariants: expected "
-                             "omega1, omega2 or a pair of half-periods")
+    try:
+        omega1, omega2 = omega
+    except (TypeError, ValueError):
+        raise ValueError("weierinvariants: expected a pair of half-periods")
     prec = ctx.prec
     try:
         ctx.prec += 10
@@ -1807,7 +1800,7 @@ def weierinvariants(ctx, omega1, omega2=None):
     return +g2, +g3
 
 @defun
-def weierhalfperiods(ctx, g2, g3=None):
+def weierhalfperiods(ctx, g):
     r"""
     Returns a pair of fundamental half-periods `(\omega_1, \omega_2)`
     corresponding to the Weierstrass invariants `(g_2, g_3)`::
@@ -1816,24 +1809,18 @@ def weierhalfperiods(ctx, g2, g3=None):
         >>> from mpmath import weierhalfperiods, weierinvariants
         >>> mp.dps = 15
         >>> mp.pretty = True
-        >>> omega1, omega2 = weierhalfperiods(60, 140)
-        >>> g2, g3 = weierinvariants(omega1, omega2)
+        >>> omega1, omega2 = weierhalfperiods((60, 140))
+        >>> g2, g3 = weierinvariants((omega1, omega2))
         >>> chop(g2), chop(g3)
         (60.0, 140.0)
-
-    The invariants may also be passed as a single pair::
-
-        >>> omega1, omega2 = weierhalfperiods((60, 140))
         >>> chop(omega2/omega1)
         (0.5 + 0.209032224450873j)
 
     """
-    if g3 is None:
-        try:
-            g2, g3 = g2
-        except (TypeError, ValueError):
-            raise ValueError("weierhalfperiods: expected "
-                             "g2, g3 or a pair of invariants")
+    try:
+        g2, g3 = g
+    except (TypeError, ValueError):
+        raise ValueError("weierhalfperiods: expected a pair of invariants")
     prec = ctx.prec
     try:
         ctx.prec += 10

--- a/mpmath/functions/elliptic.py
+++ b/mpmath/functions/elliptic.py
@@ -1476,3 +1476,548 @@ def ellippi(ctx, *args):
         RJ = ctx.elliprj(x, y, 1, 1-n*s**2)
         return s*RF, n*s**3*RJ/3
     return ctx.sum_accurately(terms) + P
+
+
+# Weierstrass Elliptic Functions
+# ============================================================================
+
+def _complex_sort(ctx, list_of_mpcs, ascending=True):
+    """
+    Sorts a list of complex numbers first by real part,
+    then by imaginary part where real parts are equal.
+    """
+    sorted_list = sorted([(c.real, c.imag) for c in list_of_mpcs],
+                         reverse=not ascending)
+    return [ctx.mpc(real=t[0], imag=t[1]) for t in sorted_list]
+
+def _roots_from_omega(ctx, omega1, omega2):
+    """
+    Compute roots e1, e2, e3 of 4*z^3 - g2*z - g3 = 0 using theta functions.
+    This is ~10x faster than solving the cubic directly.
+    """
+    tau = omega2 / omega1
+    q = ctx.qfrom(tau=tau)
+    j24 = ctx.jtheta(2, 0, q)**4
+    j44 = ctx.jtheta(4, 0, q)**4
+    c = ctx.pi**2 / omega1**2 / 12
+    e1 = c * (j24 + 2*j44)
+    e2 = c * (j24 - j44)
+    e3 = -c * (2*j24 + j44)
+    return _complex_sort(ctx, [e1, e2, e3], ascending=False)
+
+def _eisenstein_E4_E6(ctx, tau):
+    """
+    Eisenstein E-series of weight 4 and 6.
+    Uses theta function formula to avoid numerical errors.
+    """
+    q = ctx.qfrom(tau=tau)
+    j2 = ctx.jtheta(2, 0, q)
+    j3 = ctx.jtheta(3, 0, q)
+    j4 = ctx.jtheta(4, 0, q)
+    E4 = (j2**8 + j3**8 + j4**8) / 2
+    E6 = (-3*j2**8 * (j3**4 + j4**4) + (j3**12 + j4**12)) / 2
+    return E4, E6
+
+def _eisenstein_G4_G6(ctx, tau):
+    """
+    Eisenstein G-series of weight 4 and 6.
+    """
+    E4, E6 = _eisenstein_E4_E6(ctx, tau)
+    G4 = 2 * ctx.zeta(4) * E4
+    G6 = 2 * ctx.zeta(6) * E6
+    return G4, G6
+
+def _inverse_kleinj(ctx, _j):
+    """
+    Compute tau from j-invariant using the inverse j-function.
+    See: https://en.wikipedia.org/wiki/J-invariant
+    """
+    _j = ctx.convert(_j)
+    sqrt_arg = 3*(1728*_j**2 - _j**3)
+    exponent = ctx.mpf(1) / ctx.mpf(3)
+    t = (-_j**3 + 2304*_j**2 - 884736*_j +
+         12288*ctx.sqrt(sqrt_arg))**exponent
+    x = ctx.mpf(1)/768*t + (1 - _j/768) - (1536*_j - _j**2) / (768*t)
+
+    lbd = (1 + ctx.sqrt(1 - 4*x)) / 2
+    tau = ctx.j * ctx.agm(1, ctx.sqrt(1-lbd)) / ctx.agm(1, ctx.sqrt(lbd))
+    return tau
+
+def _kleinj_from_g2g3(ctx, g2, g3):
+    """
+    Klein-j invariant from g2, g3 (the 1728-normalized version).
+    """
+    g2 = ctx.convert(g2)
+    g3 = ctx.convert(g3)
+    return 1728 / (1 - 27*g3**2/g2**3)
+
+def _tau_from_g(ctx, g2, g3):
+    """
+    Compute tau (half-period ratio) from g2, g3.
+    """
+    g2 = ctx.convert(g2)
+    g3 = ctx.convert(g3)
+    j = _kleinj_from_g2g3(ctx, g2, g3)
+    tau = _inverse_kleinj(ctx, j)
+    return tau
+
+def _omega_from_g(ctx, g2, g3, tolerance=None):
+    """
+    Compute half-periods (omega1, omega2) from invariants g2, g3.
+    """
+    if tolerance is None:
+        # Start with relaxed tolerance; can be tightened with higher precision
+        tolerance = 0.2
+
+    g2 = ctx.convert(g2)
+    g3 = ctx.convert(g3)
+
+    # Special cases
+    if g2 == 0:
+        omegaA = (g3 ** (ctx.mpf(-1)/ctx.mpf(6)) *
+                  ctx.gamma(ctx.mpf(1)/ctx.mpf(3))**3 / (4*ctx.pi))
+        tau = ctx.mpc(ctx.mpf(1)/ctx.mpf(2), ctx.sqrt(3)/2)
+    elif g3 == 0:
+        tau = _tau_from_g(ctx, g2, g3)
+        G4, G6 = _eisenstein_G4_G6(ctx, tau)
+        omegaA = ctx.j * (ctx.mpf(15)/(4*g2) * G4) ** (ctx.mpf(1)/ctx.mpf(4))
+    else:
+        tau = _tau_from_g(ctx, g2, g3)
+        G4, G6 = _eisenstein_G4_G6(ctx, tau)
+        _sqrt_arg = g2/g3 * G6/G4 * ctx.mpf(7)/ctx.mpf(12)
+        omegaA = ctx.sqrt(_sqrt_arg)
+
+    omegaB = tau * omegaA
+    omegaC = omegaA + omegaB
+
+    # Match omegas to roots using Weierstrass P function
+    omegas = [omegaA, omegaB, omegaC]
+    index_combos = [(0,1,2), (0,2,1), (1,0,2), (1,2,0), (2,0,1), (2,1,0)]
+
+    e1, e2, e3 = _roots_from_omega(ctx, omegaA, omegaB)
+
+    # Compute wp at each omega to match with roots
+    wps = []
+    for omegaN in omegas:
+        wp_val = _wp_from_tau_omega(ctx, omegaN, omegaA, tau)
+        wps.append(wp_val)
+
+    maes = []
+    for ic in index_combos:
+        mae = (ctx.fabs(e1 - wps[ic[0]]) + ctx.fabs(e2 - wps[ic[1]]) +
+               ctx.fabs(e3 - wps[ic[2]])) / 3
+        maes.append(mae)
+
+    mae = min(maes)
+    min_index = maes.index(mae)
+
+    if mae > tolerance:
+        raise ValueError("omega_from_g: convergence tolerance not met")
+
+    omega1, omega2, omega3 = [omegas[k] for k in index_combos[min_index]]
+
+    # Ensure Im(tau) > 0
+    if ctx.im(omega2/omega1) <= 0:
+        omega2 = -omega2
+
+    return omega1, omega2, omega3
+
+def _g_from_omega(ctx, omega1, omega2):
+    """
+    Compute g2, g3 from half-periods omega1, omega2.
+    """
+    omega1 = ctx.convert(omega1)
+    omega2 = ctx.convert(omega2)
+    tau = omega2 / omega1
+    q = ctx.qfrom(tau=tau)
+    j2 = ctx.jtheta(2, 0, q)
+    j3 = ctx.jtheta(3, 0, q)
+    g2 = (ctx.mpf(4)/3) * (ctx.pi/(2*omega1))**4 * (j2**8 - (j2*j3)**4 + j3**8)
+    g3 = ((ctx.mpf(8)/27) * (ctx.pi/(2*omega1))**6 *
+          (j2**12 - (ctx.mpf(3)/2*j2**8*j3**4 +
+                     ctx.mpf(3)/2*j2**4*j3**8) +
+           j3**12))
+    return g2, g3
+
+def _weierstrass_omega_tau(ctx, funcname, g2=None, g3=None,
+                           tau=None, omega=None):
+    """
+    Resolve one Weierstrass parameterization to (omega1, tau).
+    """
+    if (g2 is None) != (g3 is None):
+        raise ValueError("%s: must provide both g2 and g3" % funcname)
+    parameter_count = (int(g2 is not None) + int(tau is not None) +
+                       int(omega is not None))
+    if parameter_count != 1:
+        raise ValueError("%s: must provide exactly one of g2, g3; "
+                         "omega; or tau" % funcname)
+    if omega is not None:
+        omega1, omega2 = omega
+        omega1 = ctx.convert(omega1)
+        omega2 = ctx.convert(omega2)
+        tau = omega2 / omega1
+        if ctx.im(tau) <= 0:
+            raise ValueError("%s: omega ratio must be in upper half-plane" %
+                             funcname)
+        return omega1, tau
+    if tau is not None:
+        tau = ctx.convert(tau)
+        if ctx.im(tau) <= 0:
+            raise ValueError("%s: tau must be in upper half-plane" % funcname)
+        return ctx.one, tau
+    omega1, omega2 = _omega_from_g(ctx, g2, g3)[:2]
+    return omega1, omega2 / omega1
+
+def _wp_from_tau_omega(ctx, z, omega1, tau_or_omega2):
+    """
+    Internal: Weierstrass P function using tau or omega.
+    Computes wp(z; omega1, tau or omega2)
+
+    Following the convention:
+    wp(z, omega1, omega2) = wp_theta(z/(2*omega1), tau) / (omega1^2/4)
+    """
+    z = ctx.convert(z)
+    omega1 = ctx.convert(omega1)
+    tau = ctx.convert(tau_or_omega2)
+
+    # Normalize z by the period: z_norm = z / (2 * omega1)
+    z_norm = z / (2 * omega1)
+
+    q = ctx.qfrom(tau=tau)
+    j1z = ctx.jtheta(1, ctx.pi*z_norm, q)
+    j2 = ctx.jtheta(2, 0, q)
+    j3 = ctx.jtheta(3, 0, q)
+    j4z = ctx.jtheta(4, ctx.pi*z_norm, q)
+
+    # Theta-based Weierstrass P (no omega normalization)
+    wp_theta = ((ctx.pi*j2*j3*j4z/j1z)**2 -
+                ctx.pi**2 * (j2**4 + j3**4) / 3)
+
+    # Apply omega normalization
+    return wp_theta / omega1**2 / 4
+
+def _wpprime_from_tau_omega(ctx, z, omega1, tau_or_omega2):
+    """
+    Internal: Weierstrass P' function using tau or omega.
+    Computes wp'(z; omega1, tau or omega2)
+    """
+    z = ctx.convert(z)
+    omega1 = ctx.convert(omega1)
+    tau = ctx.convert(tau_or_omega2)
+
+    # Normalize z by the period
+    z_norm = z / (2 * omega1)
+
+    q = ctx.qfrom(tau=tau)
+    z1 = ctx.pi * z_norm
+    j10p = ctx.jtheta(1, 0, q, 1)
+    j20 = ctx.jtheta(2, 0, q)
+    j30 = ctx.jtheta(3, 0, q)
+    j40 = ctx.jtheta(4, 0, q)
+    k0 = j10p**3 / (j20 * j30 * j40)
+
+    j1z1 = ctx.jtheta(1, z1, q)
+    j2z1 = ctx.jtheta(2, z1, q)
+    j3z1 = ctx.jtheta(3, z1, q)
+    j4z1 = ctx.jtheta(4, z1, q)
+    kz = j2z1 * j3z1 * j4z1 / j1z1**3
+
+    wpprime_val = -ctx.pi**3 / (4 * omega1**3) * k0 * kz
+    return wpprime_val
+
+def _wsigma_from_tau_omega(ctx, z, omega1, tau_or_omega2):
+    """
+    Internal: Weierstrass sigma function.
+    """
+    z = ctx.convert(z)
+    omega1 = ctx.convert(omega1)
+    tau = ctx.convert(tau_or_omega2)
+
+    z1 = ctx.pi * z / (2 * omega1)
+    q = ctx.qfrom(tau=tau)
+    j10p = ctx.jtheta(1, 0, q, 1)
+    j10ppp = ctx.jtheta(1, 0, q, 3)
+    j1z1 = ctx.jtheta(1, z1, q)
+
+    w_sigma = (2 * omega1 / (ctx.pi * j10p) *
+               ctx.exp(-z1**2 * j10ppp / (6 * j10p)) * j1z1)
+    return w_sigma
+
+def _wzeta_from_tau_omega(ctx, z, omega1, tau_or_omega2):
+    """
+    Internal: Weierstrass zeta function.
+    """
+    z = ctx.convert(z)
+    omega1 = ctx.convert(omega1)
+    tau = ctx.convert(tau_or_omega2)
+
+    w1 = -omega1 / ctx.pi
+    q = ctx.qfrom(tau=tau)
+    p = 1 / 2 / w1
+    eta1 = p / 6 / w1 * ctx.jtheta(1, 0, q, 3) / ctx.jtheta(1, 0, q, 1)
+
+    j1pz = ctx.jtheta(1, p*z, q, 1)
+    j1z = ctx.jtheta(1, p*z, q)
+
+    return -eta1 * z + p * j1pz / j1z
+
+
+# ============================================================================
+# Weierstrass parameter conversion functions
+# ============================================================================
+
+@defun
+def w_invariants(ctx, omega1, omega2=None):
+    r"""
+    Returns the Weierstrass invariants `(g_2, g_3)` corresponding to
+    the half-periods `(\omega_1, \omega_2)`::
+
+        >>> from mpmath import mp, chop, w_invariants
+        >>> mp.dps = 15
+        >>> mp.pretty = True
+        >>> g2, g3 = w_invariants(1, 0.5j)
+        >>> chop(g2)
+        129.987495088848
+        >>> chop(g3)
+        -284.355330876541
+
+    The half-periods may also be passed as a single pair::
+
+        >>> w_invariants((1, 0.5j))[1]
+        (-284.355330876541 + 0.0j)
+
+    """
+    if omega2 is None:
+        try:
+            omega1, omega2 = omega1
+        except (TypeError, ValueError):
+            raise ValueError("w_invariants: expected "
+                             "omega1, omega2 or a pair of half-periods")
+    prec = ctx.prec
+    try:
+        ctx.prec += 10
+        omega1 = ctx.convert(omega1)
+        omega2 = ctx.convert(omega2)
+        if ctx.im(omega2/omega1) <= 0:
+            raise ValueError("w_invariants: omega ratio must be "
+                             "in upper half-plane")
+        g2, g3 = _g_from_omega(ctx, omega1, omega2)
+    finally:
+        ctx.prec = prec
+    return +g2, +g3
+
+@defun
+def w_half_periods(ctx, g2, g3=None):
+    r"""
+    Returns a pair of fundamental half-periods `(\omega_1, \omega_2)`
+    corresponding to the Weierstrass invariants `(g_2, g_3)`::
+
+        >>> from mpmath import mp, chop
+        >>> from mpmath import w_half_periods, w_invariants
+        >>> mp.dps = 15
+        >>> mp.pretty = True
+        >>> omega1, omega2 = w_half_periods(60, 140)
+        >>> g2, g3 = w_invariants(omega1, omega2)
+        >>> chop(g2), chop(g3)
+        (60.0, 140.0)
+
+    The invariants may also be passed as a single pair::
+
+        >>> omega1, omega2 = w_half_periods((60, 140))
+        >>> chop(omega2/omega1)
+        (0.5 + 0.209032224450873j)
+
+    """
+    if g3 is None:
+        try:
+            g2, g3 = g2
+        except (TypeError, ValueError):
+            raise ValueError("w_half_periods: expected "
+                             "g2, g3 or a pair of invariants")
+    prec = ctx.prec
+    try:
+        ctx.prec += 10
+        omega1, omega2 = _omega_from_g(ctx, g2, g3)[:2]
+    finally:
+        ctx.prec = prec
+    return +omega1, +omega2
+
+
+# ============================================================================
+# Main Weierstrass Elliptic Functions
+# ============================================================================
+
+@defun_wrapped
+def wp(ctx, z, g2=None, g3=None, tau=None, omega=None):
+    r"""
+    Weierstrass elliptic function `\wp(z; g_2, g_3)`.
+
+    Computes the Weierstrass P-function, a doubly-periodic elliptic function
+    satisfying the differential equation:
+
+    .. math::
+
+        (\wp')^2 = 4\wp^3 - g_2 \wp - g_3
+
+    The function can be parameterized in multiple ways:
+    - via `g_2, g_3` (elliptic invariants) - recommended
+    - via `\omega_1, \omega_2` (half-periods)
+    - via `\tau` (half-period ratio)
+
+    **Examples**
+
+    Direct computation with invariants::
+
+        >>> from mpmath import mp, wp, chop
+        >>> mp.dps = 15
+        >>> mp.pretty = True
+        >>> chop(wp(0.5, g2=60, g3=140))
+        5.12943876105856
+
+    Using tau parameterization::
+
+        >>> chop(wp(0.5, tau=0.5j))
+        5.15638936351528
+
+    **References**
+
+    - DLMF Section 23.2: https://dlmf.nist.gov/23.2
+    - Weierstrass, K. (1895)
+
+    """
+    z = ctx.convert(z)
+    omega1, tau = _weierstrass_omega_tau(ctx, "wp", g2, g3, tau, omega)
+    return _wp_from_tau_omega(ctx, z, omega1, tau)
+
+@defun_wrapped
+def wpprime(ctx, z, g2=None, g3=None, tau=None, omega=None):
+    r"""
+    Derivative of Weierstrass elliptic function `\wp'(z; g_2, g_3)`.
+
+    Computes the derivative of the Weierstrass P-function.
+
+    **Examples**
+
+    Compute derivative::
+
+        >>> from mpmath import mp, wpprime, chop
+        >>> mp.dps = 15
+        >>> mp.pretty = True
+        >>> chop(wpprime(0.5, g2=60, g3=140))
+        -9.5957928748663
+
+    Verify differential equation::
+
+        >>> from mpmath import mp, wp, wpprime
+        >>> mp.dps = 15
+        >>> z = 0.5
+        >>> g2, g3 = 60, 140
+        >>> # Should satisfy: (wp')^2 = 4*wp^3 - g2*wp - g3
+        >>> lhs = wpprime(z, g2=g2, g3=g3)**2
+        >>> rhs = 4*wp(z, g2=g2, g3=g3)**3 - g2*wp(z, g2=g2, g3=g3) - g3
+        >>> mp.almosteq(lhs, rhs)
+        True
+
+    """
+    z = ctx.convert(z)
+    omega1, tau = _weierstrass_omega_tau(ctx, "wpprime", g2, g3, tau, omega)
+    return _wpprime_from_tau_omega(ctx, z, omega1, tau)
+
+@defun_wrapped
+def wsigma(ctx, z, g2=None, g3=None, tau=None, omega=None):
+    r"""
+    Weierstrass sigma function `\sigma(z; g_2, g_3)`.
+
+    The Weierstrass sigma function is related to the P-function by:
+
+    .. math::
+
+        \wp(z) = -\frac{d^2}{dz^2} \ln \sigma(z)
+
+    **Examples**
+
+    Compute sigma function::
+
+        >>> from mpmath import mp, wsigma, chop
+        >>> mp.dps = 15
+        >>> mp.pretty = True
+        >>> chop(wsigma(0.5, g2=60, g3=140))
+        0.490839927387142
+
+    """
+    z = ctx.convert(z)
+    omega1, tau = _weierstrass_omega_tau(ctx, "wsigma", g2, g3, tau, omega)
+    return _wsigma_from_tau_omega(ctx, z, omega1, tau)
+
+@defun_wrapped
+def wzeta(ctx, z, g2=None, g3=None, tau=None, omega=None):
+    r"""
+    Weierstrass zeta function `\zeta(z; g_2, g_3)`.
+
+    The Weierstrass zeta function is related to the P and sigma functions.
+    It is quasi-periodic (not doubly periodic).
+
+    **Examples**
+
+    Compute zeta function::
+
+        >>> from mpmath import mp, wzeta, chop
+        >>> mp.dps = 15
+        >>> mp.pretty = True
+        >>> chop(wzeta(0.5, g2=60, g3=140))
+        1.83933548687454
+
+    """
+    z = ctx.convert(z)
+    omega1, tau = _weierstrass_omega_tau(ctx, "wzeta", g2, g3, tau, omega)
+    return _wzeta_from_tau_omega(ctx, z, omega1, tau)
+
+@defun_wrapped
+def invwp(ctx, p, g2=None, g3=None, tau=None, omega=None, w_prime=None):
+    r"""
+    Inverse Weierstrass elliptic function.
+
+    Computes `z` such that `\wp(z; g_2, g_3) = p`, using Carlson's
+    symmetric integral.
+
+    **Parameters**
+
+    - `p`: the target value
+    - `g2, g3`: elliptic invariants (recommended)
+    - `tau` or `omega`: alternative parameterizations
+    - `w_prime` (optional): if provided, attempts to select the correct sign
+      of `z`
+
+    **Examples**
+
+    Find preimage under Weierstrass P::
+
+        >>> from mpmath import mp, wp, invwp
+        >>> mp.dps = 25
+        >>> z0 = 0.5
+        >>> g2, g3 = 60, 140
+        >>> p_val = wp(z0, g2=g2, g3=g3)
+        >>> z_recovered = invwp(p_val, g2=g2, g3=g3)
+        >>> mp.almosteq(z0, z_recovered)  # May differ by periods
+        True
+
+    """
+    p = ctx.convert(p)
+    omega1, tau = _weierstrass_omega_tau(ctx, "invwp", g2, g3, tau, omega)
+    omega2 = omega1 * tau
+    e1, e2, e3 = _roots_from_omega(ctx, omega1, omega2)
+
+    # Compute via elliptic integral
+    z = ctx.elliprf(p - e1, p - e2, p - e3)
+
+    # Optionally select sign based on derivative
+    if w_prime is not None:
+        w_prime = ctx.convert(w_prime)
+        wpprime_neg_z = _wpprime_from_tau_omega(ctx, -z, omega1, tau)
+        wpprime_pos_z = _wpprime_from_tau_omega(ctx, z, omega1, tau)
+
+        if (ctx.fabs(wpprime_neg_z - w_prime) <
+                ctx.fabs(wpprime_pos_z - w_prime)):
+            return -z
+
+    return z

--- a/mpmath/functions/elliptic.py
+++ b/mpmath/functions/elliptic.py
@@ -1553,81 +1553,6 @@ def _tau_from_g(ctx, g2, g3):
     tau = _inverse_kleinj(ctx, j)
     return tau
 
-def _omega_from_g(ctx, g2, g3):
-    """
-    Compute half-periods (omega1, omega2) from invariants g2, g3.
-    """
-    g2 = ctx.convert(g2)
-    g3 = ctx.convert(g3)
-
-    # Special cases
-    if g2 == 0:
-        omegaA = (g3 ** (ctx.mpf(-1)/ctx.mpf(6)) *
-                  ctx.gamma(ctx.mpf(1)/ctx.mpf(3))**3 / (4*ctx.pi))
-        tau = ctx.mpc(ctx.mpf(1)/ctx.mpf(2), ctx.sqrt(3)/2)
-    elif g3 == 0:
-        tau = _tau_from_g(ctx, g2, g3)
-        G4, G6 = _eisenstein_G4_G6(ctx, tau)
-        omegaA = ctx.j * (ctx.mpf(15)/(4*g2) * G4) ** (ctx.mpf(1)/ctx.mpf(4))
-    else:
-        tau = _tau_from_g(ctx, g2, g3)
-        G4, G6 = _eisenstein_G4_G6(ctx, tau)
-        _sqrt_arg = g2/g3 * G6/G4 * ctx.mpf(7)/ctx.mpf(12)
-        omegaA = ctx.sqrt(_sqrt_arg)
-
-    omegaB = tau * omegaA
-    omegaC = omegaA + omegaB
-
-    # Match omegas to roots using Weierstrass P function
-    omegas = [omegaA, omegaB, omegaC]
-    index_combos = [(0,1,2), (0,2,1), (1,0,2), (1,2,0), (2,0,1), (2,1,0)]
-
-    e1, e2, e3 = _roots_from_omega(ctx, omegaA, omegaB)
-
-    # Compute wp at each omega to match with roots
-    wps = []
-    for omegaN in omegas:
-        wp_val = _wp_from_tau_omega(ctx, omegaN, omegaA, tau)
-        wps.append(wp_val)
-
-    maes = []
-    for ic in index_combos:
-        mae = (abs(e1 - wps[ic[0]]) + abs(e2 - wps[ic[1]]) +
-               abs(e3 - wps[ic[2]])) / 3
-        maes.append(mae)
-
-    mae = min(maes)
-    min_index = maes.index(mae)
-
-    scale = max([ctx.one] + [abs(x) for x in [e1, e2, e3] + wps])
-    tolerance = ctx.sqrt(ctx.eps) * scale
-    if mae > tolerance: raise ValueError("weierhalfperiods: no convergence")
-
-    omega1, omega2, omega3 = [omegas[k] for k in index_combos[min_index]]
-
-    # Ensure Im(tau) > 0
-    if ctx.im(omega2/omega1) <= 0:
-        omega2 = -omega2
-
-    return omega1, omega2, omega3
-
-def _g_from_omega(ctx, omega1, omega2):
-    """
-    Compute g2, g3 from half-periods omega1, omega2.
-    """
-    omega1 = ctx.convert(omega1)
-    omega2 = ctx.convert(omega2)
-    tau = omega2 / omega1
-    q = ctx.qfrom(tau=tau)
-    j2 = ctx.jtheta(2, 0, q)
-    j3 = ctx.jtheta(3, 0, q)
-    g2 = (ctx.mpf(4)/3) * (ctx.pi/(2*omega1))**4 * (j2**8 - (j2*j3)**4 + j3**8)
-    g3 = ((ctx.mpf(8)/27) * (ctx.pi/(2*omega1))**6 *
-          (j2**12 - (ctx.mpf(3)/2*j2**8*j3**4 +
-                     ctx.mpf(3)/2*j2**4*j3**8) +
-           j3**12))
-    return g2, g3
-
 def _weierstrass_omega_tau(ctx, funcname, g2=None, g3=None, tau=None,
                            omega1=None, omega2=None):
     """
@@ -1655,65 +1580,8 @@ def _weierstrass_omega_tau(ctx, funcname, g2=None, g3=None, tau=None,
         if ctx.im(tau) <= 0:
             raise ValueError("%s: tau must be in upper half-plane" % funcname)
         return ctx.one/2, tau
-    omega1, omega2 = _omega_from_g(ctx, g2, g3)[:2]
+    omega1, omega2 = ctx.weierhalfperiods(g2, g3)
     return omega1, omega2 / omega1
-
-def _wp_from_tau_omega(ctx, z, omega1, tau_or_omega2):
-    """
-    Weierstrass P function using tau or omega.
-    Computes wp(z; omega1, tau or omega2)
-
-    Following the convention:
-    wp(z, omega1, omega2) = wp_theta(z/(2*omega1), tau) / (omega1^2/4)
-    """
-    z = ctx.convert(z)
-    omega1 = ctx.convert(omega1)
-    tau = ctx.convert(tau_or_omega2)
-
-    # Normalize z by the period: z_norm = z / (2 * omega1)
-    z_norm = z / (2 * omega1)
-
-    q = ctx.qfrom(tau=tau)
-    j1z = ctx.jtheta(1, ctx.pi*z_norm, q)
-    j2 = ctx.jtheta(2, 0, q)
-    j3 = ctx.jtheta(3, 0, q)
-    j4z = ctx.jtheta(4, ctx.pi*z_norm, q)
-
-    # Theta-based Weierstrass P (no omega normalization)
-    wp_theta = ((ctx.pi*j2*j3*j4z/j1z)**2 -
-                ctx.pi**2 * (j2**4 + j3**4) / 3)
-
-    # Apply omega normalization
-    return wp_theta / omega1**2 / 4
-
-def _wpprime_from_tau_omega(ctx, z, omega1, tau_or_omega2):
-    """
-    Weierstrass P' function using tau or omega.
-    Computes wp'(z; omega1, tau or omega2)
-    """
-    z = ctx.convert(z)
-    omega1 = ctx.convert(omega1)
-    tau = ctx.convert(tau_or_omega2)
-
-    # Normalize z by the period
-    z_norm = z / (2 * omega1)
-
-    q = ctx.qfrom(tau=tau)
-    z1 = ctx.pi * z_norm
-    j10p = ctx.jtheta(1, 0, q, 1)
-    j20 = ctx.jtheta(2, 0, q)
-    j30 = ctx.jtheta(3, 0, q)
-    j40 = ctx.jtheta(4, 0, q)
-    k0 = j10p**3 / (j20 * j30 * j40)
-
-    j1z1 = ctx.jtheta(1, z1, q)
-    j2z1 = ctx.jtheta(2, z1, q)
-    j3z1 = ctx.jtheta(3, z1, q)
-    j4z1 = ctx.jtheta(4, z1, q)
-    kz = j2z1 * j3z1 * j4z1 / j1z1**3
-
-    wpprime_val = -ctx.pi**3 / (4 * omega1**3) * k0 * kz
-    return wpprime_val
 
 # ============================================================================
 # Weierstrass parameter conversion functions
@@ -1740,7 +1608,16 @@ def weierinvariants(ctx, omega1, omega2):
         if ctx.im(omega2/omega1) <= 0:
             raise ValueError("weierinvariants: omega ratio must be "
                              "in upper half-plane")
-        g2, g3 = _g_from_omega(ctx, omega1, omega2)
+        tau = omega2 / omega1
+        q = ctx.qfrom(tau=tau)
+        j2 = ctx.jtheta(2, 0, q)
+        j3 = ctx.jtheta(3, 0, q)
+        factor = ctx.pi / (2 * omega1)
+        g2 = (ctx.mpf(4)/3) * factor**4 * (j2**8 - (j2*j3)**4 + j3**8)
+        g3 = ((ctx.mpf(8)/27) * factor**6 *
+              (j2**12 - (ctx.mpf(3)/2*j2**8*j3**4 +
+                         ctx.mpf(3)/2*j2**4*j3**8) +
+               j3**12))
         return +g2, +g3
 
 @defun
@@ -1761,7 +1638,50 @@ def weierhalfperiods(ctx, g2, g3):
 
     """
     with ctx.extraprec(10):
-        omega1, omega2 = _omega_from_g(ctx, g2, g3)[:2]
+        g2 = ctx.convert(g2)
+        g3 = ctx.convert(g3)
+
+        if g2 == 0:
+            omegaA = (g3 ** (ctx.mpf(-1)/ctx.mpf(6)) *
+                      ctx.gamma(ctx.mpf(1)/ctx.mpf(3))**3 / (4*ctx.pi))
+            tau = ctx.mpc(ctx.mpf(1)/ctx.mpf(2), ctx.sqrt(3)/2)
+        elif g3 == 0:
+            tau = _tau_from_g(ctx, g2, g3)
+            G4, G6 = _eisenstein_G4_G6(ctx, tau)
+            omegaA = (ctx.j * (ctx.mpf(15)/(4*g2) * G4) **
+                      (ctx.mpf(1)/ctx.mpf(4)))
+        else:
+            tau = _tau_from_g(ctx, g2, g3)
+            G4, G6 = _eisenstein_G4_G6(ctx, tau)
+            omegaA = ctx.sqrt(g2/g3 * G6/G4 * ctx.mpf(7)/ctx.mpf(12))
+
+        omegaB = tau * omegaA
+        omegaC = omegaA + omegaB
+        omegas = [omegaA, omegaB, omegaC]
+        index_combos = [(0,1,2), (0,2,1), (1,0,2),
+                        (1,2,0), (2,0,1), (2,1,0)]
+
+        e1, e2, e3 = _roots_from_omega(ctx, omegaA, omegaB)
+        wps = []
+        for omegaN in omegas:
+            wps.append(ctx.weierp(omegaN, omega1=omegaA, omega2=omegaB))
+
+        maes = []
+        for ic in index_combos:
+            mae = (abs(e1 - wps[ic[0]]) + abs(e2 - wps[ic[1]]) +
+                   abs(e3 - wps[ic[2]])) / 3
+            maes.append(mae)
+
+        mae = min(maes)
+        min_index = maes.index(mae)
+
+        scale = max([ctx.one] + [abs(x) for x in [e1, e2, e3] + wps])
+        tolerance = ctx.sqrt(ctx.eps) * scale
+        if mae > tolerance: raise ValueError("weierhalfperiods: no convergence")
+
+        omega1, omega2 = [omegas[k] for k in index_combos[min_index]][:2]
+        if ctx.im(omega2/omega1) <= 0:
+            omega2 = -omega2
         return +omega1, +omega2
 
 
@@ -1817,7 +1737,15 @@ def weierp(ctx, z, g2=None, g3=None, tau=None, omega1=None, omega2=None):
     z = ctx.convert(z)
     omega1, tau = _weierstrass_omega_tau(ctx, "weierp", g2, g3, tau,
                                          omega1, omega2)
-    return _wp_from_tau_omega(ctx, z, omega1, tau)
+    z_norm = z / (2 * omega1)
+    q = ctx.qfrom(tau=tau)
+    j1z = ctx.jtheta(1, ctx.pi*z_norm, q)
+    j2 = ctx.jtheta(2, 0, q)
+    j3 = ctx.jtheta(3, 0, q)
+    j4z = ctx.jtheta(4, ctx.pi*z_norm, q)
+    wp_theta = ((ctx.pi*j2*j3*j4z/j1z)**2 -
+                ctx.pi**2 * (j2**4 + j3**4) / 3)
+    return wp_theta / omega1**2 / 4
 
 @defun_wrapped
 def weierpprime(ctx, z, g2=None, g3=None, tau=None,
@@ -1863,7 +1791,20 @@ def weierpprime(ctx, z, g2=None, g3=None, tau=None,
     z = ctx.convert(z)
     omega1, tau = _weierstrass_omega_tau(ctx, "weierpprime",
                                          g2, g3, tau, omega1, omega2)
-    return _wpprime_from_tau_omega(ctx, z, omega1, tau)
+    z_norm = z / (2 * omega1)
+    q = ctx.qfrom(tau=tau)
+    z1 = ctx.pi * z_norm
+    j10p = ctx.jtheta(1, 0, q, 1)
+    j20 = ctx.jtheta(2, 0, q)
+    j30 = ctx.jtheta(3, 0, q)
+    j40 = ctx.jtheta(4, 0, q)
+    k0 = j10p**3 / (j20 * j30 * j40)
+    j1z1 = ctx.jtheta(1, z1, q)
+    j2z1 = ctx.jtheta(2, z1, q)
+    j3z1 = ctx.jtheta(3, z1, q)
+    j4z1 = ctx.jtheta(4, z1, q)
+    kz = j2z1 * j3z1 * j4z1 / j1z1**3
+    return -ctx.pi**3 / (4 * omega1**3) * k0 * kz
 
 @defun_wrapped
 def weiersigma(ctx, z, g2=None, g3=None, tau=None,
@@ -2024,8 +1965,8 @@ def weierpinv(ctx, p, g2=None, g3=None, tau=None, omega1=None, omega2=None,
     # Optionally select sign based on derivative
     if weierp_prime is not None:
         weierp_prime = ctx.convert(weierp_prime)
-        wpprime_neg_z = _wpprime_from_tau_omega(ctx, -z, omega1, tau)
-        wpprime_pos_z = _wpprime_from_tau_omega(ctx, z, omega1, tau)
+        wpprime_neg_z = ctx.weierpprime(-z, omega1=omega1, omega2=omega2)
+        wpprime_pos_z = ctx.weierpprime(z, omega1=omega1, omega2=omega2)
 
         if (abs(wpprime_neg_z - weierp_prime) <
                 abs(wpprime_pos_z - weierp_prime)):

--- a/mpmath/functions/elliptic.py
+++ b/mpmath/functions/elliptic.py
@@ -1518,12 +1518,13 @@ def _eisenstein_G4_G6(ctx, tau):
     G6 = 2 * ctx.zeta(6) * E6
     return G4, G6
 
-def _inverse_kleinj(ctx, _j):
+def _inverse_kleinj(ctx, J):
     """
-    Compute tau from j-invariant using the inverse j-function.
+    Compute tau from Klein's J-invariant using the inverse j-function.
     See: https://en.wikipedia.org/wiki/J-invariant
     """
-    _j = ctx.convert(_j)
+    J = ctx.convert(J)
+    _j = 1728 * J
     sqrt_arg = 3*(1728*_j**2 - _j**3)
     exponent = ctx.mpf(1) / ctx.mpf(3)
     t = (-_j**3 + 2304*_j**2 - 884736*_j +
@@ -1536,12 +1537,12 @@ def _inverse_kleinj(ctx, _j):
 
 def _kleinj_from_g2g3(ctx, g2, g3):
     """
-    Klein-j invariant from g2, g3 (the 1728-normalized version).
+    Klein J-invariant from g2, g3.
     See: https://en.wikipedia.org/wiki/J-invariant
     """
     g2 = ctx.convert(g2)
     g3 = ctx.convert(g3)
-    return 1728 / (1 - 27*g3**2/g2**3)
+    return 1 / (1 - 27*g3**2/g2**3)
 
 def _tau_from_g(ctx, g2, g3):
     """
@@ -1549,8 +1550,8 @@ def _tau_from_g(ctx, g2, g3):
     """
     g2 = ctx.convert(g2)
     g3 = ctx.convert(g3)
-    j = _kleinj_from_g2g3(ctx, g2, g3)
-    tau = _inverse_kleinj(ctx, j)
+    J = _kleinj_from_g2g3(ctx, g2, g3)
+    tau = _inverse_kleinj(ctx, J)
     return tau
 
 def _weierstrass_omega_tau(ctx, funcname, g2=None, g3=None, tau=None,

--- a/mpmath/functions/elliptic.py
+++ b/mpmath/functions/elliptic.py
@@ -1537,8 +1537,9 @@ def _inverse_kleinj(ctx, J):
 
 def _kleinj_from_g2g3(ctx, g2, g3):
     """
-    Klein J-invariant from g2, g3.
-    See: https://en.wikipedia.org/wiki/J-invariant
+    Klein's absolute invariant J from g2, g3.
+    (Not the j one with 1728 factor)
+    https://mathworld.wolfram.com/KleinsAbsoluteInvariant.html
     """
     g2 = ctx.convert(g2)
     g3 = ctx.convert(g3)

--- a/mpmath/functions/elliptic.py
+++ b/mpmath/functions/elliptic.py
@@ -427,7 +427,6 @@ def kleinj(ctx, tau=None, **kwargs):
     The j-function has a famous Laurent series expansion in terms of the nome
     `\bar{q}`, `j(\tau) = \bar{q}^{-1} + 744 + 196884\bar{q} + \ldots`::
 
-        >>> mp.dps = 15
         >>> taylor(lambda q: 1728*q*kleinj(qbar=q), 0, 5, singular=True)
         [1.0, 744.0, 196884.0, 21493760.0, 864299970.0, 20245856256.0]
 
@@ -1481,15 +1480,6 @@ def ellippi(ctx, *args):
 # Weierstrass Elliptic Functions
 # ============================================================================
 
-def _complex_sort(ctx, list_of_mpcs, ascending=True):
-    """
-    Sorts a list of complex numbers first by real part,
-    then by imaginary part where real parts are equal.
-    """
-    sorted_list = sorted([(c.real, c.imag) for c in list_of_mpcs],
-                         reverse=not ascending)
-    return [ctx.mpc(real=t[0], imag=t[1]) for t in sorted_list]
-
 def _roots_from_omega(ctx, omega1, omega2):
     """
     Compute roots e1, e2, e3 of 4*z^3 - g2*z - g3 = 0 using theta functions.
@@ -1503,7 +1493,8 @@ def _roots_from_omega(ctx, omega1, omega2):
     e1 = c * (j24 + 2*j44)
     e2 = c * (j24 - j44)
     e3 = -c * (2*j24 + j44)
-    return _complex_sort(ctx, [e1, e2, e3], ascending=False)
+    roots = sorted([(e.real, e.imag) for e in [e1, e2, e3]], reverse=True)
+    return [ctx.mpc(real=t[0], imag=t[1]) for t in roots]
 
 def _eisenstein_E4_E6(ctx, tau):
     """
@@ -1546,6 +1537,7 @@ def _inverse_kleinj(ctx, _j):
 def _kleinj_from_g2g3(ctx, g2, g3):
     """
     Klein-j invariant from g2, g3 (the 1728-normalized version).
+    See: https://en.wikipedia.org/wiki/J-invariant
     """
     g2 = ctx.convert(g2)
     g3 = ctx.convert(g3)
@@ -1561,14 +1553,10 @@ def _tau_from_g(ctx, g2, g3):
     tau = _inverse_kleinj(ctx, j)
     return tau
 
-def _omega_from_g(ctx, g2, g3, tolerance=None):
+def _omega_from_g(ctx, g2, g3):
     """
     Compute half-periods (omega1, omega2) from invariants g2, g3.
     """
-    if tolerance is None:
-        # Start with relaxed tolerance; can be tightened with higher precision
-        tolerance = 0.2
-
     g2 = ctx.convert(g2)
     g3 = ctx.convert(g3)
 
@@ -1604,15 +1592,16 @@ def _omega_from_g(ctx, g2, g3, tolerance=None):
 
     maes = []
     for ic in index_combos:
-        mae = (ctx.fabs(e1 - wps[ic[0]]) + ctx.fabs(e2 - wps[ic[1]]) +
-               ctx.fabs(e3 - wps[ic[2]])) / 3
+        mae = (abs(e1 - wps[ic[0]]) + abs(e2 - wps[ic[1]]) +
+               abs(e3 - wps[ic[2]])) / 3
         maes.append(mae)
 
     mae = min(maes)
     min_index = maes.index(mae)
 
-    if mae > tolerance:
-        raise ValueError("weierhalfperiods: convergence tolerance not met")
+    scale = max([ctx.one] + [abs(x) for x in [e1, e2, e3] + wps])
+    tolerance = ctx.sqrt(ctx.eps) * scale
+    if mae > tolerance: raise ValueError("weierhalfperiods: no convergence")
 
     omega1, omega2, omega3 = [omegas[k] for k in index_combos[min_index]]
 
@@ -1639,20 +1628,21 @@ def _g_from_omega(ctx, omega1, omega2):
            j3**12))
     return g2, g3
 
-def _weierstrass_omega_tau(ctx, funcname, g2=None, g3=None,
-                           tau=None, omega=None):
+def _weierstrass_omega_tau(ctx, funcname, g2=None, g3=None, tau=None,
+                           omega1=None, omega2=None):
     """
     Resolve one Weierstrass parameterization to (omega1, tau).
     """
     if (g2 is None) != (g3 is None):
         raise ValueError("%s: must provide both g2 and g3" % funcname)
+    if (omega1 is None) != (omega2 is None):
+        raise ValueError("%s: must provide both omega1 and omega2" % funcname)
     parameter_count = (int(g2 is not None) + int(tau is not None) +
-                       int(omega is not None))
+                       int(omega1 is not None))
     if parameter_count != 1:
         raise ValueError("%s: must provide exactly one of g2, g3; "
-                         "omega; or tau" % funcname)
-    if omega is not None:
-        omega1, omega2 = omega
+                         "omega1, omega2; or tau" % funcname)
+    if omega1 is not None:
         omega1 = ctx.convert(omega1)
         omega2 = ctx.convert(omega2)
         tau = omega2 / omega1
@@ -1767,25 +1757,20 @@ def _wzeta_from_tau_omega(ctx, z, omega1, tau_or_omega2):
 # ============================================================================
 
 @defun
-def weierinvariants(ctx, omega):
+def weierinvariants(ctx, omega1, omega2):
     r"""
     Returns the Weierstrass invariants `(g_2, g_3)` corresponding to
     the half-periods `(\omega_1, \omega_2)`::
 
         >>> from mpmath import mp, chop, weierinvariants
-        >>> mp.dps = 15
         >>> mp.pretty = True
-        >>> g2, g3 = weierinvariants((1, 0.5j))
+        >>> g2, g3 = weierinvariants(1, 0.5j)
         >>> chop(g2)
         129.987495088848
         >>> chop(g3)
         -284.355330876541
 
     """
-    try:
-        omega1, omega2 = omega
-    except (TypeError, ValueError):
-        raise ValueError("weierinvariants: expected a pair of half-periods")
     prec = ctx.prec
     try:
         ctx.prec += 10
@@ -1800,27 +1785,22 @@ def weierinvariants(ctx, omega):
     return +g2, +g3
 
 @defun
-def weierhalfperiods(ctx, g):
+def weierhalfperiods(ctx, g2, g3):
     r"""
     Returns a pair of fundamental half-periods `(\omega_1, \omega_2)`
     corresponding to the Weierstrass invariants `(g_2, g_3)`::
 
         >>> from mpmath import mp, chop
         >>> from mpmath import weierhalfperiods, weierinvariants
-        >>> mp.dps = 15
         >>> mp.pretty = True
-        >>> omega1, omega2 = weierhalfperiods((60, 140))
-        >>> g2, g3 = weierinvariants((omega1, omega2))
+        >>> omega1, omega2 = weierhalfperiods(60, 140)
+        >>> g2, g3 = weierinvariants(omega1, omega2)
         >>> chop(g2), chop(g3)
         (60.0, 140.0)
         >>> chop(omega2/omega1)
         (0.5 + 0.209032224450873j)
 
     """
-    try:
-        g2, g3 = g
-    except (TypeError, ValueError):
-        raise ValueError("weierhalfperiods: expected a pair of invariants")
     prec = ctx.prec
     try:
         ctx.prec += 10
@@ -1835,7 +1815,7 @@ def weierhalfperiods(ctx, g):
 # ============================================================================
 
 @defun_wrapped
-def weierp(ctx, z, g2=None, g3=None, tau=None, omega=None):
+def weierp(ctx, z, g2=None, g3=None, tau=None, omega1=None, omega2=None):
     r"""
     Weierstrass elliptic function `\wp(z; g_2, g_3)`.
 
@@ -1844,23 +1824,27 @@ def weierp(ctx, z, g2=None, g3=None, tau=None, omega=None):
 
     .. math::
 
-        (\wp')^2 = 4\wp^3 - g_2 \wp - g_3
+        (\wp'(z))^2 = 4\wp(z)^3 - g_2 \wp(z) - g_3
 
-    The function can be parameterized in multiple ways:
-    - via `g_2, g_3` (elliptic invariants)
-    - via `\omega_1, \omega_2` (half-periods)
-    - via `\tau`, using normalized periods `(1, \tau)`
+    The function may be parameterized in any one of the following ways:
+
+    - by the elliptic invariants `g_2, g_3`;
+    - by the half-periods `\omega_1, \omega_2`;
+    - by `\tau`, corresponding to the normalized half-periods
+    `\omega_1 = 1/2`, `\omega_2 = \tau/2`.
+
+    The periods of `\wp` are `2\omega_1` and `2\omega_2`. Thus the
+    `\tau` parameterization corresponds to periods `1` and `\tau`.
 
     For repeated evaluation with the same invariants, it is faster to compute
     the half-periods once with :func:`~mpmath.weierhalfperiods` and pass them
-    using the `omega` keyword.
+    using the `omega1` and `omega2` keywords.
 
     **Examples**
 
     Direct computation with invariants::
 
         >>> from mpmath import mp, weierp, chop
-        >>> mp.dps = 15
         >>> mp.pretty = True
         >>> chop(weierp(0.5, g2=60, g3=140))
         5.12943876105856
@@ -1872,27 +1856,35 @@ def weierp(ctx, z, g2=None, g3=None, tau=None, omega=None):
 
     **References**
 
-    - DLMF Section 23.2: https://dlmf.nist.gov/23.2
-    - Weierstrass, K. (1895)
+    - [DLMF]_ Chapter 23: Weierstrass Elliptic and Modular Functions (23.2.4)
 
     """
     z = ctx.convert(z)
-    omega1, tau = _weierstrass_omega_tau(ctx, "weierp", g2, g3, tau, omega)
+    omega1, tau = _weierstrass_omega_tau(ctx, "weierp", g2, g3, tau,
+                                         omega1, omega2)
     return _wp_from_tau_omega(ctx, z, omega1, tau)
 
 @defun_wrapped
-def weierpprime(ctx, z, g2=None, g3=None, tau=None, omega=None):
+def weierpprime(ctx, z, g2=None, g3=None, tau=None,
+                omega1=None, omega2=None):
     r"""
     Derivative of Weierstrass elliptic function `\wp'(z; g_2, g_3)`.
 
-    Computes the derivative of the Weierstrass P-function.
+    Computes the derivative of the Weierstrass P-function. It satisfies
+
+    .. math::
+
+        (\wp'(z))^2 = 4\wp(z)^3 - g_2 \wp(z) - g_3
+
+    The function accepts the same parameterizations as :func:`~mpmath.weierp`:
+    the invariants `g_2, g_3`, the half-periods `\omega_1, \omega_2`, or
+    `\tau`, corresponding to normalized periods `1` and `\tau`.
 
     **Examples**
 
     Compute derivative::
 
         >>> from mpmath import mp, weierpprime, chop
-        >>> mp.dps = 15
         >>> mp.pretty = True
         >>> chop(weierpprime(0.5, g2=60, g3=140))
         -9.5957928748663
@@ -1900,7 +1892,6 @@ def weierpprime(ctx, z, g2=None, g3=None, tau=None, omega=None):
     Verify differential equation::
 
         >>> from mpmath import mp, weierp, weierpprime
-        >>> mp.dps = 15
         >>> z = 0.5
         >>> g2, g3 = 60, 140
         >>> lhs = weierpprime(z, g2=g2, g3=g3)**2
@@ -1909,79 +1900,132 @@ def weierpprime(ctx, z, g2=None, g3=None, tau=None, omega=None):
         >>> mp.almosteq(lhs, rhs)
         True
 
+    **References**
+
+    - [DLMF]_ Chapter 23: Weierstrass Elliptic and Modular Functions (23.3.10)
+
     """
     z = ctx.convert(z)
     omega1, tau = _weierstrass_omega_tau(ctx, "weierpprime",
-                                         g2, g3, tau, omega)
+                                         g2, g3, tau, omega1, omega2)
     return _wpprime_from_tau_omega(ctx, z, omega1, tau)
 
 @defun_wrapped
-def weiersigma(ctx, z, g2=None, g3=None, tau=None, omega=None):
+def weiersigma(ctx, z, g2=None, g3=None, tau=None,
+               omega1=None, omega2=None):
     r"""
     Weierstrass sigma function `\sigma(z; g_2, g_3)`.
 
-    The Weierstrass sigma function is related to the P-function by:
+    The Weierstrass sigma function is related to the P-function and zeta
+    function by
 
     .. math::
 
-        \wp(z) = -\frac{d^2}{dz^2} \ln \sigma(z)
+        \zeta(z) = \frac{d}{dz} \log \sigma(z)
+
+    and
+
+    .. math::
+
+        \wp(z) = -\frac{d^2}{dz^2} \log \sigma(z).
+
+    The function accepts the same parameterizations as :func:`~mpmath.weierp`:
+    the invariants `g_2, g_3`, the half-periods `\omega_1, \omega_2`, or
+    `\tau`, corresponding to normalized periods `1` and `\tau`.
 
     **Examples**
 
     Compute sigma function::
 
         >>> from mpmath import mp, weiersigma, chop
-        >>> mp.dps = 15
         >>> mp.pretty = True
         >>> chop(weiersigma(0.5, g2=60, g3=140))
         0.490839927387142
 
+    **References**
+
+    - [DLMF]_ Chapter 23: Weierstrass Elliptic and Modular Functions (23.2.6)
+
     """
     z = ctx.convert(z)
     omega1, tau = _weierstrass_omega_tau(ctx, "weiersigma",
-                                         g2, g3, tau, omega)
+                                         g2, g3, tau, omega1, omega2)
     return _wsigma_from_tau_omega(ctx, z, omega1, tau)
 
 @defun_wrapped
-def weierzeta(ctx, z, g2=None, g3=None, tau=None, omega=None):
+def weierzeta(ctx, z, g2=None, g3=None, tau=None,
+              omega1=None, omega2=None):
     r"""
     Weierstrass zeta function `\zeta(z; g_2, g_3)`.
 
-    The Weierstrass zeta function is related to the P and sigma functions.
-    It is quasi-periodic (not doubly periodic).
+    The Weierstrass zeta function is related to the sigma function and
+    P-function by
+
+    .. math::
+
+        \zeta(z) = \frac{d}{dz} \log \sigma(z)
+
+    and
+
+    .. math::
+
+        \zeta'(z) = -\wp(z).
+
+    Unlike `\wp`, the zeta function is quasi-periodic rather than doubly
+    periodic.
+
+    The function accepts the same parameterizations as :func:`~mpmath.weierp`:
+    the invariants `g_2, g_3`, the half-periods `\omega_1, \omega_2`, or
+    `\tau`, corresponding to normalized periods `1` and `\tau`.
 
     **Examples**
 
     Compute zeta function::
 
         >>> from mpmath import mp, weierzeta, chop
-        >>> mp.dps = 15
         >>> mp.pretty = True
         >>> chop(weierzeta(0.5, g2=60, g3=140))
         1.83933548687454
 
+    **References**
+
+    - [DLMF]_ Chapter 23: Weierstrass Elliptic and Modular Functions (23.2.5)
+
     """
     z = ctx.convert(z)
     omega1, tau = _weierstrass_omega_tau(ctx, "weierzeta",
-                                         g2, g3, tau, omega)
+                                         g2, g3, tau, omega1, omega2)
     return _wzeta_from_tau_omega(ctx, z, omega1, tau)
 
 @defun_wrapped
-def weierpinv(ctx, p, g2=None, g3=None, tau=None, omega=None,
+def weierpinv(ctx, p, g2=None, g3=None, tau=None, omega1=None, omega2=None,
               weierp_prime=None):
     r"""
     Inverse Weierstrass elliptic function.
 
-    Computes `z` such that `\wp(z; g_2, g_3) = p`, using Carlson's
-    symmetric integral.
+    Computes `z` such that
+
+    .. math::
+
+        \wp(z; g_2, g_3) = p,
+
+    using Carlson's symmetric integral.
+
+    The function accepts the same parameterizations as :func:`~mpmath.weierp`:
+    the invariants `g_2, g_3`, the half-periods `\omega_1, \omega_2`, or
+    `\tau`, corresponding to normalized periods `1` and `\tau`.
+
+    The inverse is multivalued up to periods and sign. If `weierp_prime` is
+    provided, it is used to choose between `z` and `-z` by matching the
+    corresponding value of `\wp'(z)`.
 
     **Parameters**
 
     - `p`: the target value
     - `g2, g3`: elliptic invariants
-    - `tau` or `omega`: alternative parameterizations
-    - `weierp_prime` (optional): if provided, attempts to select the correct
-      sign of `z`
+    - `tau` or `omega1, omega2`: alternative parameterizations
+    - `weierp_prime` (optional): derivative value used to choose the sign of
+    the inverse
 
     **Examples**
 
@@ -1996,10 +2040,14 @@ def weierpinv(ctx, p, g2=None, g3=None, tau=None, omega=None,
         >>> mp.almosteq(z0, z_recovered)  # May differ by periods
         True
 
+    **References**
+
+    - [DLMF]_ Chapter 19: Elliptic Integrals (19.25.35)
+
     """
     p = ctx.convert(p)
     omega1, tau = _weierstrass_omega_tau(ctx, "weierpinv",
-                                         g2, g3, tau, omega)
+                                         g2, g3, tau, omega1, omega2)
     omega2 = omega1 * tau
     e1, e2, e3 = _roots_from_omega(ctx, omega1, omega2)
 
@@ -2012,8 +2060,8 @@ def weierpinv(ctx, p, g2=None, g3=None, tau=None, omega=None,
         wpprime_neg_z = _wpprime_from_tau_omega(ctx, -z, omega1, tau)
         wpprime_pos_z = _wpprime_from_tau_omega(ctx, z, omega1, tau)
 
-        if (ctx.fabs(wpprime_neg_z - weierp_prime) <
-                ctx.fabs(wpprime_pos_z - weierp_prime)):
+        if (abs(wpprime_neg_z - weierp_prime) <
+                abs(wpprime_pos_z - weierp_prime)):
             return -z
 
     return z

--- a/mpmath/functions/elliptic.py
+++ b/mpmath/functions/elliptic.py
@@ -1715,43 +1715,6 @@ def _wpprime_from_tau_omega(ctx, z, omega1, tau_or_omega2):
     wpprime_val = -ctx.pi**3 / (4 * omega1**3) * k0 * kz
     return wpprime_val
 
-def _wsigma_from_tau_omega(ctx, z, omega1, tau_or_omega2):
-    """
-    Weierstrass sigma function.
-    """
-    z = ctx.convert(z)
-    omega1 = ctx.convert(omega1)
-    tau = ctx.convert(tau_or_omega2)
-
-    z1 = ctx.pi * z / (2 * omega1)
-    q = ctx.qfrom(tau=tau)
-    j10p = ctx.jtheta(1, 0, q, 1)
-    j10ppp = ctx.jtheta(1, 0, q, 3)
-    j1z1 = ctx.jtheta(1, z1, q)
-
-    w_sigma = (2 * omega1 / (ctx.pi * j10p) *
-               ctx.exp(-z1**2 * j10ppp / (6 * j10p)) * j1z1)
-    return w_sigma
-
-def _wzeta_from_tau_omega(ctx, z, omega1, tau_or_omega2):
-    """
-    Weierstrass zeta function.
-    """
-    z = ctx.convert(z)
-    omega1 = ctx.convert(omega1)
-    tau = ctx.convert(tau_or_omega2)
-
-    w1 = -omega1 / ctx.pi
-    q = ctx.qfrom(tau=tau)
-    p = 1 / 2 / w1
-    eta1 = p / 6 / w1 * ctx.jtheta(1, 0, q, 3) / ctx.jtheta(1, 0, q, 1)
-
-    j1pz = ctx.jtheta(1, p*z, q, 1)
-    j1z = ctx.jtheta(1, p*z, q)
-
-    return -eta1 * z + p * j1pz / j1z
-
-
 # ============================================================================
 # Weierstrass parameter conversion functions
 # ============================================================================
@@ -1771,18 +1734,14 @@ def weierinvariants(ctx, omega1, omega2):
         -284.355330876541
 
     """
-    prec = ctx.prec
-    try:
-        ctx.prec += 10
+    with ctx.extraprec(10):
         omega1 = ctx.convert(omega1)
         omega2 = ctx.convert(omega2)
         if ctx.im(omega2/omega1) <= 0:
             raise ValueError("weierinvariants: omega ratio must be "
                              "in upper half-plane")
         g2, g3 = _g_from_omega(ctx, omega1, omega2)
-    finally:
-        ctx.prec = prec
-    return +g2, +g3
+        return +g2, +g3
 
 @defun
 def weierhalfperiods(ctx, g2, g3):
@@ -1801,13 +1760,9 @@ def weierhalfperiods(ctx, g2, g3):
         (0.5 + 0.209032224450873j)
 
     """
-    prec = ctx.prec
-    try:
-        ctx.prec += 10
+    with ctx.extraprec(10):
         omega1, omega2 = _omega_from_g(ctx, g2, g3)[:2]
-    finally:
-        ctx.prec = prec
-    return +omega1, +omega2
+        return +omega1, +omega2
 
 
 # ============================================================================
@@ -1950,7 +1905,13 @@ def weiersigma(ctx, z, g2=None, g3=None, tau=None,
     z = ctx.convert(z)
     omega1, tau = _weierstrass_omega_tau(ctx, "weiersigma",
                                          g2, g3, tau, omega1, omega2)
-    return _wsigma_from_tau_omega(ctx, z, omega1, tau)
+    z1 = ctx.pi * z / (2 * omega1)
+    q = ctx.qfrom(tau=tau)
+    j10p = ctx.jtheta(1, 0, q, 1)
+    j10ppp = ctx.jtheta(1, 0, q, 3)
+    j1z1 = ctx.jtheta(1, z1, q)
+    return (2 * omega1 / (ctx.pi * j10p) *
+            ctx.exp(-z1**2 * j10ppp / (6 * j10p)) * j1z1)
 
 @defun_wrapped
 def weierzeta(ctx, z, g2=None, g3=None, tau=None,
@@ -1995,7 +1956,13 @@ def weierzeta(ctx, z, g2=None, g3=None, tau=None,
     z = ctx.convert(z)
     omega1, tau = _weierstrass_omega_tau(ctx, "weierzeta",
                                          g2, g3, tau, omega1, omega2)
-    return _wzeta_from_tau_omega(ctx, z, omega1, tau)
+    w1 = -omega1 / ctx.pi
+    q = ctx.qfrom(tau=tau)
+    p = 1 / 2 / w1
+    eta1 = p / 6 / w1 * ctx.jtheta(1, 0, q, 3) / ctx.jtheta(1, 0, q, 1)
+    j1pz = ctx.jtheta(1, p*z, q, 1)
+    j1z = ctx.jtheta(1, p*z, q)
+    return -eta1 * z + p * j1pz / j1z
 
 @defun_wrapped
 def weierpinv(ctx, p, g2=None, g3=None, tau=None, omega1=None, omega2=None,

--- a/mpmath/functions/elliptic.py
+++ b/mpmath/functions/elliptic.py
@@ -1860,9 +1860,13 @@ def wp(ctx, z, g2=None, g3=None, tau=None, omega=None):
         (\wp')^2 = 4\wp^3 - g_2 \wp - g_3
 
     The function can be parameterized in multiple ways:
-    - via `g_2, g_3` (elliptic invariants) - recommended
+    - via `g_2, g_3` (elliptic invariants)
     - via `\omega_1, \omega_2` (half-periods)
     - via `\tau` (half-period ratio)
+
+    For repeated evaluation with the same invariants, it is faster to compute
+    the half-periods once with :func:`~mpmath.w_half_periods` and pass them
+    using the `omega` keyword.
 
     **Examples**
 
@@ -1983,7 +1987,7 @@ def invwp(ctx, p, g2=None, g3=None, tau=None, omega=None, w_prime=None):
     **Parameters**
 
     - `p`: the target value
-    - `g2, g3`: elliptic invariants (recommended)
+    - `g2, g3`: elliptic invariants
     - `tau` or `omega`: alternative parameterizations
     - `w_prime` (optional): if provided, attempts to select the correct sign
       of `z`

--- a/mpmath/functions/elliptic.py
+++ b/mpmath/functions/elliptic.py
@@ -1612,7 +1612,7 @@ def _omega_from_g(ctx, g2, g3, tolerance=None):
     min_index = maes.index(mae)
 
     if mae > tolerance:
-        raise ValueError("omega_from_g: convergence tolerance not met")
+        raise ValueError("weierhalfperiods: convergence tolerance not met")
 
     omega1, omega2, omega3 = [omegas[k] for k in index_combos[min_index]]
 
@@ -1664,13 +1664,13 @@ def _weierstrass_omega_tau(ctx, funcname, g2=None, g3=None,
         tau = ctx.convert(tau)
         if ctx.im(tau) <= 0:
             raise ValueError("%s: tau must be in upper half-plane" % funcname)
-        return ctx.one, tau
+        return ctx.one/2, tau
     omega1, omega2 = _omega_from_g(ctx, g2, g3)[:2]
     return omega1, omega2 / omega1
 
 def _wp_from_tau_omega(ctx, z, omega1, tau_or_omega2):
     """
-    Internal: Weierstrass P function using tau or omega.
+    Weierstrass P function using tau or omega.
     Computes wp(z; omega1, tau or omega2)
 
     Following the convention:
@@ -1698,7 +1698,7 @@ def _wp_from_tau_omega(ctx, z, omega1, tau_or_omega2):
 
 def _wpprime_from_tau_omega(ctx, z, omega1, tau_or_omega2):
     """
-    Internal: Weierstrass P' function using tau or omega.
+    Weierstrass P' function using tau or omega.
     Computes wp'(z; omega1, tau or omega2)
     """
     z = ctx.convert(z)
@@ -1727,7 +1727,7 @@ def _wpprime_from_tau_omega(ctx, z, omega1, tau_or_omega2):
 
 def _wsigma_from_tau_omega(ctx, z, omega1, tau_or_omega2):
     """
-    Internal: Weierstrass sigma function.
+    Weierstrass sigma function.
     """
     z = ctx.convert(z)
     omega1 = ctx.convert(omega1)
@@ -1745,7 +1745,7 @@ def _wsigma_from_tau_omega(ctx, z, omega1, tau_or_omega2):
 
 def _wzeta_from_tau_omega(ctx, z, omega1, tau_or_omega2):
     """
-    Internal: Weierstrass zeta function.
+    Weierstrass zeta function.
     """
     z = ctx.convert(z)
     omega1 = ctx.convert(omega1)
@@ -1767,15 +1767,15 @@ def _wzeta_from_tau_omega(ctx, z, omega1, tau_or_omega2):
 # ============================================================================
 
 @defun
-def w_invariants(ctx, omega1, omega2=None):
+def weierinvariants(ctx, omega1, omega2=None):
     r"""
     Returns the Weierstrass invariants `(g_2, g_3)` corresponding to
     the half-periods `(\omega_1, \omega_2)`::
 
-        >>> from mpmath import mp, chop, w_invariants
+        >>> from mpmath import mp, chop, weierinvariants
         >>> mp.dps = 15
         >>> mp.pretty = True
-        >>> g2, g3 = w_invariants(1, 0.5j)
+        >>> g2, g3 = weierinvariants(1, 0.5j)
         >>> chop(g2)
         129.987495088848
         >>> chop(g3)
@@ -1783,7 +1783,7 @@ def w_invariants(ctx, omega1, omega2=None):
 
     The half-periods may also be passed as a single pair::
 
-        >>> w_invariants((1, 0.5j))[1]
+        >>> weierinvariants((1, 0.5j))[1]
         (-284.355330876541 + 0.0j)
 
     """
@@ -1791,7 +1791,7 @@ def w_invariants(ctx, omega1, omega2=None):
         try:
             omega1, omega2 = omega1
         except (TypeError, ValueError):
-            raise ValueError("w_invariants: expected "
+            raise ValueError("weierinvariants: expected "
                              "omega1, omega2 or a pair of half-periods")
     prec = ctx.prec
     try:
@@ -1799,7 +1799,7 @@ def w_invariants(ctx, omega1, omega2=None):
         omega1 = ctx.convert(omega1)
         omega2 = ctx.convert(omega2)
         if ctx.im(omega2/omega1) <= 0:
-            raise ValueError("w_invariants: omega ratio must be "
+            raise ValueError("weierinvariants: omega ratio must be "
                              "in upper half-plane")
         g2, g3 = _g_from_omega(ctx, omega1, omega2)
     finally:
@@ -1807,23 +1807,23 @@ def w_invariants(ctx, omega1, omega2=None):
     return +g2, +g3
 
 @defun
-def w_half_periods(ctx, g2, g3=None):
+def weierhalfperiods(ctx, g2, g3=None):
     r"""
     Returns a pair of fundamental half-periods `(\omega_1, \omega_2)`
     corresponding to the Weierstrass invariants `(g_2, g_3)`::
 
         >>> from mpmath import mp, chop
-        >>> from mpmath import w_half_periods, w_invariants
+        >>> from mpmath import weierhalfperiods, weierinvariants
         >>> mp.dps = 15
         >>> mp.pretty = True
-        >>> omega1, omega2 = w_half_periods(60, 140)
-        >>> g2, g3 = w_invariants(omega1, omega2)
+        >>> omega1, omega2 = weierhalfperiods(60, 140)
+        >>> g2, g3 = weierinvariants(omega1, omega2)
         >>> chop(g2), chop(g3)
         (60.0, 140.0)
 
     The invariants may also be passed as a single pair::
 
-        >>> omega1, omega2 = w_half_periods((60, 140))
+        >>> omega1, omega2 = weierhalfperiods((60, 140))
         >>> chop(omega2/omega1)
         (0.5 + 0.209032224450873j)
 
@@ -1832,7 +1832,7 @@ def w_half_periods(ctx, g2, g3=None):
         try:
             g2, g3 = g2
         except (TypeError, ValueError):
-            raise ValueError("w_half_periods: expected "
+            raise ValueError("weierhalfperiods: expected "
                              "g2, g3 or a pair of invariants")
     prec = ctx.prec
     try:
@@ -1848,7 +1848,7 @@ def w_half_periods(ctx, g2, g3=None):
 # ============================================================================
 
 @defun_wrapped
-def wp(ctx, z, g2=None, g3=None, tau=None, omega=None):
+def weierp(ctx, z, g2=None, g3=None, tau=None, omega=None):
     r"""
     Weierstrass elliptic function `\wp(z; g_2, g_3)`.
 
@@ -1862,26 +1862,26 @@ def wp(ctx, z, g2=None, g3=None, tau=None, omega=None):
     The function can be parameterized in multiple ways:
     - via `g_2, g_3` (elliptic invariants)
     - via `\omega_1, \omega_2` (half-periods)
-    - via `\tau` (half-period ratio)
+    - via `\tau`, using normalized periods `(1, \tau)`
 
     For repeated evaluation with the same invariants, it is faster to compute
-    the half-periods once with :func:`~mpmath.w_half_periods` and pass them
+    the half-periods once with :func:`~mpmath.weierhalfperiods` and pass them
     using the `omega` keyword.
 
     **Examples**
 
     Direct computation with invariants::
 
-        >>> from mpmath import mp, wp, chop
+        >>> from mpmath import mp, weierp, chop
         >>> mp.dps = 15
         >>> mp.pretty = True
-        >>> chop(wp(0.5, g2=60, g3=140))
+        >>> chop(weierp(0.5, g2=60, g3=140))
         5.12943876105856
 
     Using tau parameterization::
 
-        >>> chop(wp(0.5, tau=0.5j))
-        5.15638936351528
+        >>> chop(weierp(0.5, tau=0.5j))
+        13.7503716360407
 
     **References**
 
@@ -1890,11 +1890,11 @@ def wp(ctx, z, g2=None, g3=None, tau=None, omega=None):
 
     """
     z = ctx.convert(z)
-    omega1, tau = _weierstrass_omega_tau(ctx, "wp", g2, g3, tau, omega)
+    omega1, tau = _weierstrass_omega_tau(ctx, "weierp", g2, g3, tau, omega)
     return _wp_from_tau_omega(ctx, z, omega1, tau)
 
 @defun_wrapped
-def wpprime(ctx, z, g2=None, g3=None, tau=None, omega=None):
+def weierpprime(ctx, z, g2=None, g3=None, tau=None, omega=None):
     r"""
     Derivative of Weierstrass elliptic function `\wp'(z; g_2, g_3)`.
 
@@ -1904,31 +1904,32 @@ def wpprime(ctx, z, g2=None, g3=None, tau=None, omega=None):
 
     Compute derivative::
 
-        >>> from mpmath import mp, wpprime, chop
+        >>> from mpmath import mp, weierpprime, chop
         >>> mp.dps = 15
         >>> mp.pretty = True
-        >>> chop(wpprime(0.5, g2=60, g3=140))
+        >>> chop(weierpprime(0.5, g2=60, g3=140))
         -9.5957928748663
 
     Verify differential equation::
 
-        >>> from mpmath import mp, wp, wpprime
+        >>> from mpmath import mp, weierp, weierpprime
         >>> mp.dps = 15
         >>> z = 0.5
         >>> g2, g3 = 60, 140
-        >>> # Should satisfy: (wp')^2 = 4*wp^3 - g2*wp - g3
-        >>> lhs = wpprime(z, g2=g2, g3=g3)**2
-        >>> rhs = 4*wp(z, g2=g2, g3=g3)**3 - g2*wp(z, g2=g2, g3=g3) - g3
+        >>> lhs = weierpprime(z, g2=g2, g3=g3)**2
+        >>> rhs = 4*weierp(z, g2=g2, g3=g3)**3
+        >>> rhs -= g2*weierp(z, g2=g2, g3=g3) + g3
         >>> mp.almosteq(lhs, rhs)
         True
 
     """
     z = ctx.convert(z)
-    omega1, tau = _weierstrass_omega_tau(ctx, "wpprime", g2, g3, tau, omega)
+    omega1, tau = _weierstrass_omega_tau(ctx, "weierpprime",
+                                         g2, g3, tau, omega)
     return _wpprime_from_tau_omega(ctx, z, omega1, tau)
 
 @defun_wrapped
-def wsigma(ctx, z, g2=None, g3=None, tau=None, omega=None):
+def weiersigma(ctx, z, g2=None, g3=None, tau=None, omega=None):
     r"""
     Weierstrass sigma function `\sigma(z; g_2, g_3)`.
 
@@ -1942,19 +1943,20 @@ def wsigma(ctx, z, g2=None, g3=None, tau=None, omega=None):
 
     Compute sigma function::
 
-        >>> from mpmath import mp, wsigma, chop
+        >>> from mpmath import mp, weiersigma, chop
         >>> mp.dps = 15
         >>> mp.pretty = True
-        >>> chop(wsigma(0.5, g2=60, g3=140))
+        >>> chop(weiersigma(0.5, g2=60, g3=140))
         0.490839927387142
 
     """
     z = ctx.convert(z)
-    omega1, tau = _weierstrass_omega_tau(ctx, "wsigma", g2, g3, tau, omega)
+    omega1, tau = _weierstrass_omega_tau(ctx, "weiersigma",
+                                         g2, g3, tau, omega)
     return _wsigma_from_tau_omega(ctx, z, omega1, tau)
 
 @defun_wrapped
-def wzeta(ctx, z, g2=None, g3=None, tau=None, omega=None):
+def weierzeta(ctx, z, g2=None, g3=None, tau=None, omega=None):
     r"""
     Weierstrass zeta function `\zeta(z; g_2, g_3)`.
 
@@ -1965,19 +1967,21 @@ def wzeta(ctx, z, g2=None, g3=None, tau=None, omega=None):
 
     Compute zeta function::
 
-        >>> from mpmath import mp, wzeta, chop
+        >>> from mpmath import mp, weierzeta, chop
         >>> mp.dps = 15
         >>> mp.pretty = True
-        >>> chop(wzeta(0.5, g2=60, g3=140))
+        >>> chop(weierzeta(0.5, g2=60, g3=140))
         1.83933548687454
 
     """
     z = ctx.convert(z)
-    omega1, tau = _weierstrass_omega_tau(ctx, "wzeta", g2, g3, tau, omega)
+    omega1, tau = _weierstrass_omega_tau(ctx, "weierzeta",
+                                         g2, g3, tau, omega)
     return _wzeta_from_tau_omega(ctx, z, omega1, tau)
 
 @defun_wrapped
-def invwp(ctx, p, g2=None, g3=None, tau=None, omega=None, w_prime=None):
+def weierpinv(ctx, p, g2=None, g3=None, tau=None, omega=None,
+              weierp_prime=None):
     r"""
     Inverse Weierstrass elliptic function.
 
@@ -1989,25 +1993,26 @@ def invwp(ctx, p, g2=None, g3=None, tau=None, omega=None, w_prime=None):
     - `p`: the target value
     - `g2, g3`: elliptic invariants
     - `tau` or `omega`: alternative parameterizations
-    - `w_prime` (optional): if provided, attempts to select the correct sign
-      of `z`
+    - `weierp_prime` (optional): if provided, attempts to select the correct
+      sign of `z`
 
     **Examples**
 
     Find preimage under Weierstrass P::
 
-        >>> from mpmath import mp, wp, invwp
+        >>> from mpmath import mp, weierp, weierpinv
         >>> mp.dps = 25
         >>> z0 = 0.5
         >>> g2, g3 = 60, 140
-        >>> p_val = wp(z0, g2=g2, g3=g3)
-        >>> z_recovered = invwp(p_val, g2=g2, g3=g3)
+        >>> p_val = weierp(z0, g2=g2, g3=g3)
+        >>> z_recovered = weierpinv(p_val, g2=g2, g3=g3)
         >>> mp.almosteq(z0, z_recovered)  # May differ by periods
         True
 
     """
     p = ctx.convert(p)
-    omega1, tau = _weierstrass_omega_tau(ctx, "invwp", g2, g3, tau, omega)
+    omega1, tau = _weierstrass_omega_tau(ctx, "weierpinv",
+                                         g2, g3, tau, omega)
     omega2 = omega1 * tau
     e1, e2, e3 = _roots_from_omega(ctx, omega1, omega2)
 
@@ -2015,13 +2020,13 @@ def invwp(ctx, p, g2=None, g3=None, tau=None, omega=None, w_prime=None):
     z = ctx.elliprf(p - e1, p - e2, p - e3)
 
     # Optionally select sign based on derivative
-    if w_prime is not None:
-        w_prime = ctx.convert(w_prime)
+    if weierp_prime is not None:
+        weierp_prime = ctx.convert(weierp_prime)
         wpprime_neg_z = _wpprime_from_tau_omega(ctx, -z, omega1, tau)
         wpprime_pos_z = _wpprime_from_tau_omega(ctx, z, omega1, tau)
 
-        if (ctx.fabs(wpprime_neg_z - w_prime) <
-                ctx.fabs(wpprime_pos_z - w_prime)):
+        if (ctx.fabs(wpprime_neg_z - weierp_prime) <
+                ctx.fabs(wpprime_pos_z - weierp_prime)):
             return -z
 
     return z

--- a/mpmath/tests/test_elliptic.py
+++ b/mpmath/tests/test_elliptic.py
@@ -712,17 +712,11 @@ def test_weierstrass_parameter_conversions():
     mp.dps = 30
 
     omega = (mpf(1), j/2)
-    g2, g3 = weierinvariants(*omega)
-    g2_pair, g3_pair = weierinvariants(omega)
-    assert mpc_ae(g2, g2_pair)
-    assert mpc_ae(g3, g3_pair)
+    g2, g3 = weierinvariants(omega)
 
-    omega1, omega2 = weierhalfperiods(g2, g3)
-    omega1_pair, omega2_pair = weierhalfperiods((g2, g3))
-    assert mpc_ae(omega1, omega1_pair)
-    assert mpc_ae(omega2, omega2_pair)
+    omega1, omega2 = weierhalfperiods((g2, g3))
 
-    g2_roundtrip, g3_roundtrip = weierinvariants(omega1, omega2)
+    g2_roundtrip, g3_roundtrip = weierinvariants((omega1, omega2))
     assert mpc_ae(g2, g2_roundtrip, eps=eps*10000)
     assert mpc_ae(g3, g3_roundtrip, eps=eps*10000)
     assert (omega2/omega1).imag > 0
@@ -731,7 +725,7 @@ def test_weierstrass_special_half_periods():
     mp.dps = 30
 
     lemniscatic = gamma(mpf(1)/4)**2/(4*sqrt(pi))
-    omega1, omega2 = weierhalfperiods(mpf(1), mpf(0))
+    omega1, omega2 = weierhalfperiods((mpf(1), mpf(0)))
     lattice_points = [
         m*omega1 + n*omega2
         for m in [-1, 0, 1]
@@ -743,7 +737,7 @@ def test_weierstrass_special_half_periods():
 
     equianharmonic = gamma(mpf(1)/3)**3/(4*pi)
     tau = mpf(1)/2 + sqrt(3)*j/2
-    omega1, omega2 = weierhalfperiods(mpf(0), mpf(1))
+    omega1, omega2 = weierhalfperiods((mpf(0), mpf(1)))
     assert mpc_ae(omega1, equianharmonic, eps=eps*1000)
     assert mpc_ae(omega2, equianharmonic*tau, eps=eps*1000)
 
@@ -752,8 +746,8 @@ def test_weierstrass_half_periods_convergence_failure():
     try:
         mp.dps = 5
         pytest.raises(ValueError,
-                      lambda: weierhalfperiods(mpf('1e-100'),
-                                               mpf('1e-50')))
+                      lambda: weierhalfperiods((mpf('1e-100'),
+                                                mpf('1e-50'))))
     finally:
         mp.dps = old_dps
 
@@ -761,8 +755,8 @@ def test_weierstrass_parameter_conversions_with_kleinj():
     mp.dps = 30
 
     tau = mpf('0.625') + mpf('0.75')*j
-    g2, g3 = weierinvariants(mpf(1)/2, tau/2)
-    recovered_omega1, recovered_omega2 = weierhalfperiods(g2, g3)
+    g2, g3 = weierinvariants((mpf(1)/2, tau/2))
+    recovered_omega1, recovered_omega2 = weierhalfperiods((g2, g3))
     recovered_tau = recovered_omega2/recovered_omega1
     j_from_invariants = g2**3/(g2**3 - mpf(27)*g3**2)
 
@@ -796,7 +790,7 @@ def test_weierstrass_conversions_with_weierp():
 
     z = mpf('0.3')
     g2, g3 = mpf(60), mpf(140)
-    omega = weierhalfperiods(g2, g3)
+    omega = weierhalfperiods((g2, g3))
     assert mpc_ae(weierp(z, g2=g2, g3=g3), weierp(z, omega=omega),
                   eps=eps*1000)
 
@@ -941,6 +935,81 @@ def test_weierstrass_p_agrees_with_jacobi_sn():
         expected = e3 + (e1 - e3)/sn**2
         assert mpc_ae(weierp(z, g2=g2, g3=g3), expected, eps=eps*1000)
 
+def test_weierstrass_degenerate_sinh_case():
+    mp.dps = 30
+
+    z = mpf('2.3456')
+    g2 = mpf(1)/12
+    g3 = -mpf(1)/216
+
+    expected = mpf(1)/12 + 1/(4*sinh(z/2)**2)
+    actual = weierp(z, g2=g2, g3=g3)
+
+    assert mpc_ae(actual, expected, eps=eps*1000)
+
+def test_weierstrass_values_from_wolfram_engine():
+    """
+    Test values computed with Wolfram Engine at 50 decimal digits.
+    """
+    mp.dps = 30
+
+    z = mpf(1)/5 + j/10
+    g2 = mpf(23)
+    g3 = -mpf(6)
+
+    # Wolfram Engine N[WeierstrassP[1/5 + I/10, {23, -6}], 50]
+    res = (mpf('12.034598774562061614120425445264439480909180451987') -
+           mpf('15.954494688453814173909097100149572873560659025384')*j)
+    result = weierp(z, g2=g2, g3=g3)
+    assert mpc_ae(result, res, eps=eps*1000)
+
+    # Wolfram Engine N[WeierstrassZeta[1/5 + I/10, {23, -6}], 50]
+    res = (mpf('3.9992187928039781633477175010941910299674720024081') -
+           mpf('2.0041989210825396679692243492987154755001509689191')*j)
+    result = weierzeta(z, g2=g2, g3=g3)
+    assert mpc_ae(result, res, eps=eps*1000)
+
+    # Wolfram Engine N[WeierstrassPPrime[1/5 + I/10, {23, -6}], 50]
+    res = (-mpf('31.54270502882344156819611453200111232882467293381') +
+           mpf('176.22165647344596777337677909680659880143827576854')*j)
+    result = weierpprime(z, g2=g2, g3=g3)
+    assert mpc_ae(result, res, eps=eps*1000)
+
+    # Wolfram Engine N[WeierstrassSigma[1/5 + I/10, {23, -6}], 50]
+    res = (mpf('0.20003622045198197835660834749697373254229661740043') +
+           mpf('0.09996069154774003218065176170970294010303412640179')*j)
+    result = weiersigma(z, g2=g2, g3=g3)
+    assert mpc_ae(result, res, eps=eps*1000)
+
+    z = mpf(23)/7 + j/19
+    g2 = mpf(4)
+    g3 = j/7
+
+    # Wolfram Engine N[WeierstrassP[23/7 + I/19, {4, I/7}], 50]
+    res = (mpf('2.2404307465194869190166863785647513208647609853834') -
+           mpf('0.5325343281547884762112232120255440012711106470188')*j)
+    result = weierp(z, g2=g2, g3=g3)
+    assert mpc_ae(result, res, eps=eps*1000)
+
+    # Wolfram Engine N[WeierstrassZeta[23/7 + I/19, {4, I/7}], 50]
+    res = (mpf('2.6598023545241487676259152806188261775361664938905') -
+           mpf('0.1724953898440469052904087998933282167782688769615')*j)
+    result = weierzeta(z, g2=g2, g3=g3)
+    assert mpc_ae(result, res, eps=eps*1000)
+
+    # Wolfram Engine N[WeierstrassPPrime[23/7 + I/19, {4, I/7}], 50]
+    res = (-mpf('5.8878748476527295086161128667469618082615948921289') +
+           mpf('2.5039163494781823494565528962139346083786451647413')*j)
+    result = weierpprime(z, g2=g2, g3=g3)
+    assert mpc_ae(result, res, eps=eps*1000)
+
+    # Wolfram Engine N[WeierstrassSigma[23/7 + I/19, {4, I/7}], 50]
+    res = (-mpf('6.9051546244372935099218335621773818059877316069834') -
+           mpf('1.7875281795111006668737717361366903871401611117693')*j)
+    result = weiersigma(z, g2=g2, g3=g3)
+    assert mpc_ae(result, res, eps=eps*1000)
+
+
 def test_weierstrass_invalid_parameterization():
     z = mpf('0.3')
     pytest.raises(ValueError, lambda: weierp(z))
@@ -949,6 +1018,8 @@ def test_weierstrass_invalid_parameterization():
     pytest.raises(ValueError, lambda: weierp(z, omega=(mpf(1), -j)))
     pytest.raises(ValueError,
                   lambda: weierp(z, g2=mpf(60), g3=mpf(140), tau=j/2))
-    pytest.raises(ValueError, lambda: weierinvariants(mpf(1), -j))
+    pytest.raises(TypeError, lambda: weierinvariants(mpf(1), -j))
+    pytest.raises(ValueError, lambda: weierinvariants((mpf(1), -j)))
     pytest.raises(ValueError, lambda: weierinvariants(mpf(1)))
+    pytest.raises(TypeError, lambda: weierhalfperiods(mpf(1), mpf(0)))
     pytest.raises(ValueError, lambda: weierhalfperiods(mpf(1)))

--- a/mpmath/tests/test_elliptic.py
+++ b/mpmath/tests/test_elliptic.py
@@ -693,12 +693,15 @@ def test_weierstrass_tau_uses_normalized_periods():
 
     z = mpf('0.3')
     tau = j/2
-    omega = (mpf(1)/2, tau/2)
+    omega1 = mpf(1)/2
+    omega2 = tau/2
 
     for f in [weierp, weierpprime, weiersigma, weierzeta]:
-        assert mpc_ae(f(z, tau=tau), f(z, omega=omega), eps=eps*1000)
+        assert mpc_ae(f(z, tau=tau),
+                      f(z, omega1=omega1, omega2=omega2), eps=eps*1000)
 
 def test_weierstrass_g2g3_differential_equation():
+    # https://dlmf.nist.gov/23.3#E10
     mp.dps = 30
 
     z = mpf('0.3')
@@ -711,12 +714,13 @@ def test_weierstrass_g2g3_differential_equation():
 def test_weierstrass_parameter_conversions():
     mp.dps = 30
 
-    omega = (mpf(1), j/2)
-    g2, g3 = weierinvariants(omega)
+    omega1 = mpf(1)
+    omega2 = j/2
+    g2, g3 = weierinvariants(omega1, omega2)
 
-    omega1, omega2 = weierhalfperiods((g2, g3))
+    omega1, omega2 = weierhalfperiods(g2, g3)
 
-    g2_roundtrip, g3_roundtrip = weierinvariants((omega1, omega2))
+    g2_roundtrip, g3_roundtrip = weierinvariants(omega1, omega2)
     assert mpc_ae(g2, g2_roundtrip, eps=eps*10000)
     assert mpc_ae(g3, g3_roundtrip, eps=eps*10000)
     assert (omega2/omega1).imag > 0
@@ -724,8 +728,9 @@ def test_weierstrass_parameter_conversions():
 def test_weierstrass_special_half_periods():
     mp.dps = 30
 
+    # Scaled version of http://dlmf.nist.gov/23.5.E5
     lemniscatic = gamma(mpf(1)/4)**2/(4*sqrt(pi))
-    omega1, omega2 = weierhalfperiods((mpf(1), mpf(0)))
+    omega1, omega2 = weierhalfperiods(mpf(1), mpf(0))
     lattice_points = [
         m*omega1 + n*omega2
         for m in [-1, 0, 1]
@@ -735,28 +740,30 @@ def test_weierstrass_special_half_periods():
     assert min(abs(point - lemniscatic) for point in lattice_points) < eps*1000
     assert min(abs(point - j*lemniscatic) for point in lattice_points) < eps*1000
 
+    # Scaled version of http://dlmf.nist.gov/23.5.E9
     equianharmonic = gamma(mpf(1)/3)**3/(4*pi)
     tau = mpf(1)/2 + sqrt(3)*j/2
-    omega1, omega2 = weierhalfperiods((mpf(0), mpf(1)))
+    omega1, omega2 = weierhalfperiods(mpf(0), mpf(1))
     assert mpc_ae(omega1, equianharmonic, eps=eps*1000)
     assert mpc_ae(omega2, equianharmonic*tau, eps=eps*1000)
 
-def test_weierstrass_half_periods_convergence_failure():
-    old_dps = mp.dps
-    try:
-        mp.dps = 5
-        pytest.raises(ValueError,
-                      lambda: weierhalfperiods((mpf('1e-100'),
-                                                mpf('1e-50'))))
-    finally:
-        mp.dps = old_dps
+def test_weierstrass_half_periods_high_precision():
+    mp.dps = 80
+
+    g2 = mpf(60)
+    g3 = mpf(140)
+    omega1, omega2 = weierhalfperiods(g2, g3)
+    g2_roundtrip, g3_roundtrip = weierinvariants(omega1, omega2)
+
+    assert mpc_ae(g2, g2_roundtrip, eps=eps*10000)
+    assert mpc_ae(g3, g3_roundtrip, eps=eps*10000)
 
 def test_weierstrass_parameter_conversions_with_kleinj():
     mp.dps = 30
 
     tau = mpf('0.625') + mpf('0.75')*j
-    g2, g3 = weierinvariants((mpf(1)/2, tau/2))
-    recovered_omega1, recovered_omega2 = weierhalfperiods((g2, g3))
+    g2, g3 = weierinvariants(mpf(1)/2, tau/2)
+    recovered_omega1, recovered_omega2 = weierhalfperiods(g2, g3)
     recovered_tau = recovered_omega2/recovered_omega1
     j_from_invariants = g2**3/(g2**3 - mpf(27)*g3**2)
 
@@ -768,14 +775,13 @@ def test_weierstrass_half_period_values_are_cubic_roots():
 
     omega1 = mpf(1)
     omega2 = j/2
-    omega = (omega1, omega2)
-    g2, g3 = weierinvariants(omega)
+    g2, g3 = weierinvariants(omega1, omega2)
 
     roots = polyroots([-g3, -g2, mpf(0), mpf(4)], maxsteps=50)
     half_period_values = [
-        weierp(omega1, omega=omega),
-        weierp(omega2, omega=omega),
-        weierp(omega1 + omega2, omega=omega),
+        weierp(omega1, omega1=omega1, omega2=omega2),
+        weierp(omega2, omega1=omega1, omega2=omega2),
+        weierp(omega1 + omega2, omega1=omega1, omega2=omega2),
     ]
 
     for value in half_period_values:
@@ -790,90 +796,113 @@ def test_weierstrass_conversions_with_weierp():
 
     z = mpf('0.3')
     g2, g3 = mpf(60), mpf(140)
-    omega = weierhalfperiods((g2, g3))
-    assert mpc_ae(weierp(z, g2=g2, g3=g3), weierp(z, omega=omega),
-                  eps=eps*1000)
+    omega1, omega2 = weierhalfperiods(g2, g3)
+    assert mpc_ae(weierp(z, g2=g2, g3=g3),
+                  weierp(z, omega1=omega1, omega2=omega2), eps=eps*1000)
 
 def test_weierstrass_periodicity():
     mp.dps = 30
 
+    # http://dlmf.nist.gov/23.2.E9
     z = mpf('0.3')
     omega1 = mpf(1)
     omega2 = j/2
-    omega = (omega1, omega2)
-    p = weierp(z, omega=omega)
-    pp = weierpprime(z, omega=omega)
+    p = weierp(z, omega1=omega1, omega2=omega2)
+    pp = weierpprime(z, omega1=omega1, omega2=omega2)
 
-    assert mpc_ae(weierp(z + 2*omega1, omega=omega), p, eps=eps*1000)
-    assert mpc_ae(weierp(z + 2*omega2, omega=omega), p, eps=eps*1000)
-    assert mpc_ae(weierpprime(z + 2*omega1, omega=omega), pp,
+    assert mpc_ae(weierp(z + 2*omega1, omega1=omega1, omega2=omega2),
+                  p, eps=eps*1000)
+    assert mpc_ae(weierp(z + 2*omega2, omega1=omega1, omega2=omega2),
+                  p, eps=eps*1000)
+    assert mpc_ae(weierpprime(z + 2*omega1,
+                              omega1=omega1, omega2=omega2), pp,
                   eps=eps*1000)
-    assert mpc_ae(weierpprime(z + 2*omega2, omega=omega), pp,
+    assert mpc_ae(weierpprime(z + 2*omega2,
+                              omega1=omega1, omega2=omega2), pp,
                   eps=eps*1000)
 
 def test_weierstrass_scaling_laws():
     mp.dps = 30
 
+    # http://dlmf.nist.gov/23.10.iv
     z = mpf('0.3')
     scale = mpf('1.7')
-    omega = (mpf(1), j/2)
-    scaled_omega = (scale*omega[0], scale*omega[1])
+    omega1 = mpf(1)
+    omega2 = j/2
+    scaled_omega1 = scale*omega1
+    scaled_omega2 = scale*omega2
 
-    assert mpc_ae(weierp(scale*z, omega=scaled_omega),
-                  weierp(z, omega=omega)/scale**2, eps=eps*1000)
-    assert mpc_ae(weierpprime(scale*z, omega=scaled_omega),
-                  weierpprime(z, omega=omega)/scale**3, eps=eps*1000)
-    assert mpc_ae(weiersigma(scale*z, omega=scaled_omega),
-                  scale*weiersigma(z, omega=omega), eps=eps*1000)
-    assert mpc_ae(weierzeta(scale*z, omega=scaled_omega),
-                  weierzeta(z, omega=omega)/scale, eps=eps*1000)
+    assert mpc_ae(weierp(scale*z, omega1=scaled_omega1,
+                         omega2=scaled_omega2),
+                  weierp(z, omega1=omega1, omega2=omega2)/scale**2,
+                  eps=eps*1000)
+    assert mpc_ae(weierpprime(scale*z, omega1=scaled_omega1,
+                              omega2=scaled_omega2),
+                  weierpprime(z, omega1=omega1, omega2=omega2)/scale**3,
+                  eps=eps*1000)
+    assert mpc_ae(weiersigma(scale*z, omega1=scaled_omega1,
+                             omega2=scaled_omega2),
+                  scale*weiersigma(z, omega1=omega1, omega2=omega2),
+                  eps=eps*1000)
+    assert mpc_ae(weierzeta(scale*z, omega1=scaled_omega1,
+                            omega2=scaled_omega2),
+                  weierzeta(z, omega1=omega1, omega2=omega2)/scale,
+                  eps=eps*1000)
 
 def test_weierstrass_tau_omega_parameterizations():
     mp.dps = 30
 
     z = mpf('0.3')
     tau = j/2
-    omega = (mpf(1)/2, tau/2)
+    omega1 = mpf(1)/2
+    omega2 = tau/2
     for f in [weierp, weierpprime, weiersigma, weierzeta]:
-        assert mpc_ae(f(z, tau=tau), f(z, omega=omega))
+        assert mpc_ae(f(z, tau=tau), f(z, omega1=omega1, omega2=omega2))
 
 def test_weierstrass_addition_theorem():
     mp.dps = 30
 
+    # http://dlmf.nist.gov/23.10.E1
     z = mpf('0.3')
     w = mpf('0.4') + j/10
-    omega = (mpf(1), j/2)
+    omega1 = mpf(1)
+    omega2 = j/2
 
-    pz = weierp(z, omega=omega)
-    pw = weierp(w, omega=omega)
-    ppz = weierpprime(z, omega=omega)
-    ppw = weierpprime(w, omega=omega)
+    pz = weierp(z, omega1=omega1, omega2=omega2)
+    pw = weierp(w, omega1=omega1, omega2=omega2)
+    ppz = weierpprime(z, omega1=omega1, omega2=omega2)
+    ppw = weierpprime(w, omega1=omega1, omega2=omega2)
     rhs = ((ppz - ppw)/(pz - pw))**2/4 - pz - pw
 
-    assert mpc_ae(weierp(z + w, omega=omega), rhs, eps=eps*1000)
+    assert mpc_ae(weierp(z + w, omega1=omega1, omega2=omega2),
+                  rhs, eps=eps*1000)
 
 def test_weierstrass_zeta_legendre_relation():
     mp.dps = 30
 
+    # http://dlmf.nist.gov/23.2.E11
+    # http://dlmf.nist.gov/23.2.E14
     z = mpf('0.3') + j/10
     omega1 = mpf(1)
     omega2 = j/2
-    omega = (omega1, omega2)
 
-    eta1_increment = weierzeta(z + 2*omega1, omega=omega)
-    eta1_increment -= weierzeta(z, omega=omega)
-    eta2_increment = weierzeta(z + 2*omega2, omega=omega)
-    eta2_increment -= weierzeta(z, omega=omega)
+    eta1_increment = weierzeta(z + 2*omega1,
+                               omega1=omega1, omega2=omega2)
+    eta1_increment -= weierzeta(z, omega1=omega1, omega2=omega2)
+    eta2_increment = weierzeta(z + 2*omega2,
+                               omega1=omega1, omega2=omega2)
+    eta2_increment -= weierzeta(z, omega1=omega1, omega2=omega2)
     assert mpc_ae(eta1_increment*omega2 - eta2_increment*omega1,
                   pi*j, eps=eps*1000)
 
-    eta1 = weierzeta(omega1, omega=omega)
-    eta2 = weierzeta(omega2, omega=omega)
+    eta1 = weierzeta(omega1, omega1=omega1, omega2=omega2)
+    eta2 = weierzeta(omega2, omega1=omega1, omega2=omega2)
     assert mpc_ae(eta1*omega2 - eta2*omega1, pi*j/2, eps=eps*1000)
 
 def test_weierstrass_sigma_zeta_identities():
     mp.dps = 30
 
+    # http://dlmf.nist.gov/23.2.E8
     z = mpf('0.3')
     tau = j/2
     assert mpc_ae(diff(lambda t: weiersigma(t, tau=tau), z) /
@@ -913,6 +942,7 @@ def test_weierstrass_p_agrees_with_jacobi_sn():
     #     m = (e2 - e3)/(e1 - e3)
     #
     # and 4*(x - e1)*(x - e2)*(x - e3) = 4*x**3 - g2*x - g3.
+    # Shifted version of http://dlmf.nist.gov/23.6.E26
     e1 = mpf(2)
     e2 = -mpf(1)/2
     e3 = -mpf(3)/2
@@ -1015,11 +1045,10 @@ def test_weierstrass_invalid_parameterization():
     pytest.raises(ValueError, lambda: weierp(z))
     pytest.raises(ValueError, lambda: weierp(z, g2=mpf(1)))
     pytest.raises(ValueError, lambda: weierp(z, tau=-j))
-    pytest.raises(ValueError, lambda: weierp(z, omega=(mpf(1), -j)))
+    pytest.raises(ValueError, lambda: weierp(z, omega1=mpf(1)))
+    pytest.raises(ValueError, lambda: weierp(z, omega1=mpf(1), omega2=-j))
     pytest.raises(ValueError,
                   lambda: weierp(z, g2=mpf(60), g3=mpf(140), tau=j/2))
-    pytest.raises(TypeError, lambda: weierinvariants(mpf(1), -j))
-    pytest.raises(ValueError, lambda: weierinvariants((mpf(1), -j)))
-    pytest.raises(ValueError, lambda: weierinvariants(mpf(1)))
-    pytest.raises(TypeError, lambda: weierhalfperiods(mpf(1), mpf(0)))
-    pytest.raises(ValueError, lambda: weierhalfperiods(mpf(1)))
+    pytest.raises(ValueError, lambda: weierinvariants(mpf(1), -j))
+    pytest.raises(TypeError, lambda: weierinvariants(mpf(1)))
+    pytest.raises(TypeError, lambda: weierhalfperiods(mpf(1)))

--- a/mpmath/tests/test_elliptic.py
+++ b/mpmath/tests/test_elliptic.py
@@ -17,8 +17,10 @@ import pytest
 
 from mpmath import (cos, cosh, cot, coth, csc, csch, diff, ellipe, ellipfun,
                     ellipk, ellippi, elliprc, elliprd, elliprf, elliprg,
-                    elliprj, eps, exp, isnan, j, jtheta, ldexp, ln2, mp, mpc,
-                    mpf, nan, pi, qfrom, sec, sech, sin, sinh, sqrt, tan, tanh)
+                    elliprj, eps, exp, gamma, invwp, isnan, j, jtheta, kleinj,
+                    ldexp, ln2, mp, mpc, mpf, nan, pi, polyroots, qfrom, sec,
+                    sech, sin, sinh, sqrt, tan, tanh, w_half_periods,
+                    w_invariants, wp, wpprime, wsigma, wzeta)
 
 
 def mpc_ae(a, b, eps=eps):
@@ -681,3 +683,192 @@ def test_issue_1104():
     ans = jtheta(4, z, q, 3)
     assert mpc_ae(ans, ref)
     assert mpc_ae(ans, mp.extraprec(10000)(jtheta)(4, z, q, 3))
+
+# Weierstrass Elliptic Functions
+# ============================================================================
+
+def test_weierstrass_tau_values():
+    mp.dps = 30
+
+    z = mpf('0.3')
+    tau = j/2
+    assert mpc_ae(wp(z, tau=tau),
+                  mpf('11.6229960825738115058320196726'),
+                  eps=eps*1000)
+    assert mpc_ae(wpprime(z, tau=tau),
+                  mpf('-71.0936078666012624540338225975'),
+                  eps=eps*1000)
+    assert mpc_ae(wsigma(z, tau=tau),
+                  mpf('0.298755877985088643871228805199'),
+                  eps=eps*1000)
+    assert mpc_ae(wzeta(z, tau=tau),
+                  mpf('3.27937075406163200565491131581'),
+                  eps=eps*1000)
+
+def test_weierstrass_g2g3_differential_equation():
+    mp.dps = 30
+
+    z = mpf('0.3')
+    for g2, g3 in [(mpf(60), mpf(140)), (mpf(0), mpf(140)),
+                   (mpf(60), mpf(0))]:
+        p = wp(z, g2=g2, g3=g3)
+        pp = wpprime(z, g2=g2, g3=g3)
+        assert mpc_ae(pp**2, 4*p**3 - g2*p - g3, eps=eps*1000)
+
+def test_weierstrass_parameter_conversions():
+    mp.dps = 30
+
+    omega = (mpf(1), j/2)
+    g2, g3 = w_invariants(*omega)
+    g2_pair, g3_pair = w_invariants(omega)
+    assert mpc_ae(g2, g2_pair)
+    assert mpc_ae(g3, g3_pair)
+    assert mpc_ae(g2, mpf('129.987495088848273451479710118'),
+                  eps=eps*1000)
+    assert mpc_ae(g3, mpf('-284.355330876540799400227179397'),
+                  eps=eps*1000)
+
+    omega1, omega2 = w_half_periods(g2, g3)
+    omega1_pair, omega2_pair = w_half_periods((g2, g3))
+    assert mpc_ae(omega1, omega1_pair)
+    assert mpc_ae(omega2, omega2_pair)
+
+    g2_roundtrip, g3_roundtrip = w_invariants(omega1, omega2)
+    assert mpc_ae(g2, g2_roundtrip, eps=eps*10000)
+    assert mpc_ae(g3, g3_roundtrip, eps=eps*10000)
+    assert (omega2/omega1).imag > 0
+
+def test_weierstrass_special_half_periods():
+    mp.dps = 30
+
+    lemniscatic = gamma(mpf(1)/4)**2/(4*sqrt(pi))
+    omega1, omega2 = w_half_periods(mpf(1), mpf(0))
+    lattice_points = [
+        m*omega1 + n*omega2
+        for m in [-1, 0, 1]
+        for n in [-1, 0, 1]
+        if m or n
+    ]
+    assert min(abs(point - lemniscatic) for point in lattice_points) < eps*1000
+    assert min(abs(point - j*lemniscatic) for point in lattice_points) < eps*1000
+
+    equianharmonic = gamma(mpf(1)/3)**3/(4*pi)
+    tau = mpf(1)/2 + sqrt(3)*j/2
+    omega1, omega2 = w_half_periods(mpf(0), mpf(1))
+    assert mpc_ae(omega1, equianharmonic, eps=eps*1000)
+    assert mpc_ae(omega2, equianharmonic*tau, eps=eps*1000)
+
+def test_weierstrass_half_periods_convergence_failure():
+    old_dps = mp.dps
+    try:
+        mp.dps = 5
+        pytest.raises(ValueError,
+                      lambda: w_half_periods(mpf('1e-100'), mpf('1e-50')))
+    finally:
+        mp.dps = old_dps
+
+def test_weierstrass_parameter_conversions_with_kleinj():
+    mp.dps = 30
+
+    tau = mpf('0.625') + mpf('0.75')*j
+    g2, g3 = w_invariants(mpf(1), tau)
+    recovered_omega1, recovered_omega2 = w_half_periods(g2, g3)
+    recovered_tau = recovered_omega2/recovered_omega1
+    j_from_invariants = g2**3/(g2**3 - mpf(27)*g3**2)
+
+    assert mpc_ae(kleinj(tau), j_from_invariants, eps=eps*1000)
+    assert mpc_ae(kleinj(recovered_tau), kleinj(tau), eps=eps*1000)
+
+def test_weierstrass_half_period_values_are_cubic_roots():
+    mp.dps = 30
+
+    omega1 = mpf(1)
+    omega2 = j/2
+    omega = (omega1, omega2)
+    g2, g3 = w_invariants(omega)
+
+    roots = polyroots([-g3, -g2, mpf(0), mpf(4)], maxsteps=50)
+    half_period_values = [
+        wp(omega1, omega=omega),
+        wp(omega2, omega=omega),
+        wp(omega1 + omega2, omega=omega),
+    ]
+
+    for value in half_period_values:
+        assert min(abs(value - root) for root in roots) < eps*1000
+    for root in roots:
+        assert min(abs(value - root) for value in half_period_values) < eps*1000
+
+def test_weierstrass_conversions_with_wp():
+    mp.dps = 30
+
+    z = mpf('0.3')
+    g2, g3 = mpf(60), mpf(140)
+    omega = w_half_periods(g2, g3)
+    assert mpc_ae(wp(z, g2=g2, g3=g3), wp(z, omega=omega),
+                  eps=eps*1000)
+
+def test_weierstrass_periodicity():
+    mp.dps = 30
+
+    z = mpf('0.3')
+    omega1 = mpf(1)
+    omega2 = j/2
+    omega = (omega1, omega2)
+    p = wp(z, omega=omega)
+    pp = wpprime(z, omega=omega)
+
+    assert mpc_ae(wp(z + 2*omega1, omega=omega), p, eps=eps*1000)
+    assert mpc_ae(wp(z + 2*omega2, omega=omega), p, eps=eps*1000)
+    assert mpc_ae(wpprime(z + 2*omega1, omega=omega), pp, eps=eps*1000)
+    assert mpc_ae(wpprime(z + 2*omega2, omega=omega), pp, eps=eps*1000)
+
+def test_weierstrass_tau_omega_parameterizations():
+    mp.dps = 30
+
+    z = mpf('0.3')
+    tau = j/2
+    omega = (mpf(1), tau)
+    for f in [wp, wpprime, wsigma, wzeta]:
+        assert mpc_ae(f(z, tau=tau), f(z, omega=omega))
+
+def test_weierstrass_sigma_zeta_identities():
+    mp.dps = 30
+
+    z = mpf('0.3')
+    tau = j/2
+    assert mpc_ae(diff(lambda t: wsigma(t, tau=tau), z) /
+                  wsigma(z, tau=tau), wzeta(z, tau=tau), eps=eps*1000)
+    assert mpc_ae(diff(lambda t: wzeta(t, tau=tau), z),
+                  -wp(z, tau=tau), eps=eps*1000)
+
+def test_weierstrass_invwp():
+    mp.dps = 30
+
+    z = mpf('0.3')
+    g2, g3 = mpf(60), mpf(140)
+    p = wp(z, g2=g2, g3=g3)
+    pp = wpprime(z, g2=g2, g3=g3)
+    z2 = invwp(p, g2=g2, g3=g3)
+    assert mpc_ae(z2, z, eps=eps*1000)
+    assert mpc_ae(wp(z2, g2=g2, g3=g3), p, eps=eps*1000)
+
+    z2 = invwp(p, g2=g2, g3=g3, w_prime=pp)
+    assert mpc_ae(z2, z, eps=eps*1000)
+    assert mpc_ae(wpprime(z2, g2=g2, g3=g3), pp, eps=eps*1000)
+
+    z2 = invwp(p, g2=g2, g3=g3, w_prime=-pp)
+    assert mpc_ae(z2, -z, eps=eps*1000)
+    assert mpc_ae(wpprime(z2, g2=g2, g3=g3), -pp, eps=eps*1000)
+
+def test_weierstrass_invalid_parameterization():
+    z = mpf('0.3')
+    pytest.raises(ValueError, lambda: wp(z))
+    pytest.raises(ValueError, lambda: wp(z, g2=mpf(1)))
+    pytest.raises(ValueError, lambda: wp(z, tau=-j))
+    pytest.raises(ValueError, lambda: wp(z, omega=(mpf(1), -j)))
+    pytest.raises(ValueError,
+                  lambda: wp(z, g2=mpf(60), g3=mpf(140), tau=j/2))
+    pytest.raises(ValueError, lambda: w_invariants(mpf(1), -j))
+    pytest.raises(ValueError, lambda: w_invariants(mpf(1)))
+    pytest.raises(ValueError, lambda: w_half_periods(mpf(1)))

--- a/mpmath/tests/test_elliptic.py
+++ b/mpmath/tests/test_elliptic.py
@@ -17,10 +17,11 @@ import pytest
 
 from mpmath import (cos, cosh, cot, coth, csc, csch, diff, ellipe, ellipfun,
                     ellipk, ellippi, elliprc, elliprd, elliprf, elliprg,
-                    elliprj, eps, exp, gamma, invwp, isnan, j, jtheta, kleinj,
-                    ldexp, ln2, mp, mpc, mpf, nan, pi, polyroots, qfrom, sec,
-                    sech, sin, sinh, sqrt, tan, tanh, w_half_periods,
-                    w_invariants, wp, wpprime, wsigma, wzeta)
+                    elliprj, eps, exp, gamma, isnan, j, jtheta, kleinj, ldexp,
+                    ln2, mp, mpc, mpf, nan, pi, polyroots, qfrom, sec, sech,
+                    sin, sinh, sqrt, tan, tanh, weierhalfperiods,
+                    weierinvariants, weierp, weierpinv, weierpprime,
+                    weiersigma, weierzeta)
 
 
 def mpc_ae(a, b, eps=eps):
@@ -687,23 +688,15 @@ def test_issue_1104():
 # Weierstrass Elliptic Functions
 # ============================================================================
 
-def test_weierstrass_tau_values():
+def test_weierstrass_tau_uses_normalized_periods():
     mp.dps = 30
 
     z = mpf('0.3')
     tau = j/2
-    assert mpc_ae(wp(z, tau=tau),
-                  mpf('11.6229960825738115058320196726'),
-                  eps=eps*1000)
-    assert mpc_ae(wpprime(z, tau=tau),
-                  mpf('-71.0936078666012624540338225975'),
-                  eps=eps*1000)
-    assert mpc_ae(wsigma(z, tau=tau),
-                  mpf('0.298755877985088643871228805199'),
-                  eps=eps*1000)
-    assert mpc_ae(wzeta(z, tau=tau),
-                  mpf('3.27937075406163200565491131581'),
-                  eps=eps*1000)
+    omega = (mpf(1)/2, tau/2)
+
+    for f in [weierp, weierpprime, weiersigma, weierzeta]:
+        assert mpc_ae(f(z, tau=tau), f(z, omega=omega), eps=eps*1000)
 
 def test_weierstrass_g2g3_differential_equation():
     mp.dps = 30
@@ -711,29 +704,25 @@ def test_weierstrass_g2g3_differential_equation():
     z = mpf('0.3')
     for g2, g3 in [(mpf(60), mpf(140)), (mpf(0), mpf(140)),
                    (mpf(60), mpf(0))]:
-        p = wp(z, g2=g2, g3=g3)
-        pp = wpprime(z, g2=g2, g3=g3)
+        p = weierp(z, g2=g2, g3=g3)
+        pp = weierpprime(z, g2=g2, g3=g3)
         assert mpc_ae(pp**2, 4*p**3 - g2*p - g3, eps=eps*1000)
 
 def test_weierstrass_parameter_conversions():
     mp.dps = 30
 
     omega = (mpf(1), j/2)
-    g2, g3 = w_invariants(*omega)
-    g2_pair, g3_pair = w_invariants(omega)
+    g2, g3 = weierinvariants(*omega)
+    g2_pair, g3_pair = weierinvariants(omega)
     assert mpc_ae(g2, g2_pair)
     assert mpc_ae(g3, g3_pair)
-    assert mpc_ae(g2, mpf('129.987495088848273451479710118'),
-                  eps=eps*1000)
-    assert mpc_ae(g3, mpf('-284.355330876540799400227179397'),
-                  eps=eps*1000)
 
-    omega1, omega2 = w_half_periods(g2, g3)
-    omega1_pair, omega2_pair = w_half_periods((g2, g3))
+    omega1, omega2 = weierhalfperiods(g2, g3)
+    omega1_pair, omega2_pair = weierhalfperiods((g2, g3))
     assert mpc_ae(omega1, omega1_pair)
     assert mpc_ae(omega2, omega2_pair)
 
-    g2_roundtrip, g3_roundtrip = w_invariants(omega1, omega2)
+    g2_roundtrip, g3_roundtrip = weierinvariants(omega1, omega2)
     assert mpc_ae(g2, g2_roundtrip, eps=eps*10000)
     assert mpc_ae(g3, g3_roundtrip, eps=eps*10000)
     assert (omega2/omega1).imag > 0
@@ -742,7 +731,7 @@ def test_weierstrass_special_half_periods():
     mp.dps = 30
 
     lemniscatic = gamma(mpf(1)/4)**2/(4*sqrt(pi))
-    omega1, omega2 = w_half_periods(mpf(1), mpf(0))
+    omega1, omega2 = weierhalfperiods(mpf(1), mpf(0))
     lattice_points = [
         m*omega1 + n*omega2
         for m in [-1, 0, 1]
@@ -754,7 +743,7 @@ def test_weierstrass_special_half_periods():
 
     equianharmonic = gamma(mpf(1)/3)**3/(4*pi)
     tau = mpf(1)/2 + sqrt(3)*j/2
-    omega1, omega2 = w_half_periods(mpf(0), mpf(1))
+    omega1, omega2 = weierhalfperiods(mpf(0), mpf(1))
     assert mpc_ae(omega1, equianharmonic, eps=eps*1000)
     assert mpc_ae(omega2, equianharmonic*tau, eps=eps*1000)
 
@@ -763,7 +752,8 @@ def test_weierstrass_half_periods_convergence_failure():
     try:
         mp.dps = 5
         pytest.raises(ValueError,
-                      lambda: w_half_periods(mpf('1e-100'), mpf('1e-50')))
+                      lambda: weierhalfperiods(mpf('1e-100'),
+                                               mpf('1e-50')))
     finally:
         mp.dps = old_dps
 
@@ -771,8 +761,8 @@ def test_weierstrass_parameter_conversions_with_kleinj():
     mp.dps = 30
 
     tau = mpf('0.625') + mpf('0.75')*j
-    g2, g3 = w_invariants(mpf(1), tau)
-    recovered_omega1, recovered_omega2 = w_half_periods(g2, g3)
+    g2, g3 = weierinvariants(mpf(1)/2, tau/2)
+    recovered_omega1, recovered_omega2 = weierhalfperiods(g2, g3)
     recovered_tau = recovered_omega2/recovered_omega1
     j_from_invariants = g2**3/(g2**3 - mpf(27)*g3**2)
 
@@ -785,27 +775,29 @@ def test_weierstrass_half_period_values_are_cubic_roots():
     omega1 = mpf(1)
     omega2 = j/2
     omega = (omega1, omega2)
-    g2, g3 = w_invariants(omega)
+    g2, g3 = weierinvariants(omega)
 
     roots = polyroots([-g3, -g2, mpf(0), mpf(4)], maxsteps=50)
     half_period_values = [
-        wp(omega1, omega=omega),
-        wp(omega2, omega=omega),
-        wp(omega1 + omega2, omega=omega),
+        weierp(omega1, omega=omega),
+        weierp(omega2, omega=omega),
+        weierp(omega1 + omega2, omega=omega),
     ]
 
     for value in half_period_values:
+        assert mpc_ae(4*value**3 - g2*value - g3, mpf(0),
+                      eps=eps*1000)
         assert min(abs(value - root) for root in roots) < eps*1000
     for root in roots:
         assert min(abs(value - root) for value in half_period_values) < eps*1000
 
-def test_weierstrass_conversions_with_wp():
+def test_weierstrass_conversions_with_weierp():
     mp.dps = 30
 
     z = mpf('0.3')
     g2, g3 = mpf(60), mpf(140)
-    omega = w_half_periods(g2, g3)
-    assert mpc_ae(wp(z, g2=g2, g3=g3), wp(z, omega=omega),
+    omega = weierhalfperiods(g2, g3)
+    assert mpc_ae(weierp(z, g2=g2, g3=g3), weierp(z, omega=omega),
                   eps=eps*1000)
 
 def test_weierstrass_periodicity():
@@ -815,60 +807,148 @@ def test_weierstrass_periodicity():
     omega1 = mpf(1)
     omega2 = j/2
     omega = (omega1, omega2)
-    p = wp(z, omega=omega)
-    pp = wpprime(z, omega=omega)
+    p = weierp(z, omega=omega)
+    pp = weierpprime(z, omega=omega)
 
-    assert mpc_ae(wp(z + 2*omega1, omega=omega), p, eps=eps*1000)
-    assert mpc_ae(wp(z + 2*omega2, omega=omega), p, eps=eps*1000)
-    assert mpc_ae(wpprime(z + 2*omega1, omega=omega), pp, eps=eps*1000)
-    assert mpc_ae(wpprime(z + 2*omega2, omega=omega), pp, eps=eps*1000)
+    assert mpc_ae(weierp(z + 2*omega1, omega=omega), p, eps=eps*1000)
+    assert mpc_ae(weierp(z + 2*omega2, omega=omega), p, eps=eps*1000)
+    assert mpc_ae(weierpprime(z + 2*omega1, omega=omega), pp,
+                  eps=eps*1000)
+    assert mpc_ae(weierpprime(z + 2*omega2, omega=omega), pp,
+                  eps=eps*1000)
+
+def test_weierstrass_scaling_laws():
+    mp.dps = 30
+
+    z = mpf('0.3')
+    scale = mpf('1.7')
+    omega = (mpf(1), j/2)
+    scaled_omega = (scale*omega[0], scale*omega[1])
+
+    assert mpc_ae(weierp(scale*z, omega=scaled_omega),
+                  weierp(z, omega=omega)/scale**2, eps=eps*1000)
+    assert mpc_ae(weierpprime(scale*z, omega=scaled_omega),
+                  weierpprime(z, omega=omega)/scale**3, eps=eps*1000)
+    assert mpc_ae(weiersigma(scale*z, omega=scaled_omega),
+                  scale*weiersigma(z, omega=omega), eps=eps*1000)
+    assert mpc_ae(weierzeta(scale*z, omega=scaled_omega),
+                  weierzeta(z, omega=omega)/scale, eps=eps*1000)
 
 def test_weierstrass_tau_omega_parameterizations():
     mp.dps = 30
 
     z = mpf('0.3')
     tau = j/2
-    omega = (mpf(1), tau)
-    for f in [wp, wpprime, wsigma, wzeta]:
+    omega = (mpf(1)/2, tau/2)
+    for f in [weierp, weierpprime, weiersigma, weierzeta]:
         assert mpc_ae(f(z, tau=tau), f(z, omega=omega))
+
+def test_weierstrass_addition_theorem():
+    mp.dps = 30
+
+    z = mpf('0.3')
+    w = mpf('0.4') + j/10
+    omega = (mpf(1), j/2)
+
+    pz = weierp(z, omega=omega)
+    pw = weierp(w, omega=omega)
+    ppz = weierpprime(z, omega=omega)
+    ppw = weierpprime(w, omega=omega)
+    rhs = ((ppz - ppw)/(pz - pw))**2/4 - pz - pw
+
+    assert mpc_ae(weierp(z + w, omega=omega), rhs, eps=eps*1000)
+
+def test_weierstrass_zeta_legendre_relation():
+    mp.dps = 30
+
+    z = mpf('0.3') + j/10
+    omega1 = mpf(1)
+    omega2 = j/2
+    omega = (omega1, omega2)
+
+    eta1_increment = weierzeta(z + 2*omega1, omega=omega)
+    eta1_increment -= weierzeta(z, omega=omega)
+    eta2_increment = weierzeta(z + 2*omega2, omega=omega)
+    eta2_increment -= weierzeta(z, omega=omega)
+    assert mpc_ae(eta1_increment*omega2 - eta2_increment*omega1,
+                  pi*j, eps=eps*1000)
+
+    eta1 = weierzeta(omega1, omega=omega)
+    eta2 = weierzeta(omega2, omega=omega)
+    assert mpc_ae(eta1*omega2 - eta2*omega1, pi*j/2, eps=eps*1000)
 
 def test_weierstrass_sigma_zeta_identities():
     mp.dps = 30
 
     z = mpf('0.3')
     tau = j/2
-    assert mpc_ae(diff(lambda t: wsigma(t, tau=tau), z) /
-                  wsigma(z, tau=tau), wzeta(z, tau=tau), eps=eps*1000)
-    assert mpc_ae(diff(lambda t: wzeta(t, tau=tau), z),
-                  -wp(z, tau=tau), eps=eps*1000)
+    assert mpc_ae(diff(lambda t: weiersigma(t, tau=tau), z) /
+                  weiersigma(z, tau=tau), weierzeta(z, tau=tau),
+                  eps=eps*1000)
+    assert mpc_ae(diff(lambda t: weierzeta(t, tau=tau), z),
+                  -weierp(z, tau=tau), eps=eps*1000)
 
-def test_weierstrass_invwp():
+def test_weierstrass_weierpinv():
     mp.dps = 30
 
     z = mpf('0.3')
     g2, g3 = mpf(60), mpf(140)
-    p = wp(z, g2=g2, g3=g3)
-    pp = wpprime(z, g2=g2, g3=g3)
-    z2 = invwp(p, g2=g2, g3=g3)
+    p = weierp(z, g2=g2, g3=g3)
+    pp = weierpprime(z, g2=g2, g3=g3)
+    z2 = weierpinv(p, g2=g2, g3=g3)
     assert mpc_ae(z2, z, eps=eps*1000)
-    assert mpc_ae(wp(z2, g2=g2, g3=g3), p, eps=eps*1000)
+    assert mpc_ae(weierp(z2, g2=g2, g3=g3), p, eps=eps*1000)
 
-    z2 = invwp(p, g2=g2, g3=g3, w_prime=pp)
+    z2 = weierpinv(p, g2=g2, g3=g3, weierp_prime=pp)
     assert mpc_ae(z2, z, eps=eps*1000)
-    assert mpc_ae(wpprime(z2, g2=g2, g3=g3), pp, eps=eps*1000)
+    assert mpc_ae(weierpprime(z2, g2=g2, g3=g3), pp, eps=eps*1000)
 
-    z2 = invwp(p, g2=g2, g3=g3, w_prime=-pp)
+    z2 = weierpinv(p, g2=g2, g3=g3, weierp_prime=-pp)
     assert mpc_ae(z2, -z, eps=eps*1000)
-    assert mpc_ae(wpprime(z2, g2=g2, g3=g3), -pp, eps=eps*1000)
+    assert mpc_ae(weierpprime(z2, g2=g2, g3=g3), -pp, eps=eps*1000)
+
+def test_weierstrass_p_agrees_with_jacobi_sn():
+    mp.dps = 30
+
+    # If e1 + e2 + e3 = 0, then
+    #
+    #     wp(z; g2, g3) = e3 + (e1 - e3)/sn(sqrt(e1 - e3)*z, m)**2
+    #
+    # where
+    #
+    #     m = (e2 - e3)/(e1 - e3)
+    #
+    # and 4*(x - e1)*(x - e2)*(x - e3) = 4*x**3 - g2*x - g3.
+    e1 = mpf(2)
+    e2 = -mpf(1)/2
+    e3 = -mpf(3)/2
+
+    g2 = -4*(e1*e2 + e1*e3 + e2*e3)
+    g3 = 4*e1*e2*e3
+
+    scale = sqrt(e1 - e3)
+    m = (e2 - e3)/(e1 - e3)
+
+    z_values = [
+        mpf('0.2'),
+        mpf('0.3'),
+        mpf('0.2') + j/10,
+        mpf('0.4') - j/20,
+    ]
+
+    for z in z_values:
+        sn = ellipfun('sn', scale*z, m)
+        expected = e3 + (e1 - e3)/sn**2
+        assert mpc_ae(weierp(z, g2=g2, g3=g3), expected, eps=eps*1000)
 
 def test_weierstrass_invalid_parameterization():
     z = mpf('0.3')
-    pytest.raises(ValueError, lambda: wp(z))
-    pytest.raises(ValueError, lambda: wp(z, g2=mpf(1)))
-    pytest.raises(ValueError, lambda: wp(z, tau=-j))
-    pytest.raises(ValueError, lambda: wp(z, omega=(mpf(1), -j)))
+    pytest.raises(ValueError, lambda: weierp(z))
+    pytest.raises(ValueError, lambda: weierp(z, g2=mpf(1)))
+    pytest.raises(ValueError, lambda: weierp(z, tau=-j))
+    pytest.raises(ValueError, lambda: weierp(z, omega=(mpf(1), -j)))
     pytest.raises(ValueError,
-                  lambda: wp(z, g2=mpf(60), g3=mpf(140), tau=j/2))
-    pytest.raises(ValueError, lambda: w_invariants(mpf(1), -j))
-    pytest.raises(ValueError, lambda: w_invariants(mpf(1)))
-    pytest.raises(ValueError, lambda: w_half_periods(mpf(1)))
+                  lambda: weierp(z, g2=mpf(60), g3=mpf(140), tau=j/2))
+    pytest.raises(ValueError, lambda: weierinvariants(mpf(1), -j))
+    pytest.raises(ValueError, lambda: weierinvariants(mpf(1)))
+    pytest.raises(ValueError, lambda: weierhalfperiods(mpf(1)))

--- a/mpmath/tests/test_elliptic.py
+++ b/mpmath/tests/test_elliptic.py
@@ -728,7 +728,7 @@ def test_weierstrass_special_half_periods():
     mp.dps = 30
 
     # Scaled version of http://dlmf.nist.gov/23.5.E5
-    lemniscatic = gamma(mpf(1)/4)**2/(4*sqrt(pi))
+    lemniscatic = gamma(1/4)**2/(4*sqrt(pi))
     omega1, omega2 = weierhalfperiods(1, 0)
     lattice_points = [
         m*omega1 + n*omega2
@@ -749,22 +749,22 @@ def test_weierstrass_special_half_periods():
 def test_weierstrass_half_periods_high_precision():
     mp.dps = 80
 
-    g2 = mpf(60)
-    g3 = mpf(140)
+    g2 = 60
+    g3 = 140
     omega1, omega2 = weierhalfperiods(g2, g3)
     g2_roundtrip, g3_roundtrip = weierinvariants(omega1, omega2)
 
-    assert mpc_ae(g2, g2_roundtrip, eps=eps*10000)
-    assert mpc_ae(g3, g3_roundtrip, eps=eps*10000)
+    assert mpc_ae(g2_roundtrip, g2, eps=eps*10000)
+    assert mpc_ae(g3_roundtrip, g3, eps=eps*10000)
 
 def test_weierstrass_parameter_conversions_with_kleinj():
     mp.dps = 30
 
-    tau = mpf('0.625') + mpf('0.75')*j
+    tau = 0.625 + 0.75j
     g2, g3 = weierinvariants(0.5, tau/2)
     recovered_omega1, recovered_omega2 = weierhalfperiods(g2, g3)
     recovered_tau = recovered_omega2/recovered_omega1
-    j_from_invariants = g2**3/(g2**3 - mpf(27)*g3**2)
+    j_from_invariants = g2**3/(g2**3 - 27*g3**2)
 
     assert mpc_ae(kleinj(tau), j_from_invariants, eps=eps*1000)
     assert mpc_ae(kleinj(recovered_tau), kleinj(tau), eps=eps*1000)

--- a/mpmath/tests/test_elliptic.py
+++ b/mpmath/tests/test_elliptic.py
@@ -693,7 +693,7 @@ def test_weierstrass_tau_uses_normalized_periods():
 
     z = mpf('0.3')
     tau = j/2
-    omega1 = mpf(1)/2
+    omega1 = 0.5
     omega2 = tau/2
 
     for f in [weierp, weierpprime, weiersigma, weierzeta]:
@@ -705,8 +705,7 @@ def test_weierstrass_g2g3_differential_equation():
     mp.dps = 30
 
     z = mpf('0.3')
-    for g2, g3 in [(mpf(60), mpf(140)), (mpf(0), mpf(140)),
-                   (mpf(60), mpf(0))]:
+    for g2, g3 in [(60, 140), (0, 140), (60, 0)]:
         p = weierp(z, g2=g2, g3=g3)
         pp = weierpprime(z, g2=g2, g3=g3)
         assert mpc_ae(pp**2, 4*p**3 - g2*p - g3, eps=eps*1000)
@@ -714,7 +713,7 @@ def test_weierstrass_g2g3_differential_equation():
 def test_weierstrass_parameter_conversions():
     mp.dps = 30
 
-    omega1 = mpf(1)
+    omega1 = 1
     omega2 = j/2
     g2, g3 = weierinvariants(omega1, omega2)
 
@@ -730,7 +729,7 @@ def test_weierstrass_special_half_periods():
 
     # Scaled version of http://dlmf.nist.gov/23.5.E5
     lemniscatic = gamma(mpf(1)/4)**2/(4*sqrt(pi))
-    omega1, omega2 = weierhalfperiods(mpf(1), mpf(0))
+    omega1, omega2 = weierhalfperiods(1, 0)
     lattice_points = [
         m*omega1 + n*omega2
         for m in [-1, 0, 1]
@@ -742,8 +741,8 @@ def test_weierstrass_special_half_periods():
 
     # Scaled version of http://dlmf.nist.gov/23.5.E9
     equianharmonic = gamma(mpf(1)/3)**3/(4*pi)
-    tau = mpf(1)/2 + sqrt(3)*j/2
-    omega1, omega2 = weierhalfperiods(mpf(0), mpf(1))
+    tau = 0.5 + sqrt(3)*j/2
+    omega1, omega2 = weierhalfperiods(0, 1)
     assert mpc_ae(omega1, equianharmonic, eps=eps*1000)
     assert mpc_ae(omega2, equianharmonic*tau, eps=eps*1000)
 
@@ -762,7 +761,7 @@ def test_weierstrass_parameter_conversions_with_kleinj():
     mp.dps = 30
 
     tau = mpf('0.625') + mpf('0.75')*j
-    g2, g3 = weierinvariants(mpf(1)/2, tau/2)
+    g2, g3 = weierinvariants(0.5, tau/2)
     recovered_omega1, recovered_omega2 = weierhalfperiods(g2, g3)
     recovered_tau = recovered_omega2/recovered_omega1
     j_from_invariants = g2**3/(g2**3 - mpf(27)*g3**2)
@@ -773,11 +772,11 @@ def test_weierstrass_parameter_conversions_with_kleinj():
 def test_weierstrass_half_period_values_are_cubic_roots():
     mp.dps = 30
 
-    omega1 = mpf(1)
+    omega1 = 1
     omega2 = j/2
     g2, g3 = weierinvariants(omega1, omega2)
 
-    roots = polyroots([-g3, -g2, mpf(0), mpf(4)], maxsteps=50)
+    roots = polyroots([-g3, -g2, 0, 4], maxsteps=50)
     half_period_values = [
         weierp(omega1, omega1=omega1, omega2=omega2),
         weierp(omega2, omega1=omega1, omega2=omega2),
@@ -785,7 +784,7 @@ def test_weierstrass_half_period_values_are_cubic_roots():
     ]
 
     for value in half_period_values:
-        assert mpc_ae(4*value**3 - g2*value - g3, mpf(0),
+        assert mpc_ae(4*value**3 - g2*value - g3, 0,
                       eps=eps*1000)
         assert min(abs(value - root) for root in roots) < eps*1000
     for root in roots:
@@ -795,7 +794,7 @@ def test_weierstrass_conversions_with_weierp():
     mp.dps = 30
 
     z = mpf('0.3')
-    g2, g3 = mpf(60), mpf(140)
+    g2, g3 = 60, 140
     omega1, omega2 = weierhalfperiods(g2, g3)
     assert mpc_ae(weierp(z, g2=g2, g3=g3),
                   weierp(z, omega1=omega1, omega2=omega2), eps=eps*1000)
@@ -805,7 +804,7 @@ def test_weierstrass_periodicity():
 
     # http://dlmf.nist.gov/23.2.E9
     z = mpf('0.3')
-    omega1 = mpf(1)
+    omega1 = 1
     omega2 = j/2
     p = weierp(z, omega1=omega1, omega2=omega2)
     pp = weierpprime(z, omega1=omega1, omega2=omega2)
@@ -827,7 +826,7 @@ def test_weierstrass_scaling_laws():
     # http://dlmf.nist.gov/23.10.iv
     z = mpf('0.3')
     scale = mpf('1.7')
-    omega1 = mpf(1)
+    omega1 = 1
     omega2 = j/2
     scaled_omega1 = scale*omega1
     scaled_omega2 = scale*omega2
@@ -854,7 +853,7 @@ def test_weierstrass_tau_omega_parameterizations():
 
     z = mpf('0.3')
     tau = j/2
-    omega1 = mpf(1)/2
+    omega1 = 0.5
     omega2 = tau/2
     for f in [weierp, weierpprime, weiersigma, weierzeta]:
         assert mpc_ae(f(z, tau=tau), f(z, omega1=omega1, omega2=omega2))
@@ -865,7 +864,7 @@ def test_weierstrass_addition_theorem():
     # http://dlmf.nist.gov/23.10.E1
     z = mpf('0.3')
     w = mpf('0.4') + j/10
-    omega1 = mpf(1)
+    omega1 = 1
     omega2 = j/2
 
     pz = weierp(z, omega1=omega1, omega2=omega2)
@@ -883,7 +882,7 @@ def test_weierstrass_zeta_legendre_relation():
     # http://dlmf.nist.gov/23.2.E11
     # http://dlmf.nist.gov/23.2.E14
     z = mpf('0.3') + j/10
-    omega1 = mpf(1)
+    omega1 = 1
     omega2 = j/2
 
     eta1_increment = weierzeta(z + 2*omega1,
@@ -915,7 +914,7 @@ def test_weierstrass_weierpinv():
     mp.dps = 30
 
     z = mpf('0.3')
-    g2, g3 = mpf(60), mpf(140)
+    g2, g3 = 60, 140
     p = weierp(z, g2=g2, g3=g3)
     pp = weierpprime(z, g2=g2, g3=g3)
     z2 = weierpinv(p, g2=g2, g3=g3)
@@ -943,8 +942,8 @@ def test_weierstrass_p_agrees_with_jacobi_sn():
     #
     # and 4*(x - e1)*(x - e2)*(x - e3) = 4*x**3 - g2*x - g3.
     # Shifted version of http://dlmf.nist.gov/23.6.E26
-    e1 = mpf(2)
-    e2 = -mpf(1)/2
+    e1 = 2
+    e2 = -0.5
     e3 = -mpf(3)/2
 
     g2 = -4*(e1*e2 + e1*e3 + e2*e3)
@@ -984,8 +983,8 @@ def test_weierstrass_values_from_wolfram_engine():
     mp.dps = 30
 
     z = mpf(1)/5 + j/10
-    g2 = mpf(23)
-    g3 = -mpf(6)
+    g2 = 23
+    g3 = -6
 
     # Wolfram Engine N[WeierstrassP[1/5 + I/10, {23, -6}], 50]
     res = (mpf('12.034598774562061614120425445264439480909180451987') -
@@ -1012,7 +1011,7 @@ def test_weierstrass_values_from_wolfram_engine():
     assert mpc_ae(result, res, eps=eps*1000)
 
     z = mpf(23)/7 + j/19
-    g2 = mpf(4)
+    g2 = 4
     g3 = j/7
 
     # Wolfram Engine N[WeierstrassP[23/7 + I/19, {4, I/7}], 50]
@@ -1043,12 +1042,11 @@ def test_weierstrass_values_from_wolfram_engine():
 def test_weierstrass_invalid_parameterization():
     z = mpf('0.3')
     pytest.raises(ValueError, lambda: weierp(z))
-    pytest.raises(ValueError, lambda: weierp(z, g2=mpf(1)))
+    pytest.raises(ValueError, lambda: weierp(z, g2=1))
     pytest.raises(ValueError, lambda: weierp(z, tau=-j))
-    pytest.raises(ValueError, lambda: weierp(z, omega1=mpf(1)))
-    pytest.raises(ValueError, lambda: weierp(z, omega1=mpf(1), omega2=-j))
-    pytest.raises(ValueError,
-                  lambda: weierp(z, g2=mpf(60), g3=mpf(140), tau=j/2))
-    pytest.raises(ValueError, lambda: weierinvariants(mpf(1), -j))
-    pytest.raises(TypeError, lambda: weierinvariants(mpf(1)))
-    pytest.raises(TypeError, lambda: weierhalfperiods(mpf(1)))
+    pytest.raises(ValueError, lambda: weierp(z, omega1=1))
+    pytest.raises(ValueError, lambda: weierp(z, omega1=1, omega2=-j))
+    pytest.raises(ValueError, lambda: weierp(z, g2=60, g3=140, tau=j/2))
+    pytest.raises(ValueError, lambda: weierinvariants(1, -j))
+    pytest.raises(TypeError, lambda: weierinvariants(1))
+    pytest.raises(TypeError, lambda: weierhalfperiods(1))


### PR DESCRIPTION
Add Weierstrass wp, wpprime, sigma, zeta, and inverse wp functions with support for invariants, half-periods, and tau parameterizations.

Add conversions between Weierstrass invariants and half-periods, including special lemniscatic and equianharmonic cases. Add tests for differential identities, parameter roundtrips, Klein invariant consistency, cubic roots at half-periods, periodicity, inverse wp, and invalid parameterizations.

Document the new functions in the elliptic functions reference.

Based on (a slightly modified fork) of the pyweierstrass package by @stla / Stéphane Laurent
https://pyweierstrass.readthedocs.io/en/latest/ 
https://github.com/stla/pyweierstrass?tab=GPL-3.0-1-ov-file

All tests pass. In addition to tests in this suite, also confirmed it reproduces expected results when solving known nonlinear diff eqns in various notebooks by comparing against scipy numeric solutions.

**AI use declaration:** Codex was used to assist with mpmath style conversion. All lines of code were manually read by a human (me) and iteratively adjusted. Flake ran. 

Co-authored-by: Stéphane Laurent <stla@users.noreply.github.com>