### PR TITLE
Fix last-digit rounding of the "f" format type

### DIFF
--- a/mpmath/libmp/libmpf.py
+++ b/mpmath/libmp/libmpf.py
@@ -1086,12 +1086,12 @@ def to_digits_exp(s, dps, base=10):
     return sign, digits, exponent
 
 def round_digits(sign, digits, dps, base, rnd=round_down, fixed=False,
-                 sticky=False):
+                 inexact=False):
     """
     Returns the rounded digits, and the number of places the decimal point was
     shifted.
 
-    ``sticky`` marks that the value has a nonzero remainder past the last
+    ``inexact`` marks that the value has a nonzero remainder past the last
     supplied digit, so directed and nearest rounding round it up even when
     every extracted guard digit is zero.
     """
@@ -1121,7 +1121,7 @@ def round_digits(sign, digits, dps, base, rnd=round_down, fixed=False,
         # The first digit after dps is a 5 and we should determine whether we
         # round it up or down.
         if digits[dps] == rnd_digs[0]:
-            tie_down = not sticky
+            tie_down = not inexact
 
             # If the digit we round to is even, we may round down if all the
             # following digits are 0.
@@ -1136,7 +1136,7 @@ def round_digits(sign, digits, dps, base, rnd=round_down, fixed=False,
     elif rnd == round_up:
         # If any digit following a 0 is different from zero, we round up.
         if digits[dps] == '0':
-            tie_up = sticky
+            tie_up = inexact
             for i in range(dps+1, len(digits)):
                 if digits[i] != '0':
                     tie_up = True
@@ -1491,43 +1491,30 @@ def format_fixed(s, dps, rnd=round_down):
             s, max(dps+exponent+4, int(s[3]/blog2_10)), base)
     # to_digits_exp truncates; flag a nonzero remainder past the last digit so
     # rounding is not fooled by a short zero tail (#1131).
-    sticky = s[2] + len(digits) - 1 - exponent < 0
+    inexact = s[2] + len(digits) - 1 - exponent < 0
     orig_dps = dps
     dps += exponent + 1
 
-    # The value's leading digit is past the last requested place, so it rounds
-    # to 0 -- or to a single unit there when rounding away from zero (#1131).
     if dps < 0:
-        if rnd == round_ceiling:
-            roundup = not s[0]
-        elif rnd == round_floor:
-            roundup = bool(s[0])
-        else:
-            roundup = rnd == round_up
-        digits = '1'.rjust(orig_dps + 1, '0') if roundup else '0'*(orig_dps + 1)
-        int_part, frac_part = digits[0], digits[1:]
+        # The number we want to print is lower in magnitude that the
+        # requested precision.
+        digits = '0'*(-dps) + digits
+        exponent -= dps
+        dps = 0
 
+    digits, exp_add = round_digits(s[0], digits, dps, base, rnd, True, inexact)
+    exponent += exp_add
+
+    # Here we prepend the corresponding 0s to the digits string, according
+    # to the value of exponent
+    split = 1
+    if exponent < 0:
+        digits = "0"*(-exponent) + digits
     else:
-        digits, exp_add = round_digits(s[0], digits, dps, base, rnd, True,
-                                       sticky)
-        exponent += exp_add
+        split += exponent
 
-        # Here we prepend the corresponding 0s to the digits string, according
-        # to the value of exponent
-        if exponent < 0:
-            digits = ("0"*(-exponent)) + digits
-            split = 1
-        else:
-            split = exponent + 1
-        int_part = digits[:split]
-
-        # Finally, assemble the digits including the decimal point
-        if orig_dps == 0:
-            return int_part, ''
-
-        frac_part = digits[split:]
-
-    return int_part, frac_part
+    # Finally, assemble the digits including the decimal point
+    return digits[:split], digits[split:]
 
 
 def format_scientific(s, dps, rnd=round_down):

--- a/mpmath/libmp/libmpf.py
+++ b/mpmath/libmp/libmpf.py
@@ -1085,10 +1085,15 @@ def to_digits_exp(s, dps, base=10):
     exponent += len(digits) - fixdps - 1
     return sign, digits, exponent
 
-def round_digits(sign, digits, dps, base, rnd=round_down, fixed=False):
+def round_digits(sign, digits, dps, base, rnd=round_down, fixed=False,
+                 sticky=False):
     """
     Returns the rounded digits, and the number of places the decimal point was
     shifted.
+
+    ``sticky`` marks that the value has a nonzero remainder past the last
+    supplied digit, so directed and nearest rounding round it up even when
+    every extracted guard digit is zero.
     """
 
     assert len(digits) > dps
@@ -1116,7 +1121,7 @@ def round_digits(sign, digits, dps, base, rnd=round_down, fixed=False):
         # The first digit after dps is a 5 and we should determine whether we
         # round it up or down.
         if digits[dps] == rnd_digs[0]:
-            tie_down = True
+            tie_down = not sticky
 
             # If the digit we round to is even, we may round down if all the
             # following digits are 0.
@@ -1131,6 +1136,7 @@ def round_digits(sign, digits, dps, base, rnd=round_down, fixed=False):
     elif rnd == round_up:
         # If any digit following a 0 is different from zero, we round up.
         if digits[dps] == '0':
+            tie_up = sticky
             for i in range(dps+1, len(digits)):
                 if digits[i] != '0':
                     tie_up = True
@@ -1483,17 +1489,27 @@ def format_fixed(s, dps, rnd=round_down):
     # exponent by +- 1)
     _, digits, exponent = to_digits_exp(
             s, max(dps+exponent+4, int(s[3]/blog2_10)), base)
+    # to_digits_exp truncates; flag a nonzero remainder past the last digit so
+    # rounding is not fooled by a short zero tail (#1131).
+    sticky = s[2] + len(digits) - 1 - exponent < 0
     orig_dps = dps
     dps += exponent + 1
 
-    # The number we want to print is lower in magnitude that the requested
-    # precision. We should only print 0s.
+    # The value's leading digit is past the last requested place, so it rounds
+    # to 0 -- or to a single unit there when rounding away from zero (#1131).
     if dps < 0:
-        int_part = '0'
-        frac_part = orig_dps*'0'
+        if rnd == round_ceiling:
+            roundup = not s[0]
+        elif rnd == round_floor:
+            roundup = bool(s[0])
+        else:
+            roundup = rnd == round_up
+        digits = '1'.rjust(orig_dps + 1, '0') if roundup else '0'*(orig_dps + 1)
+        int_part, frac_part = digits[0], digits[1:]
 
     else:
-        digits, exp_add = round_digits(s[0], digits, dps, base, rnd, True)
+        digits, exp_add = round_digits(s[0], digits, dps, base, rnd, True,
+                                       sticky)
         exponent += exp_add
 
         # Here we prepend the corresponding 0s to the digits string, according

--- a/mpmath/tests/test_format.py
+++ b/mpmath/tests/test_format.py
@@ -916,16 +916,16 @@ def test_hexadecimal_fmt():
 
 @given(st.floats(allow_nan=False, allow_infinity=False,
                  allow_subnormal=False),
-       st.integers(min_value=1, max_value=40))
-def test_fixed_with_gmpy2_bulk(x, p):
+       st.integers(min_value=1, max_value=40),
+       st.sampled_from(list('UDNYZ')))
+def test_fixed_with_gmpy2_bulk(x, dps, mode):
     gmpy2 = pytest.importorskip('gmpy2')
     if not x and math.copysign(1, x) == -1:
         return  # skip negative zero
