### PR TITLE
Return 0 at polynomial roots of chebyt/chebyu/gegenbauer instead of raising NoConvergence

### DIFF
--- a/mpmath/functions/orthogonal.py
+++ b/mpmath/functions/orthogonal.py
@@ -320,6 +320,10 @@ def gegenbauer(ctx, n, a, z, **kwargs):
         return 0*(z+n)
     if not z and ctx.isint(n) and int(n.real) % 2:
         return ctx.zero
+    # At a zero of the polynomial the hypergeometric series cancels to
+    # exactly zero; treat sub-precision results as zero instead of failing
+    # to converge (e.g. gegenbauer(2, 1, mpf('0.5')) == 0).
+    kwargs.setdefault('zeroprec', ctx.prec)
     if ctx.isnpint(a+0.5):
         # TODO: something else is required here
         # E.g.: gegenbauer(-2, -0.5, 3) == -12
@@ -456,6 +460,10 @@ def chebyt(ctx, n, x, **kwargs):
         return x * 0
     if kwargs.get('force_series') is None:
         kwargs['force_series'] = True
+    # At a root of the polynomial the series cancels to exactly zero;
+    # treat sub-precision results as zero rather than failing to converge
+    # (e.g. chebyt(mpf('1.5'), mpf('0.5')) == 0).
+    kwargs.setdefault('zeroprec', ctx.prec)
     return ctx.hyp2f1(-n,n,(1,2),(1-x)/2, **kwargs)
 
 @defun_wrapped
@@ -464,6 +472,10 @@ def chebyu(ctx, n, x, **kwargs):
         return x * 0
     if kwargs.get('force_series') is None:
         kwargs['force_series'] = True
+    # At a root of the polynomial the series cancels to exactly zero;
+    # treat sub-precision results as zero rather than failing to converge
+    # (e.g. chebyu(2, mpf('0.5')) == 0).
+    kwargs.setdefault('zeroprec', ctx.prec)
     return (n+1) * ctx.hyp2f1(-n, n+2, (3,2), (1-x)/2, **kwargs)
 
 @defun

--- a/mpmath/tests/test_functions2.py
+++ b/mpmath/tests/test_functions2.py
@@ -720,6 +720,19 @@ def test_orthpoly():
     assert chebyt(10**3, 1j, force_series=False) == chebyt(10**3, 1j)
     pytest.raises(NoConvergence, lambda: chebyt(10**6, 1j))  # issue 852
     assert chebyu(10**3, 1j, force_series=False) == chebyu(10**3, 1j)
+    # at a root the series cancels to exactly zero; must return 0 rather
+    # than raising NoConvergence.  U_2(x)=4x^2-1 and U_5 both vanish at 1/2.
+    assert chebyu(2, mpf('0.5')) == 0
+    assert chebyu(2, mpf('-0.5')) == 0
+    assert chebyu(5, mpf('0.5')) == 0
+    assert chebyu(2, mpc('0.5')) == 0
+    # T_{3/2}(x)=cos(1.5*acos(x)) vanishes at x=1/2 (fractional degree)
+    assert chebyt(mpf('1.5'), mpf('0.5')) == 0
+    # neighbouring non-root values are unchanged
+    assert chebyu(4, mpf('0.5')).ae(-1)
+    assert chebyt(3, mpf('0.5')).ae(-1)
+    # the large-degree guard (issue 852) must remain in force
+    pytest.raises(NoConvergence, lambda: chebyt(10**6, 1j))
     assert legendre(3.5,-1) == inf
     assert legendre(4.5,-1) == -inf
     assert legendre(3.5+1j,-1) == mpc(inf,inf)
@@ -783,6 +796,11 @@ def test_gegenbauer():
     assert gegenbauer(2, 1, 0).ae(-1)
     assert gegenbauer(4, 1.5, 0).ae(1.875)
     assert gegenbauer(2.5, 1, 0).ae(-0.70710678118654752440)
+    # nonzero roots of the polynomial vanish exactly; C_2^1 == U_2 has a
+    # root at 1/2, which previously raised NoConvergence.
+    assert gegenbauer(2, 1, mpf('0.5')) == 0
+    assert gegenbauer(2, 1, mpf('-0.5')) == 0
+    assert gegenbauer(4, 1, mpf('0.5')).ae(-1)
     mp.dps = 200
     assert gegenbauer(2,-1.0, 27397079.00297188) == 0  # issue 461
 


### PR DESCRIPTION
These three orthogonal polynomials are evaluated through a terminating hypergeometric series. At a *root* of the polynomial the series cancels to exactly zero, and `hypsum` cannot obtain relative precision on a zero result, so it raises `NoConvergence` for ordinary input:

```python
>>> from mpmath import chebyu, chebyt, gegenbauer, mpf
>>> chebyu(2, mpf("0.5"))       # U_2(x) = 4x^2 - 1, root at 1/2  -> value 0
NoConvergence: ...
>>> chebyt(mpf("1.5"), mpf("0.5"))
NoConvergence: ...
>>> gegenbauer(2, 1, mpf("0.5"))   # C_2^1 == U_2, same root
NoConvergence: ...
```

All three should return `0`.

**Fix.** Pass `zeroprec=ctx.prec` before the hypergeometric call. This is mpmath's existing convention for treating a sub-precision cancellation as an exact zero — `hyp2f1` already uses it internally and it is documented for `gegenbauer`. It cleanly extends the `z=0` fix in #1101 to the remaining nonzero roots.

The large-degree guard from issue #852 is unaffected: `chebyt(10**6, 1j)` fails because it exceeds `maxterms`, not because of zero cancellation, so it still raises `NoConvergence` (asserted in the added test).

**Tests.** Added to `test_orthpoly` and `test_gegenbauer`: root values return `0` (real, complex, and fractional-degree cases), neighbouring non-root values are unchanged, and the issue-852 guard is re-asserted. Full `test_functions2.py` passes (66 passed, 1 skipped).