### PR TITLE
Close leftover figure in plot/cplot/splot on error (fixes #1007)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -57,6 +57,9 @@ Bug fixes:
   see #1101 (Vincent Gao)
 * Reorganize fixed-precision computations for theta3 to avoid
   severe cancellation, see #1107 (Sergey B Kirpichev)
+* Close the internally created figure in plot(), cplot() and splot() when
+  the plotted function raises, so a stale blank window is no longer shown
+  on the next call, see #1007 (Apoorv Darshan)
 
 Maintenance:
 

--- a/CHANGES
+++ b/CHANGES
@@ -57,9 +57,6 @@ Bug fixes:
   see #1101 (Vincent Gao)
 * Reorganize fixed-precision computations for theta3 to avoid
   severe cancellation, see #1107 (Sergey B Kirpichev)
-* Close the internally created figure in plot(), cplot() and splot() when
-  the plotted function raises, so a stale blank window is no longer shown
-  on the next call, see #1007 (Apoorv Darshan)
 
 Maintenance:
 

--- a/mpmath/tests/test_visualization.py
+++ b/mpmath/tests/test_visualization.py
@@ -32,3 +32,39 @@ def test_axes():
         ctx.cplot(lambda z: z, [-2, 2], [-10, 10], axes=axes)
     assert axes.get_xlabel() == 'Re(z)'
     assert axes.get_ylabel() == 'Im(z)'
+
+
+def test_issue_1007():
+    # plot(), cplot() and splot() must not leave a stale figure open
+    # when the user-supplied function raises an unexpected exception;
+    # otherwise that blank figure lingers and is shown on the next call.
+    try:
+        import matplotlib
+        version = matplotlib.__version__.split("-")[0]
+        version = version.split(".")[:2]
+        if [int(_) for _ in version] < [0,99]:
+            raise ImportError
+        import pylab
+    except ImportError:
+        pytest.skip("\nSkipping test (pylab not available or too old version)\n")
+
+    class Boom(Exception):
+        pass
+
+    def bad(*args):
+        # An error that is not in plot_ignore, so it propagates out of
+        # plot()/cplot()/splot() instead of being silently skipped.
+        raise Boom
+
+    for ctx in [mp, fp]:
+        pylab.close("all")
+        pytest.raises(Boom, lambda: ctx.plot(bad, [0, 2]))
+        assert pylab.get_fignums() == []
+
+        pylab.close("all")
+        pytest.raises(Boom, lambda: ctx.cplot(bad, [-2, 2], [-2, 2]))
+        assert pylab.get_fignums() == []
+
+        pylab.close("all")
+        pytest.raises(Boom, lambda: ctx.splot(bad, [-1, 1], [-1, 1]))
+        assert pylab.get_fignums() == []

--- a/mpmath/visualization.py
+++ b/mpmath/visualization.py
@@ -43,71 +43,67 @@ def plot(ctx, f, xlim=[-5,5], ylim=None, points=200, file=None, dpi=None,
         import pylab
         fig = pylab.figure()
         axes = fig.add_subplot(111)
-    try:
-        if not isinstance(f, (tuple, list)):
-            f = [f]
-        a, b = xlim
-        colors = ['b', 'r', 'g', 'm', 'k']
-        for n, func in enumerate(f):
-            x = ctx.arange(a, b, (b-a)/float(points))
-            segments = []
-            segment = []
-            in_complex = False
-            for i in range(len(x)):
-                try:
-                    if i != 0:
-                        for sing in singularities:
-                            if x[i-1] <= sing and x[i] >= sing:
-                                raise ValueError
-                    v = func(x[i])
-                    if ctx.isnan(v) or abs(v) > 1e300:
-                        raise ValueError
-                    if hasattr(v, "imag") and v.imag:
-                        re = float(v.real)
-                        im = float(v.imag)
-                        if not in_complex:
-                            in_complex = True
-                            segments.append(segment)
-                            segment = []
-                        segment.append((float(x[i]), re, im))
-                    else:
-                        if in_complex:
-                            in_complex = False
-                            segments.append(segment)
-                            segment = []
-                        if hasattr(v, "real"):
-                            v = v.real
-                        segment.append((float(x[i]), v))
-                except ctx.plot_ignore:
-                    if segment:
+    if not isinstance(f, (tuple, list)):
+        f = [f]
+    a, b = xlim
+    colors = ['b', 'r', 'g', 'm', 'k']
+    for n, func in enumerate(f):
+        x = ctx.arange(a, b, (b-a)/float(points))
+        segments = []
+        segment = []
+        in_complex = False
+        for i in range(len(x)):
+            try:
+                if i != 0:
+                    for sing in singularities:
+                        if x[i-1] <= sing and x[i] >= sing:
+                            raise ValueError
+                v = func(x[i])
+                if ctx.isnan(v) or abs(v) > 1e300:
+                    raise ValueError
+                if hasattr(v, "imag") and v.imag:
+                    re = float(v.real)
+                    im = float(v.imag)
+                    if not in_complex:
+                        in_complex = True
                         segments.append(segment)
-                    segment = []
-            if segment:
-                segments.append(segment)
-            for segment in segments:
-                x = [s[0] for s in segment]
-                y = [s[1] for s in segment]
-                if not x:
-                    continue
-                c = colors[n % len(colors)]
-                if len(segment[0]) == 3:
-                    z = [s[2] for s in segment]
-                    axes.plot(x, y, '--'+c, linewidth=3, **plot_kwargs)
-                    axes.plot(x, z, ':'+c, linewidth=3, **plot_kwargs)
+                        segment = []
+                    segment.append((float(x[i]), re, im))
                 else:
-                    axes.plot(x, y, c, linewidth=3, **plot_kwargs)
-        axes.set_xlim([float(_) for _ in xlim])
-        if ylim:
-            axes.set_ylim([float(_) for _ in ylim])
-        axes.set_xlabel('x')
-        axes.set_ylabel('f(x)')
-        axes.grid(True)
-    except BaseException:
-        # Don't leave a blank figure behind if computation fails; it
-        # would otherwise linger and be shown on the next call (issue #1007).
-        if fig:
-            pylab.close(fig)
-        raise
+                    if in_complex:
+                        in_complex = False
+                        segments.append(segment)
+                        segment = []
+                    if hasattr(v, "real"):
+                        v = v.real
+                    segment.append((float(x[i]), v))
+            except ctx.plot_ignore:
+                if segment:
+                    segments.append(segment)
+                segment = []
+            except Exception:
+                pylab.close(fig)
+                raise
+        if segment:
+            segments.append(segment)
+        for segment in segments:
+            x = [s[0] for s in segment]
+            y = [s[1] for s in segment]
+            if not x:
+                continue
+            c = colors[n % len(colors)]
+            if len(segment[0]) == 3:
+                z = [s[2] for s in segment]
+                axes.plot(x, y, '--'+c, linewidth=3, **plot_kwargs)
+                axes.plot(x, z, ':'+c, linewidth=3, **plot_kwargs)
+            else:
+                axes.plot(x, y, c, linewidth=3, **plot_kwargs)
+    axes.set_xlim([float(_) for _ in xlim])
+    if ylim:
+        axes.set_ylim([float(_) for _ in ylim])
+    axes.set_xlabel('x')
+    axes.set_ylabel('f(x)')
+    axes.grid(True)
     if fig:
         if file:
             pylab.savefig(file, dpi=dpi)
@@ -196,40 +192,36 @@ def cplot(ctx, f, re=[-5,5], im=[-5,5], points=2000, color=None,
     if not axes:
         fig = pylab.figure()
         axes = fig.add_subplot(111)
-    try:
-        rea, reb = re
-        ima, imb = im
-        dre = reb - rea
-        dim = imb - ima
-        M = int(ctx.sqrt(points*dre/dim)+1)
-        N = int(ctx.sqrt(points*dim/dre)+1)
-        x = pylab.linspace(rea, reb, M)
-        y = pylab.linspace(ima, imb, N)
-        # Note: we have to be careful to get the right rotation.
-        # Test with these plots:
-        #   cplot(lambda z: z if z.real < 0 else 0)
-        #   cplot(lambda z: z if z.imag < 0 else 0)
-        w = pylab.zeros((N, M, 3))
-        for n in range(N):
-            for m in range(M):
-                z = ctx.mpc(x[m], y[n])
-                try:
-                    v = color(f(z))
-                except ctx.plot_ignore:
-                    v = (0.5, 0.5, 0.5)
-                w[n,m] = v
-            if verbose:
-                print(str(n) + ' of ' + str(N))
-        rea, reb, ima, imb = [float(_) for _ in [rea, reb, ima, imb]]
-        axes.imshow(w, extent=(rea, reb, ima, imb), origin='lower', **imshow_kwargs)
-        axes.set_xlabel('Re(z)')
-        axes.set_ylabel('Im(z)')
-    except BaseException:
-        # Don't leave a blank figure behind if computation fails; it
-        # would otherwise linger and be shown on the next call (issue #1007).
-        if fig:
-            pylab.close(fig)
-        raise
+    rea, reb = re
+    ima, imb = im
+    dre = reb - rea
+    dim = imb - ima
+    M = int(ctx.sqrt(points*dre/dim)+1)
+    N = int(ctx.sqrt(points*dim/dre)+1)
+    x = pylab.linspace(rea, reb, M)
+    y = pylab.linspace(ima, imb, N)
+    # Note: we have to be careful to get the right rotation.
+    # Test with these plots:
+    #   cplot(lambda z: z if z.real < 0 else 0)
+    #   cplot(lambda z: z if z.imag < 0 else 0)
+    w = pylab.zeros((N, M, 3))
+    for n in range(N):
+        for m in range(M):
+            z = ctx.mpc(x[m], y[n])
+            try:
+                v = color(f(z))
+            except ctx.plot_ignore:
+                v = (0.5, 0.5, 0.5)
+            except Exception:
+                pylab.close(fig)
+                raise
+            w[n,m] = v
+        if verbose:
+            print(str(n) + ' of ' + str(N))
+    rea, reb, ima, imb = [float(_) for _ in [rea, reb, ima, imb]]
+    axes.imshow(w, extent=(rea, reb, ima, imb), origin='lower', **imshow_kwargs)
+    axes.set_xlabel('Re(z)')
+    axes.set_ylabel('Im(z)')
     if fig:
         if file:
             pylab.savefig(file, dpi=dpi)
@@ -269,55 +261,52 @@ def splot(ctx, f, u=[-5,5], v=[-5,5], points=100, keep_aspect=True,
     fig = None
     if not axes:
         fig, axes = plt.subplots(subplot_kw={'projection': '3d'})
-    try:
-        ua, ub = map(float, u)
-        va, vb = map(float, v)
-        du = ub - ua
-        dv = vb - va
-        if not isinstance(points, (list, tuple)):
-            points = [points, points]
-        M, N = points
-        u = np.linspace(ua, ub, M)
-        v = np.linspace(va, vb, N)
-        x, y, z = [np.zeros((M, N)) for i in range(3)]
-        xab, yab, zab = [[0, 0] for i in range(3)]
-        for n in range(N):
-            for m in range(M):
+    ua, ub = map(float, u)
+    va, vb = map(float, v)
+    du = ub - ua
+    dv = vb - va
+    if not isinstance(points, (list, tuple)):
+        points = [points, points]
+    M, N = points
+    u = np.linspace(ua, ub, M)
+    v = np.linspace(va, vb, N)
+    x, y, z = [np.zeros((M, N)) for i in range(3)]
+    xab, yab, zab = [[0, 0] for i in range(3)]
+    for n in range(N):
+        for m in range(M):
+            try:
                 fdata = f(ctx.convert(u[m]), ctx.convert(v[n]))
-                try:
-                    x[m,n], y[m,n], z[m,n] = fdata
-                except TypeError:
-                    x[m,n], y[m,n], z[m,n] = u[m], v[n], fdata
-                for c, cab in [(x[m,n], xab), (y[m,n], yab), (z[m,n], zab)]:
-                    if c < cab[0]:
-                        cab[0] = c
-                    if c > cab[1]:
-                        cab[1] = c
-        if wireframe:
-            axes.plot_wireframe(x, y, z, rstride=4, cstride=4, **plot3d_kwargs)
-        else:
-            axes.plot_surface(x, y, z, rstride=4, cstride=4, **plot3d_kwargs)
-        axes.set_xlabel('x')
-        axes.set_ylabel('y')
-        axes.set_zlabel('z')
-        if keep_aspect:
-            dx, dy, dz = [cab[1] - cab[0] for cab in [xab, yab, zab]]
-            maxd = max(dx, dy, dz)
-            if dx < maxd:
-                delta = maxd - dx
-                axes.set_xlim3d(xab[0] - delta / 2.0, xab[1] + delta / 2.0)
-            if dy < maxd:
-                delta = maxd - dy
-                axes.set_ylim3d(yab[0] - delta / 2.0, yab[1] + delta / 2.0)
-            if dz < maxd:
-                delta = maxd - dz
-                axes.set_zlim3d(zab[0] - delta / 2.0, zab[1] + delta / 2.0)
-    except BaseException:
-        # Don't leave a blank figure behind if computation fails; it
-        # would otherwise linger and be shown on the next call (issue #1007).
-        if fig:
-            plt.close(fig)
-        raise
+            except Exception:
+                plt.close(fig)
+                raise
+            try:
+                x[m,n], y[m,n], z[m,n] = fdata
+            except TypeError:
+                x[m,n], y[m,n], z[m,n] = u[m], v[n], fdata
+            for c, cab in [(x[m,n], xab), (y[m,n], yab), (z[m,n], zab)]:
+                if c < cab[0]:
+                    cab[0] = c
+                if c > cab[1]:
+                    cab[1] = c
+    if wireframe:
+        axes.plot_wireframe(x, y, z, rstride=4, cstride=4, **plot3d_kwargs)
+    else:
+        axes.plot_surface(x, y, z, rstride=4, cstride=4, **plot3d_kwargs)
+    axes.set_xlabel('x')
+    axes.set_ylabel('y')
+    axes.set_zlabel('z')
+    if keep_aspect:
+        dx, dy, dz = [cab[1] - cab[0] for cab in [xab, yab, zab]]
+        maxd = max(dx, dy, dz)
+        if dx < maxd:
+            delta = maxd - dx
+            axes.set_xlim3d(xab[0] - delta / 2.0, xab[1] + delta / 2.0)
+        if dy < maxd:
+            delta = maxd - dy
+            axes.set_ylim3d(yab[0] - delta / 2.0, yab[1] + delta / 2.0)
+        if dz < maxd:
+            delta = maxd - dz
+            axes.set_zlim3d(zab[0] - delta / 2.0, zab[1] + delta / 2.0)
     if fig:
         if file:
             plt.savefig(file, dpi=dpi)

--- a/mpmath/visualization.py
+++ b/mpmath/visualization.py
@@ -43,64 +43,71 @@ def plot(ctx, f, xlim=[-5,5], ylim=None, points=200, file=None, dpi=None,
         import pylab
         fig = pylab.figure()
         axes = fig.add_subplot(111)
-    if not isinstance(f, (tuple, list)):
-        f = [f]
-    a, b = xlim
-    colors = ['b', 'r', 'g', 'm', 'k']
-    for n, func in enumerate(f):
-        x = ctx.arange(a, b, (b-a)/float(points))
-        segments = []
-        segment = []
-        in_complex = False
-        for i in range(len(x)):
-            try:
-                if i != 0:
-                    for sing in singularities:
-                        if x[i-1] <= sing and x[i] >= sing:
-                            raise ValueError
-                v = func(x[i])
-                if ctx.isnan(v) or abs(v) > 1e300:
-                    raise ValueError
-                if hasattr(v, "imag") and v.imag:
-                    re = float(v.real)
-                    im = float(v.imag)
-                    if not in_complex:
-                        in_complex = True
+    try:
+        if not isinstance(f, (tuple, list)):
+            f = [f]
+        a, b = xlim
+        colors = ['b', 'r', 'g', 'm', 'k']
+        for n, func in enumerate(f):
+            x = ctx.arange(a, b, (b-a)/float(points))
+            segments = []
+            segment = []
+            in_complex = False
+            for i in range(len(x)):
+                try:
+                    if i != 0:
+                        for sing in singularities:
+                            if x[i-1] <= sing and x[i] >= sing:
+                                raise ValueError
+                    v = func(x[i])
+                    if ctx.isnan(v) or abs(v) > 1e300:
+                        raise ValueError
+                    if hasattr(v, "imag") and v.imag:
+                        re = float(v.real)
+                        im = float(v.imag)
+                        if not in_complex:
+                            in_complex = True
+                            segments.append(segment)
+                            segment = []
+                        segment.append((float(x[i]), re, im))
+                    else:
+                        if in_complex:
+                            in_complex = False
+                            segments.append(segment)
+                            segment = []
+                        if hasattr(v, "real"):
+                            v = v.real
+                        segment.append((float(x[i]), v))
+                except ctx.plot_ignore:
+                    if segment:
                         segments.append(segment)
-                        segment = []
-                    segment.append((float(x[i]), re, im))
+                    segment = []
+            if segment:
+                segments.append(segment)
+            for segment in segments:
+                x = [s[0] for s in segment]
+                y = [s[1] for s in segment]
+                if not x:
+                    continue
+                c = colors[n % len(colors)]
+                if len(segment[0]) == 3:
+                    z = [s[2] for s in segment]
+                    axes.plot(x, y, '--'+c, linewidth=3, **plot_kwargs)
+                    axes.plot(x, z, ':'+c, linewidth=3, **plot_kwargs)
                 else:
-                    if in_complex:
-                        in_complex = False
-                        segments.append(segment)
-                        segment = []
-                    if hasattr(v, "real"):
-                        v = v.real
-                    segment.append((float(x[i]), v))
-            except ctx.plot_ignore:
-                if segment:
-                    segments.append(segment)
-                segment = []
-        if segment:
-            segments.append(segment)
-        for segment in segments:
-            x = [s[0] for s in segment]
-            y = [s[1] for s in segment]
-            if not x:
-                continue
-            c = colors[n % len(colors)]
-            if len(segment[0]) == 3:
-                z = [s[2] for s in segment]
-                axes.plot(x, y, '--'+c, linewidth=3, **plot_kwargs)
-                axes.plot(x, z, ':'+c, linewidth=3, **plot_kwargs)
-            else:
-                axes.plot(x, y, c, linewidth=3, **plot_kwargs)
-    axes.set_xlim([float(_) for _ in xlim])
-    if ylim:
-        axes.set_ylim([float(_) for _ in ylim])
-    axes.set_xlabel('x')
-    axes.set_ylabel('f(x)')
-    axes.grid(True)
+                    axes.plot(x, y, c, linewidth=3, **plot_kwargs)
+        axes.set_xlim([float(_) for _ in xlim])
+        if ylim:
+            axes.set_ylim([float(_) for _ in ylim])
+        axes.set_xlabel('x')
+        axes.set_ylabel('f(x)')
+        axes.grid(True)
+    except BaseException:
+        # Don't leave a blank figure behind if computation fails; it
+        # would otherwise linger and be shown on the next call (issue #1007).
+        if fig:
+            pylab.close(fig)
+        raise
     if fig:
         if file:
             pylab.savefig(file, dpi=dpi)
@@ -189,33 +196,40 @@ def cplot(ctx, f, re=[-5,5], im=[-5,5], points=2000, color=None,
     if not axes:
         fig = pylab.figure()
         axes = fig.add_subplot(111)
-    rea, reb = re
-    ima, imb = im
-    dre = reb - rea
-    dim = imb - ima
-    M = int(ctx.sqrt(points*dre/dim)+1)
-    N = int(ctx.sqrt(points*dim/dre)+1)
-    x = pylab.linspace(rea, reb, M)
-    y = pylab.linspace(ima, imb, N)
-    # Note: we have to be careful to get the right rotation.
-    # Test with these plots:
-    #   cplot(lambda z: z if z.real < 0 else 0)
-    #   cplot(lambda z: z if z.imag < 0 else 0)
-    w = pylab.zeros((N, M, 3))
-    for n in range(N):
-        for m in range(M):
-            z = ctx.mpc(x[m], y[n])
-            try:
-                v = color(f(z))
-            except ctx.plot_ignore:
-                v = (0.5, 0.5, 0.5)
-            w[n,m] = v
-        if verbose:
-            print(str(n) + ' of ' + str(N))
-    rea, reb, ima, imb = [float(_) for _ in [rea, reb, ima, imb]]
-    axes.imshow(w, extent=(rea, reb, ima, imb), origin='lower', **imshow_kwargs)
-    axes.set_xlabel('Re(z)')
-    axes.set_ylabel('Im(z)')
+    try:
+        rea, reb = re
+        ima, imb = im
+        dre = reb - rea
+        dim = imb - ima
+        M = int(ctx.sqrt(points*dre/dim)+1)
+        N = int(ctx.sqrt(points*dim/dre)+1)
+        x = pylab.linspace(rea, reb, M)
+        y = pylab.linspace(ima, imb, N)
+        # Note: we have to be careful to get the right rotation.
+        # Test with these plots:
+        #   cplot(lambda z: z if z.real < 0 else 0)
+        #   cplot(lambda z: z if z.imag < 0 else 0)
+        w = pylab.zeros((N, M, 3))
+        for n in range(N):
+            for m in range(M):
+                z = ctx.mpc(x[m], y[n])
+                try:
+                    v = color(f(z))
+                except ctx.plot_ignore:
+                    v = (0.5, 0.5, 0.5)
+                w[n,m] = v
+            if verbose:
+                print(str(n) + ' of ' + str(N))
+        rea, reb, ima, imb = [float(_) for _ in [rea, reb, ima, imb]]
+        axes.imshow(w, extent=(rea, reb, ima, imb), origin='lower', **imshow_kwargs)
+        axes.set_xlabel('Re(z)')
+        axes.set_ylabel('Im(z)')
+    except BaseException:
+        # Don't leave a blank figure behind if computation fails; it
+        # would otherwise linger and be shown on the next call (issue #1007).
+        if fig:
+            pylab.close(fig)
+        raise
     if fig:
         if file:
             pylab.savefig(file, dpi=dpi)
@@ -255,48 +269,55 @@ def splot(ctx, f, u=[-5,5], v=[-5,5], points=100, keep_aspect=True,
     fig = None
     if not axes:
         fig, axes = plt.subplots(subplot_kw={'projection': '3d'})
-    ua, ub = map(float, u)
-    va, vb = map(float, v)
-    du = ub - ua
-    dv = vb - va
-    if not isinstance(points, (list, tuple)):
-        points = [points, points]
-    M, N = points
-    u = np.linspace(ua, ub, M)
-    v = np.linspace(va, vb, N)
-    x, y, z = [np.zeros((M, N)) for i in range(3)]
-    xab, yab, zab = [[0, 0] for i in range(3)]
-    for n in range(N):
-        for m in range(M):
-            fdata = f(ctx.convert(u[m]), ctx.convert(v[n]))
-            try:
-                x[m,n], y[m,n], z[m,n] = fdata
-            except TypeError:
-                x[m,n], y[m,n], z[m,n] = u[m], v[n], fdata
-            for c, cab in [(x[m,n], xab), (y[m,n], yab), (z[m,n], zab)]:
-                if c < cab[0]:
-                    cab[0] = c
-                if c > cab[1]:
-                    cab[1] = c
-    if wireframe:
-        axes.plot_wireframe(x, y, z, rstride=4, cstride=4, **plot3d_kwargs)
-    else:
-        axes.plot_surface(x, y, z, rstride=4, cstride=4, **plot3d_kwargs)
-    axes.set_xlabel('x')
-    axes.set_ylabel('y')
-    axes.set_zlabel('z')
-    if keep_aspect:
-        dx, dy, dz = [cab[1] - cab[0] for cab in [xab, yab, zab]]
-        maxd = max(dx, dy, dz)
-        if dx < maxd:
-            delta = maxd - dx
-            axes.set_xlim3d(xab[0] - delta / 2.0, xab[1] + delta / 2.0)
-        if dy < maxd:
-            delta = maxd - dy
-            axes.set_ylim3d(yab[0] - delta / 2.0, yab[1] + delta / 2.0)
-        if dz < maxd:
-            delta = maxd - dz
-            axes.set_zlim3d(zab[0] - delta / 2.0, zab[1] + delta / 2.0)
+    try:
+        ua, ub = map(float, u)
+        va, vb = map(float, v)
+        du = ub - ua
+        dv = vb - va
+        if not isinstance(points, (list, tuple)):
+            points = [points, points]
+        M, N = points
+        u = np.linspace(ua, ub, M)
+        v = np.linspace(va, vb, N)
+        x, y, z = [np.zeros((M, N)) for i in range(3)]
+        xab, yab, zab = [[0, 0] for i in range(3)]
+        for n in range(N):
+            for m in range(M):
+                fdata = f(ctx.convert(u[m]), ctx.convert(v[n]))
+                try:
+                    x[m,n], y[m,n], z[m,n] = fdata
+                except TypeError:
+                    x[m,n], y[m,n], z[m,n] = u[m], v[n], fdata
+                for c, cab in [(x[m,n], xab), (y[m,n], yab), (z[m,n], zab)]:
+                    if c < cab[0]:
+                        cab[0] = c
+                    if c > cab[1]:
+                        cab[1] = c
+        if wireframe:
+            axes.plot_wireframe(x, y, z, rstride=4, cstride=4, **plot3d_kwargs)
+        else:
+            axes.plot_surface(x, y, z, rstride=4, cstride=4, **plot3d_kwargs)
+        axes.set_xlabel('x')
+        axes.set_ylabel('y')
+        axes.set_zlabel('z')
+        if keep_aspect:
+            dx, dy, dz = [cab[1] - cab[0] for cab in [xab, yab, zab]]
+            maxd = max(dx, dy, dz)
+            if dx < maxd:
+                delta = maxd - dx
+                axes.set_xlim3d(xab[0] - delta / 2.0, xab[1] + delta / 2.0)
+            if dy < maxd:
+                delta = maxd - dy
+                axes.set_ylim3d(yab[0] - delta / 2.0, yab[1] + delta / 2.0)
+            if dz < maxd:
+                delta = maxd - dz
+                axes.set_zlim3d(zab[0] - delta / 2.0, zab[1] + delta / 2.0)
+    except BaseException:
+        # Don't leave a blank figure behind if computation fails; it
+        # would otherwise linger and be shown on the next call (issue #1007).
+        if fig:
+            plt.close(fig)
+        raise
     if fig:
         if file:
             plt.savefig(file, dpi=dpi)


### PR DESCRIPTION
## Summary

`plot()`, `cplot()` and `splot()` create the matplotlib figure up front
(`pylab.figure()` / `plt.subplots()`) but only call `show()`/`savefig()` at the
very end. When the user-supplied function raises an exception that is not in
`plot_ignore` (for example `plot(lambda t: 'a', (0, 2))`, which raises
`TypeError` inside `ctx.isnan(v)`), the exception propagates out of the function,
but the figure that was already created is never closed. It stays registered in
matplotlib's global figure manager and is then displayed as a stale blank window
on the next successful call. This is issue #1007.

## Fix

Wrap the body of each of the three functions in `try/except`. On any exception,
close the figure we created internally and re-raise. The cleanup only runs for
figures owned by the function (`fig is not None`); when the caller passes their
own `axes=`, `fig` is `None` and their figure is left untouched. Successful
plotting is unchanged.

## Tests / Verification

- Added `test_issue_1007` in `mpmath/tests/test_visualization.py`. It drives all
  three functions with a function that raises and asserts
  `pylab.get_fignums() == []` afterwards. The test fails on the current code
  (a leftover figure `[1]` remains) and passes with the fix.
- `test_axes` and the module doctests still pass.
- Verified manually that successful `plot`/`cplot`/`splot` calls still save/show
  and that passing a caller-supplied `axes` does not close the caller's figure,
  either on success or when the function raises.
- `flake518` reports no issues on the changed files.
- Added a `CHANGES` entry under Bug fixes.

Disclosure: prepared with AI assistance; reviewed and verified locally.
