### PR TITLE
Simplify and standardise weierhalfperiods

### DIFF
--- a/mpmath/functions/elliptic.py
+++ b/mpmath/functions/elliptic.py
@@ -1635,6 +1635,9 @@ def _roots_from_omega(ctx, omega1, omega2):
     """
     Compute roots e1, e2, e3 of 4*z^3 - g2*z - g3 = 0 using theta functions.
     This is ~10x faster than solving the cubic directly.
+
+    The roots are naturally labelled by e1 = wp(omega1),
+    e2 = wp(omega1 + omega2), and e3 = wp(omega2).
     """
     tau = omega2 / omega1
     q = ctx.qfrom(tau=tau)
@@ -1644,8 +1647,33 @@ def _roots_from_omega(ctx, omega1, omega2):
     e1 = c * (j24 + 2*j44)
     e2 = c * (j24 - j44)
     e3 = -c * (2*j24 + j44)
-    roots = sorted([(e.real, e.imag) for e in [e1, e2, e3]], reverse=True)
-    return [ctx.mpc(real=t[0], imag=t[1]) for t in roots]
+    return e1, e2, e3
+
+
+def _canonicalize_weierstrass_periods(ctx, omega1, omega2):
+    """Choose a deterministic orientation for a reduced period basis."""
+    tau = omega2 / omega1
+
+    # Identify the vertical edges of the fundamental domain.
+    if ctx.almosteq(ctx.re(tau), -ctx.one/2):
+        omega2 += omega1
+        tau = omega2 / omega1
+
+    # Identify equivalent points on the circular boundary.
+    if ctx.almosteq(abs(tau), ctx.one) and ctx.re(tau) < 0:
+        omega1, omega2 = omega2, -omega1
+
+    # The invariants do not distinguish a basis from its simultaneous
+    # negation. Follow the usual convention of placing omega1 in the right
+    # half-plane, using the negative imaginary axis as the boundary.
+    real = ctx.re(omega1)
+    if ((real < 0 and not ctx.almosteq(real, 0)) or
+            (ctx.almosteq(real, 0) and ctx.im(omega1) > 0)):
+        omega1 = -omega1
+        omega2 = -omega2
+
+    return omega1, omega2
+
 
 def _eisenstein_E4_E6(ctx, tau):
     """
@@ -1737,7 +1765,14 @@ def weierinvariants(ctx, omega1, omega2):
 def weierhalfperiods(ctx, g2, g3):
     r"""
     Returns a pair of fundamental half-periods `(\omega_1, \omega_2)`
-    corresponding to the Weierstrass invariants `(g_2, g_3)`::
+    corresponding to the Weierstrass invariants `(g_2, g_3)`.
+
+    The basis is chosen so that `\tau = \omega_2/\omega_1` lies in the
+    standard modular fundamental domain. On its boundary, the representative
+    with `\operatorname{Re}(\tau) = 1/2` is preferred to `-1/2`, and the
+    right half of the circle `|\tau| = 1` is preferred. The simultaneous sign
+    ambiguity is fixed by placing `\omega_1` in the right half-plane, with
+    the negative imaginary axis included as its boundary::
 
         >>> from mpmath import mp, chop
         >>> from mpmath import weierhalfperiods, weierinvariants
@@ -1747,7 +1782,7 @@ def weierhalfperiods(ctx, g2, g3):
         >>> chop(g2), chop(g3)
         (60.0, 140.0)
         >>> chop(omega2/omega1)