+    fmt = f'.{dps}{mode}f'
     gx = gmpy2.mpfr(x)
     mx = mp.mpf(x)
-    for rnd in 'NUDYZ':
-        fmt = '.%d%sf' % (p, rnd)
-        assert format(mx, fmt) == format(gx, fmt)
+    assert format(mx, fmt) == format(gx, fmt)
 
 
 def test_issue_1131():

--- a/mpmath/tests/test_format.py
+++ b/mpmath/tests/test_format.py
@@ -930,17 +930,17 @@ def test_fixed_with_gmpy2_bulk(x, p):
 
 def test_issue_1131():
     # 'f' formatting must round the last digit like the 'e' path and MPFR do.
-    # ~0.000464, below 0.1 unit in the last place at .1f:
-    tiny = float.fromhex('0x1.e6a84962cb8p-12')
+    # below 0.1 unit in the last place at .1f:
+    tiny = 0.0004641126344492319
     cases = [
         # nonzero remainder hidden past the extracted guard digits
-        (float.fromhex('0x1.605b39ff191e1p-1'), '.15Uf', '0.688196003332050'),
-        (float.fromhex('0x1.605b39ff191e1p-1'), '.15Yf', '0.688196003332050'),
-        (float.fromhex('0x1.52e639e794efdp-1'), '.21Nf', '0.661912736434231541161'),
-        (float.fromhex('0x1.42696b91b17cap-1'), '.21Uf', '0.629710542235210057883'),
-        (float.fromhex('0x1.42696b91b17cap-1'), '.21Yf', '0.629710542235210057883'),
-        (float.fromhex('0x1.7a4c433af45ap-4'),  '.21Uf', '0.092357885950397733411'),
-        (float.fromhex('0x1.3c38bbc793bf4p-3'), '.30Uf',
+        (0.688196003332049,   '.15Uf', '0.688196003332050'),
+        (0.688196003332049,   '.15Yf', '0.688196003332050'),
+        (0.6619127364342315,  '.21Nf', '0.661912736434231541161'),
+        (0.6297105422352101,  '.21Uf', '0.629710542235210057883'),
+        (0.6297105422352101,  '.21Yf', '0.629710542235210057883'),
+        (0.09235788595039773, '.21Uf', '0.092357885950397733411'),
+        (0.15440508559046828, '.30Uf',
          '0.154405085590468282852327774891'),
         # value below the last requested place: away from zero rounds it up,
         # toward zero truncates it (.0f drops the trailing '.0', as in CPython)
@@ -953,9 +953,10 @@ def test_issue_1131():
     for x, fmt, expected in cases:
         assert format(mp.mpf(x), fmt) == expected, (x.hex(), fmt)
 
-    # exact dyadic half-way ties still round to even; carries still propagate
+    # the expansion terminates with a 5 at the rounding position: round-half-even
     assert format(mp.mpf('0.125'), '.2Nf') == '0.12'
     assert format(mp.mpf('0.375'), '.2Nf') == '0.38'
     assert format(mp.mpf('2.5'), '.0Nf') == '2'
     assert format(mp.mpf('3.5'), '.0Nf') == '4'
+    # carry propagation
     assert format(mp.mpf('0.6999999999'), '.4Uf') == '0.7000'

--- a/mpmath/tests/test_format.py
+++ b/mpmath/tests/test_format.py
@@ -912,3 +912,50 @@ def test_hexadecimal_fmt():
         assert f'{x:.0a}' == '0x1p+0'
         assert f'{x:#.0a}' == '0x1.p+0'
         assert f"{mp.mpf('1.234567890123456789'):+.0a}" == '+0x1p+0'
+
+
+@given(st.floats(allow_nan=False, allow_infinity=False,
+                 allow_subnormal=False),
+       st.integers(min_value=1, max_value=40))
+def test_fixed_with_gmpy2_bulk(x, p):
+    gmpy2 = pytest.importorskip('gmpy2')
+    if not x and math.copysign(1, x) == -1:
+        return  # skip negative zero
+    gx = gmpy2.mpfr(x)
+    mx = mp.mpf(x)
+    for rnd in 'NUDYZ':
+        fmt = '.%d%sf' % (p, rnd)
+        assert format(mx, fmt) == format(gx, fmt)
+
+
+def test_issue_1131():
+    # 'f' formatting must round the last digit like the 'e' path and MPFR do.
+    # ~0.000464, below 0.1 unit in the last place at .1f:
+    tiny = float.fromhex('0x1.e6a84962cb8p-12')
+    cases = [
+        # nonzero remainder hidden past the extracted guard digits
+        (float.fromhex('0x1.605b39ff191e1p-1'), '.15Uf', '0.688196003332050'),
+        (float.fromhex('0x1.605b39ff191e1p-1'), '.15Yf', '0.688196003332050'),
+        (float.fromhex('0x1.52e639e794efdp-1'), '.21Nf', '0.661912736434231541161'),
+        (float.fromhex('0x1.42696b91b17cap-1'), '.21Uf', '0.629710542235210057883'),
+        (float.fromhex('0x1.42696b91b17cap-1'), '.21Yf', '0.629710542235210057883'),
+        (float.fromhex('0x1.7a4c433af45ap-4'),  '.21Uf', '0.092357885950397733411'),
+        (float.fromhex('0x1.3c38bbc793bf4p-3'), '.30Uf',
+         '0.154405085590468282852327774891'),
+        # value below the last requested place: away from zero rounds it up,
+        # toward zero truncates it (.0f drops the trailing '.0', as in CPython)
+        (tiny,  '.1Nf', '0.0'), (tiny,  '.1Zf', '0.0'), (tiny,  '.1Df', '0.0'),
+        (tiny,  '.1Uf', '0.1'), (tiny,  '.1Yf', '0.1'),
+        (tiny,  '.3Uf', '0.001'), (tiny, '.0Uf', '1'),
+        (-tiny, '.1Nf', '-0.0'), (-tiny, '.1Uf', '-0.0'), (-tiny, '.1Zf', '-0.0'),
+        (-tiny, '.1Df', '-0.1'), (-tiny, '.1Yf', '-0.1'),
+    ]
+    for x, fmt, expected in cases:
+        assert format(mp.mpf(x), fmt) == expected, (x.hex(), fmt)
+
+    # exact dyadic half-way ties still round to even; carries still propagate
+    assert format(mp.mpf('0.125'), '.2Nf') == '0.12'
+    assert format(mp.mpf('0.375'), '.2Nf') == '0.38'
+    assert format(mp.mpf('2.5'), '.0Nf') == '2'
+    assert format(mp.mpf('3.5'), '.0Nf') == '4'
+    assert format(mp.mpf('0.6999999999'), '.4Uf') == '0.7000'


### PR DESCRIPTION
The `f` type rounds the last digit incorrectly under directed/nearest rounding, while the `e` path and MPFR round the same value correctly:

```pycon
>>> from mpmath import mpf
>>> x = mpf(float.fromhex('0x1.605b39ff191e1p-1'))   # 0.68819600333204900000083...
>>> format(x, '.15Uf')     # f, toward +inf
'0.688196003332049'
>>> format(x, '.14Ue')     # e, same value
'6.88196003332050e-01'
```

| input | spec | `f` (before) | `e` / MPFR |
|---|---|---|---|
| `0x1.605b39ff191e1p-1` | `.15Uf` | `…049` | `…050` |
| `0x1.52e639e794efdp-1` | `.21Nf` | `…541160` | `…541161` |
| `0x1.7a4c433af45ap-4`  | `.21Uf` | `…733410` | `…733411` |

`format_fixed()` extracts only `dps + O(1)` guard digits and lets `round_digits()` decide. When the true remainder lies past those digits (every extracted guard digit is `0`), the value looks exact at the cutoff and directed/nearest rounding truncates instead of rounding up. `format_scientific()` escapes this only by requesting a wider window, so raising the guard constant would just move the boundary.

Since the value is dyadic, whether the extracted digits are exact is decidable directly (`exp + fractional_digits < 0`). I pass that as a `sticky` flag into `round_digits()` and round on it, so `f` agrees with `e` and MPFR by construction rather than by a guard-digit margin.

Testing turned up a second defect in the same function: a value whose leading digit falls past the last requested place took an early return that printed only zeros and ignored the rounding mode, e.g. `format(mpf(0.0004), '.1Uf')` gave `0.0` where `e`/MPFR give `0.1`. Rounded away from zero in that branch too.

Checked against a gmpy2 differential over a wide range of doubles, precisions and all five rounding modes (no mismatches); the existing suite still passes. Regression tests added in `test_format.py`.

Fixes #1131.