-        (-0.5 + 0.209032224450873j)
+        (0.5 + 1.19598784664302j)
 
     """
     with ctx.extraprec(10):
@@ -1769,33 +1804,15 @@ def weierhalfperiods(ctx, g2, g3):
             omegaA = ctx.sqrt(g2/g3 * G6/G4 * ctx.mpf(7)/ctx.mpf(12))
 
         omegaB = tau * omegaA
-        omegaC = omegaA + omegaB
-        omegas = [omegaA, omegaB, omegaC]
-        index_combos = [(0,1,2), (0,2,1), (1,0,2),
-                        (1,2,0), (2,0,1), (2,1,0)]
+        if g2 != 0 and g3 != 0:
+            a, b, c, d = ctx._reduce_psl2z(tau)
+            omega1 = d*omegaA + c*omegaB
+            omega2 = b*omegaA + a*omegaB
+        else:
+            omega1, omega2 = omegaA, omegaB
 
-        e1, e2, e3 = _roots_from_omega(ctx, omegaA, omegaB)
-        wps = []
-        for omegaN in omegas:
-            wps.append(ctx.weierp(omegaN, omega1=omegaA, omega2=omegaB))
-
-        maes = []
-        for ic in index_combos:
-            mae = (abs(e1 - wps[ic[0]]) + abs(e2 - wps[ic[1]]) +
-                   abs(e3 - wps[ic[2]])) / 3
-            maes.append(mae)
-
-        mae = min(maes)
-        min_index = maes.index(mae)
-
-        scale = max([ctx.one] + [abs(x) for x in [e1, e2, e3] + wps])
-        tolerance = ctx.sqrt(ctx.eps) * scale
-        if mae > tolerance:
-            raise ValueError("weierhalfperiods: no convergence")
-
-        omega1, omega2 = [omegas[k] for k in index_combos[min_index]][:2]
-        if ctx.im(omega2/omega1) <= 0:
-            omega2 = -omega2
+        omega1, omega2 = _canonicalize_weierstrass_periods(
+            ctx, omega1, omega2)
         return +omega1, +omega2
 
 
@@ -2037,17 +2054,17 @@ def weierpinv(ctx, p, g2=None, g3=None, tau=None, omega1=None, omega2=None,
     the invariants `g_2, g_3`, the half-periods `\omega_1, \omega_2`, or
     `\tau`, corresponding to normalized periods `1` and `\tau`.
 
-    The inverse is multivalued up to periods and sign. If `weierp_prime` is
+    The inverse is multivalued up to periods and sign. If ``weierp_prime`` is
     provided, it is used to choose between `z` and `-z` by matching the
     corresponding value of `\wp'(z)`.
 
     **Parameters**
 
-    - `p`: the target value
-    - `g2, g3`: elliptic invariants
-    - `tau` or `omega1, omega2`: alternative parameterizations
-    - `weierp_prime` (optional): derivative value used to choose the sign of
-      the inverse
+    - ``p``: the target value
+    - ``g2``, ``g3``: elliptic invariants
+    - ``tau`` or ``omega1``, ``omega2``: alternative parameterizations
+    - ``weierp_prime`` (optional): derivative value used to choose the sign
+      of the inverse
 
     **Examples**
 

--- a/mpmath/tests/test_elliptic.py
+++ b/mpmath/tests/test_elliptic.py
@@ -14,7 +14,6 @@ Author of the first version: M.T. Taschuk
 import random
 
 import pytest
-import mpmath.functions.elliptic as elliptic_functions
 
 from mpmath import (cos, cosh, cot, coth, csc, csch, diff, ellipe, ellipfun,
                     ellipk, ellippi, elliprc, elliprd, elliprf, elliprg,
@@ -857,7 +856,9 @@ def test_weierstrass_parameter_conversions():
     g2_roundtrip, g3_roundtrip = weierinvariants(omega1, omega2)
     assert mpc_ae(g2, g2_roundtrip, eps=eps*10000)
     assert mpc_ae(g3, g3_roundtrip, eps=eps*10000)
-    assert (omega2/omega1).imag > 0
+    tau = omega2/omega1
+    assert abs(tau.real) <= mpf('0.5')
+    assert abs(tau) >= 1
 
 def test_weierstrass_special_half_periods():
     mp.dps = 30
@@ -892,12 +893,43 @@ def test_weierstrass_half_periods_high_precision():
     assert mpc_ae(g2_roundtrip, g2, eps=eps*10000)
     assert mpc_ae(g3_roundtrip, g3, eps=eps*10000)
 
-def test_weierstrass_half_periods_no_convergence(monkeypatch):
-    def bad_roots(ctx, omega1, omega2):
-        return [ctx.mpf(10), ctx.mpf(20), ctx.mpf(30)]
+def test_weierstrass_half_periods_reference_values():
+    mp.dps = 30
 
-    monkeypatch.setattr(elliptic_functions, "_roots_from_omega", bad_roots)
-    pytest.raises(ValueError, lambda: weierhalfperiods(0, 1))
+    cases = [
+        # Wolfram Engine N[WeierstrassHalfPeriods[{12, 1}], 30]
+        ((12, 1),
+         (mpc('0.980738294394739292410226347661'),
+          mpc('1.01377388832044810173727513686j'))),
+        # Wolfram Engine N[WeierstrassHalfPeriods[{12, -1}], 30]
+        ((12, -1),
+         (mpc('-0.980738294394739292410226347661j'),
+          mpc('1.01377388832044810173727513686'))),
+        # Wolfram Engine
+        # N[WeierstrassHalfPeriods[{1 + 2 I, 3 - 4 I}], 30]
+        ((1+2j, 3-4j),
+         (mpc('0.384323637351610816269007338473',
+              '1.048679479243511496217225594331'),
+          mpc('-1.174237734840406867019569638285',
+              '-0.123713024549329486202780646669'))),
+    ]
+
+    for invariants, expected in cases:
+        periods = weierhalfperiods(*invariants)
+        assert mpc_ae(periods[0], expected[0], eps=eps*1000)
+        assert mpc_ae(periods[1], expected[1], eps=eps*1000)
+
+def test_weierstrass_half_periods_boundary_convention():
+    for dps in [15, 30, 50]:
+        with mp.workdps(dps):
+            omega1, omega2 = weierhalfperiods(60, 140)
+            tau = omega2/omega1
+            assert mp.almosteq(tau.real, mpf('0.5'))
+
+            omega1, omega2 = weierhalfperiods(-4, 1)
+            tau = omega2/omega1
+            assert mp.almosteq(abs(tau), 1)
+            assert tau.real >= 0
 
 def test_weierstrass_parameter_conversions_with_kleinj():
     mp.dps = 30


### PR DESCRIPTION
## Summary

Simplify `weierhalfperiods` by removing the root sorting and period-matching step.

The theta-function formulas in `_roots_from_omega` naturally return roots labelled by their corresponding half-periods:

- `e1 = wp(omega1)`
- `e2 = wp(omega1 + omega2)`
- `e3 = wp(omega2)`

Previously, these roots were sorted by their real and imaginary parts.`weierhalfperiods` then evaluated `weierp` at three candidate half-periods and searched all permutations to recover the association. This discarded the natural labelling and added several expensive elliptic-function evaluations.

## Changes

- Return the naturally labelled roots directly from `_roots_from_omega`.
- Remove root sorting, three additional `weierp` evaluations, and permutation matching from `weierhalfperiods`.
- Reduce the returned period ratio to the modular fundamental domain.
- Add deterministic conventions for boundary and sign ambiguities:
  - prefer `Re(tau) = 1/2` to `-1/2`;
  - prefer the right half of the boundary `abs(tau) = 1`;
  - place `omega1` in the right half-plane, including the negative imaginary axis as its boundary.
- Document these conventions in the `weierhalfperiods` docstring.
- Preserve the natural root ordering in `weierpinv`. Carlson's `R_F` is symmetric in its three arguments, so inverse evaluation does not depend on root ordering.
- Add reference values for representative real and complex invariants.
- Add tests confirming that boundary choices are stable across working precisions.
- Fix inline-code rendering of parameter names in the `weierpinv` docstring.

Extensive comparisons of half-periods against Wolfram Engine showed direct agreement for ordinary real and complex invariants, while some exact modular-boundary and special-lattice cases may return a different but equivalent period basis because Wolfram applies undocumented phase-dependent branch choices; reproducing those cases exactly could be considered later by implementing a dedicated Wolfram-compatible analytic branch convention.

## Performance

Removing the period-matching evaluations substantially reduces the cost of `weierhalfperiods`.

Representative local timings showed approximately:

| Case | Speedup |
| --- | ---: |
| Generic real invariants | 5–6x |
| Generic complex invariants | 5–6x |
| Lemniscatic case | 5–12x |
| Equianharmonic case | 40–90x |

Exact timings depend on working precision.

## Behavioural change

`weierhalfperiods` may now return a different, modularly equivalent basis for the same lattice.

For example, for `(g2, g3) = (60, 140)`, the period ratio changes from

    -0.5 + 0.209032224450873j

to the fundamental-domain representative

    0.5 + 1.19598784664302j

The two ratios are related by an integer unimodular transformation and produce the same invariants and Weierstrass functions.

## Tests

The elliptic tests and elliptic-function doctests pass:

    72 passed
    
    
AI use declaration: GPT5.6 Sol from OpenAI was used to assist. All lines of code were read and iterated on by me.