### PR TITLE
Add fft()/invfft() functions for DFT calculation

### DIFF
--- a/docs/calculus/fft.rst
+++ b/docs/calculus/fft.rst
@@ -10,4 +10,4 @@ FFT
 Inverse FFT
 ...........
 
-.. autofunction:: mpmath.ifft
+.. autofunction:: mpmath.invfft

--- a/docs/calculus/fft.rst
+++ b/docs/calculus/fft.rst
@@ -1,0 +1,13 @@
+Fast Fourier Transform
+----------------------------------
+
+FFT
+...
+
+.. autofunction:: mpmath.fft
+
+
+Inverse FFT
+...........
+
+.. autofunction:: mpmath.ifft

--- a/docs/calculus/index.rst
+++ b/docs/calculus/index.rst
@@ -12,3 +12,4 @@ Numerical calculus
    odes
    approximation
    inverselaplace
+   fft

--- a/mpmath/__init__.py
+++ b/mpmath/__init__.py
@@ -452,6 +452,8 @@ trianglew = mp.trianglew
 sawtoothw = mp.sawtoothw
 unit_triangle = mp.unit_triangle
 sigmoid = mp.sigmoid
+fft = mp.fft
+ifft = mp.ifft
 
 
 # Hack to guard against setting module properties instead of 'mp', Issue #657

--- a/mpmath/__init__.py
+++ b/mpmath/__init__.py
@@ -453,7 +453,7 @@ sawtoothw = mp.sawtoothw
 unit_triangle = mp.unit_triangle
 sigmoid = mp.sigmoid
 fft = mp.fft
-ifft = mp.ifft
+invfft = mp.invfft
 
 
 # Hack to guard against setting module properties instead of 'mp', Issue #657

--- a/mpmath/calculus/__init__.py
+++ b/mpmath/calculus/__init__.py
@@ -4,3 +4,4 @@ from . import approximation
 from . import differentiation
 from . import extrapolation
 from . import polynomials
+from . import fft

--- a/mpmath/calculus/fft.py
+++ b/mpmath/calculus/fft.py
@@ -13,18 +13,14 @@ def _fft_cooley_tuckey(ctx, values, inverse=False):
         return values
 
     # Bit-Reversal Permutation
-    def reverse_bits(n, width):
-        result = 0
-        for _ in range(width):
-            result <<= 1
-            result |= (n & 1)
-            n >>= 1
-        return result
-
     transformed = [ctx.zero] * n
     num_bits = n.bit_length() - 1
     for i in range(n):
-        rev = reverse_bits(i, num_bits)
+        rev = 0
+        for _ in range(num_bits):
+            rev <<= 1
+            rev |= (i & 1)
+            i >>= 1           
         transformed[rev] = values[i]
 
     sign = ctx.one if inverse else -ctx.one

--- a/mpmath/calculus/fft.py
+++ b/mpmath/calculus/fft.py
@@ -13,13 +13,18 @@ def _fft_cooley_tuckey(ctx, values, inverse=False):
         return values
 
     # Bit-Reversal Permutation
+    def reverse_bits(n, width):
+        result = 0
+        for _ in range(width):
+            result <<= 1
+            result |= (n & 1)
+            n >>= 1
+        return result
+
     transformed = [ctx.zero] * n
     num_bits = n.bit_length() - 1
     for i in range(n):
-        rev = 0
-        for b in range(num_bits):
-            if (i >> b) & 1:
-                rev |= 1 << (num_bits - 1 - b)
+        rev = reverse_bits(i, num_bits)
         transformed[rev] = values[i]
 
     sign = ctx.one if inverse else -ctx.one

--- a/mpmath/calculus/fft.py
+++ b/mpmath/calculus/fft.py
@@ -17,11 +17,12 @@ def _fft_cooley_tuckey(ctx, values, inverse=False):
     num_bits = n.bit_length() - 1
     for i in range(n):
         rev = 0
+        val = values[i]
         for _ in range(num_bits):
             rev <<= 1
             rev |= (i & 1)
             i >>= 1           
-        transformed[rev] = values[i]
+        transformed[rev] = val
 
     sign = ctx.one if inverse else -ctx.one
 

--- a/mpmath/calculus/fft.py
+++ b/mpmath/calculus/fft.py
@@ -50,6 +50,16 @@ def fft(ctx, values):
     Computes the Discrete Fourier Transform (DFT) of a sequence.
 
     Raises NotImplementedError if the input sequence length is not a power of 2.
+
+    A few basic examples are:
+
+        >>> from mpmath import mp, fft
+        >>> mp.nprint(fft([1, 0, 0, 0]))
+        [1.0, (1.0 + 0.0j), 1.0, (1.0 + 0.0j)]
+        >>> mp.nprint(fft([1 + 2j, 1 + 2j]))
+        [(2.0 + 4.0j), (0.0 + 0.0j)]
+        >>> mp.nprint(fft([1, 2, 3, 4]))
+        [10.0, (-2.0 + 2.0j), -2.0, (-2.0 - 2.0j)]
     """
     n = len(values)
     if n == 0:
@@ -69,6 +79,15 @@ def invfft(ctx, values):
     Computes the inverse Discrete Fourier Transform (IDFT) of a sequence.
 
     Raises NotImplementedError if the input sequence length is not a power of 2.
+
+    A few basic examples are:
+
+        >>> from mpmath import mp, fft, invfft
+        >>> mp.nprint(invfft([1, 1, 1, 1]))
+        [1.0, (0.0 + 0.0j), 0.0, (0.0 + 0.0j)]
+        >>> x = [1, 2, 3, 4]
+        >>> mp.nprint(invfft(fft(x)))
+        [(1.0 + 0.0j), (2.0 + 0.0j), (3.0 + 0.0j), (4.0 + 0.0j)]
     """
     n = len(values)
     if n == 0:

--- a/mpmath/calculus/fft.py
+++ b/mpmath/calculus/fft.py
@@ -2,9 +2,10 @@ from .calculus import defun
 
 def _fft_cooley_tuckey(ctx, values, inverse=False):
     """
-    This function implements the Radix-2 Cooley-Tukey FFT algorithm iteratively. It computes the Fast Fourier Transform (or Inverse FFT) of a sequence of complex numbers.
-    The input sequence must have a length that is a power of 2.
-
+    This function implements the Radix-2 Cooley-Tukey FFT algorithm iteratively.
+    It computes the Fast Fourier Transform (or Inverse FFT) of a sequence of
+    complex numbers.
+    
     https://en.wikipedia.org/wiki/Cooley%E2%80%93Tukey_FFT_algorithm
     """
     n = len(values)
@@ -21,13 +22,12 @@ def _fft_cooley_tuckey(ctx, values, inverse=False):
                 rev |= 1 << (num_bits - 1 - b)
         transformed[rev] = values[i]
 
-    sign = 1 if inverse else -1
-    two_pi_j = 2 * ctx.pi * ctx.j
+    sign = ctx.one if inverse else -ctx.one
 
     length = 2
     while length <= n:
         half = length // 2
-        w_len = ctx.exp(sign * two_pi_j / length)
+        w_len = ctx.expjpi(2 * sign / length)
 
         for i in range(0, n, length):
             w = ctx.one
@@ -44,11 +44,11 @@ def _fft_cooley_tuckey(ctx, values, inverse=False):
 
     return transformed
 
-# TODO: Add support for non-power-of-two lengths using Bluestein's algorithm or similar methods.
-
 @defun
 def fft(ctx, values):
-    r"""Computes the Discrete Fourier Transform (DFT) of a sequence using the Radix-2 Cooley-Tukey FFT algorithm.
+    r"""
+    Computes the Discrete Fourier Transform (DFT) of a sequence.
+
     Raises NotImplementedError if the input sequence length is not a power of 2.
     """
     n = len(values)
@@ -56,35 +56,27 @@ def fft(ctx, values):
         return []
 
     is_power_of_two = (n & (n - 1)) == 0
-
     if not is_power_of_two:
         raise NotImplementedError(f"FFT is only implemented for lengths that are powers of 2, got length: {n}")
 
     converted_values = [ctx.convert(v) for v in values]
-
-    result = _fft_cooley_tuckey(ctx, converted_values, False)
-
-    return result
+    return _fft_cooley_tuckey(ctx, converted_values, False)
 
 @defun
 def invfft(ctx, values):
-    r"""Computes the inverse Discrete Fourier Transform (IDFT) of a sequence using the Radix-2 Cooley-Tukey FFT algorithm.
+    r"""
+    Computes the inverse Discrete Fourier Transform (IDFT) of a sequence.
+
     Raises NotImplementedError if the input sequence length is not a power of 2.
     """
-
     n = len(values)
     if n == 0:
         return []
 
     is_power_of_two = (n & (n - 1)) == 0
-
     if not is_power_of_two:
         raise NotImplementedError(f"Inverse FFT is only implemented for lengths that are powers of 2, got length: {n}")
 
     converted_values = [ctx.convert(v) for v in values]
-
     result = _fft_cooley_tuckey(ctx, converted_values, True)
-
-    result = [val / n for val in result]
-
-    return result
+    return [val / n for val in result]

--- a/mpmath/calculus/fft.py
+++ b/mpmath/calculus/fft.py
@@ -5,7 +5,7 @@ def _fft_cooley_tuckey(ctx, values, inverse=False):
     This function implements the Radix-2 Cooley-Tukey FFT algorithm iteratively.
     It computes the Fast Fourier Transform (or Inverse FFT) of a sequence of
     complex numbers.
-    
+
     https://en.wikipedia.org/wiki/Cooley%E2%80%93Tukey_FFT_algorithm
     """
     n = len(values)

--- a/mpmath/calculus/fft.py
+++ b/mpmath/calculus/fft.py
@@ -51,15 +51,16 @@ def fft(ctx, values):
 
     Raises NotImplementedError if the input sequence length is not a power of 2.
 
-    A few basic examples are:
+    **Examples**
 
-        >>> from mpmath import mp, fft
-        >>> mp.nprint(fft([1, 0, 0, 0]))
-        [1.0, (1.0 + 0.0j), 1.0, (1.0 + 0.0j)]
-        >>> mp.nprint(fft([1 + 2j, 1 + 2j]))
-        [(2.0 + 4.0j), (0.0 + 0.0j)]
-        >>> mp.nprint(fft([1, 2, 3, 4]))
-        [10.0, (-2.0 + 2.0j), -2.0, (-2.0 - 2.0j)]
+    >>> from mpmath import mp
+    >>> mp.pretty = True
+    >>> mp.fft([1, 0, 0, 0])
+    [1.0, (1.0 + 0.0j), 1.0, (1.0 + 0.0j)]
+    >>> mp.fft([1 + 2j, 1 + 2j])
+    [(2.0 + 4.0j), (0.0 + 0.0j)]
+    >>> mp.fft([1, 2, 3, 4])
+    [10.0, (-2.0 + 2.0j), -2.0, (-2.0 - 2.0j)]
     """
     n = len(values)
     if n == 0:
@@ -71,7 +72,9 @@ def fft(ctx, values):
                                   f"are powers of 2, got length: {n}")
 
     converted_values = [ctx.convert(v) for v in values]
-    return _fft_cooley_tuckey(ctx, converted_values, False)
+    with ctx.extraprec(10):
+        result = _fft_cooley_tuckey(ctx, converted_values)
+    return [+v for v in result]
 
 @defun
 def invfft(ctx, values):
@@ -80,14 +83,15 @@ def invfft(ctx, values):
 
     Raises NotImplementedError if the input sequence length is not a power of 2.
 
-    A few basic examples are:
+    **Examples**
 
-        >>> from mpmath import mp, fft, invfft
-        >>> mp.nprint(invfft([1, 1, 1, 1]))
-        [1.0, (0.0 + 0.0j), 0.0, (0.0 + 0.0j)]
-        >>> x = [1, 2, 3, 4]
-        >>> mp.nprint(invfft(fft(x)))
-        [(1.0 + 0.0j), (2.0 + 0.0j), (3.0 + 0.0j), (4.0 + 0.0j)]
+    >>> from mpmath import mp
+    >>> mp.pretty = True
+    >>> mp.invfft([1, 1, 1, 1])
+    [1.0, (0.0 + 0.0j), 0.0, (0.0 + 0.0j)]
+    >>> x = [1, 2, 3, 4]
+    >>> mp.invfft(mp.fft(x))
+    [(1.0 + 0.0j), (2.0 + 0.0j), (3.0 + 0.0j), (4.0 + 0.0j)]
     """
     n = len(values)
     if n == 0:
@@ -99,5 +103,6 @@ def invfft(ctx, values):
                                   f"are powers of 2, got length: {n}")
 
     converted_values = [ctx.convert(v) for v in values]
-    result = _fft_cooley_tuckey(ctx, converted_values, True)
+    with ctx.extraprec(10):
+        result = _fft_cooley_tuckey(ctx, converted_values, True)
     return [val / n for val in result]

--- a/mpmath/calculus/fft.py
+++ b/mpmath/calculus/fft.py
@@ -1,0 +1,47 @@
+from .calculus import defun
+
+def _fft_recursive(ctx, values, inverse=False):
+    n = len(values)
+
+    if n == 1:
+        return values
+
+    sign = 1 if inverse else -1
+
+    even = _fft_recursive(ctx, values[0::2], inverse)
+    odd = _fft_recursive(ctx, values[1::2], inverse)
+    root = ctx.exp(sign * 2 * ctx.pi * ctx.j / n)
+    factor = ctx.one
+    half = n // 2
+    transformed = [ctx.zero] * n
+    for k in range(half):
+        term = factor * odd[k]
+        transformed[k] = even[k] + term
+        transformed[k + half] = even[k] - term
+        factor *= root
+    return transformed
+
+@defun
+def fft(ctx, values, inverse=False):
+    r"""Computes the discrete Fourier transform of a sequence.
+
+    If ``inverse=True``, computes the inverse transform and normalizes the
+    result by the sequence length.
+    """
+    n = len(values)
+    if n == 0:
+        return []
+    if n & (n - 1) != 0:
+        raise ValueError("Length of input must be a power of 2.")
+
+    converted_values = [ctx.convert(v) for v in values]
+    transformed = _fft_recursive(ctx, converted_values, inverse=inverse)
+    if inverse and transformed:
+        n = len(transformed)
+        transformed = [value / n for value in transformed]
+    return transformed
+
+@defun
+def ifft(ctx, values):
+    r"""Computes the inverse discrete Fourier transform of a sequence."""
+    return fft(ctx, values, inverse=True)

--- a/mpmath/calculus/fft.py
+++ b/mpmath/calculus/fft.py
@@ -23,12 +23,48 @@ def _fft_recursive(ctx, values, inverse=False):
         factor *= root
     return transformed
 
+def _fft_iterative(ctx, values, inverse=False):
+    n = len(values)
+    if n <= 1:
+        return list(values)
+
+    # Bit-Reversal Permutation
+    transformed = [ctx.zero] * n
+    num_bits = n.bit_length() - 1
+    for i in range(n):
+        rev = 0
+        for b in range(num_bits):
+            if (i >> b) & 1:
+                rev |= 1 << (num_bits - 1 - b)
+        transformed[rev] = values[i]
+
+    sign = 1 if inverse else -1
+    two_pi_j = 2 * ctx.pi * ctx.j
+
+    length = 2
+    while length <= n:
+        half = length >> 1
+        w_len = ctx.exp(sign * two_pi_j / length)
+
+        for i in range(0, n, length):
+            w = ctx.one
+            for j in range(half):
+                u = transformed[i + j]
+                v = transformed[i + j + half] * w
+                
+                transformed[i + j] = u + v
+                transformed[i + j + half] = u - v
+                
+                w *= w_len
+
+        length = length << 1
+
+    return transformed
+
 @defun
-def fft(ctx, values, inverse=False, pad_to_power_of_two=False):
+def fft(ctx, values, pad_to_power_of_two=False):
     r"""Computes the Fast Fourier Transform (or Inverse FFT) with optional zero-padding.
 
-    If ``inverse=True``, computes the inverse transform and normalizes the
-    result by the sequence length.
     If ``pad_to_power_of_two=True``, the input sequence is automatically zero-padded to the next power of 2 if its length is not already a power of 2.
     """
     orig_n = len(values)
@@ -39,28 +75,68 @@ def fft(ctx, values, inverse=False, pad_to_power_of_two=False):
 
     if not is_power_of_two:
         if not pad_to_power_of_two:
-            raise ValueError(f"Length of input ({orig_n}) must be a power of 2.")
+            raise NotImplementedError("FFT is only implemented for lengths that are powers of 2. Use pad_to_power_of_two=True to automatically pad the input sequence.")
 
         padded_n = 1 << math.ceil(math.log2(orig_n))
     else:
         padded_n = orig_n
 
     converted_values = [ctx.convert(v) for v in values]
+    pad_length = padded_n - orig_n
 
     if padded_n > orig_n:
-        converted_values.extend([ctx.zero] * (padded_n - orig_n))
+        converted_values.extend([ctx.zero] * pad_length)
 
-    result = _fft_recursive(ctx, converted_values, inverse)
-
-    if inverse:
-        scale = ctx.convert(padded_n)
-        result = [val / scale for val in result]
+    result = _fft_iterative(ctx, converted_values, False)
 
     return result
 
 @defun
-def ifft(ctx, values, pad_to_power_of_two=False):
+def invfft(ctx, values, pad_to_power_of_two=False):
     r"""Computes the inverse discrete Fourier transform of a sequence with optional zero-padding.
     If ``pad_to_power_of_two=True``, the input sequence is automatically zero-padded to the next power of 2 if its length is not already a power of 2.
     """
-    return fft(ctx, values, inverse=True, pad_to_power_of_two=pad_to_power_of_two)
+
+    orig_n = len(values)
+    if orig_n == 0:
+        return []
+
+    is_power_of_two = (orig_n & (orig_n - 1)) == 0
+
+    if not is_power_of_two:
+        if not pad_to_power_of_two:
+            raise NotImplementedError("Inverse FFT is only implemented for lengths that are powers of 2. Use pad_to_power_of_two=True to automatically pad the input sequence.")
+
+        padded_n = 1 << math.ceil(math.log2(orig_n))
+    else:
+        padded_n = orig_n
+
+    converted_values = [ctx.convert(v) for v in values]
+    pad_length = padded_n - orig_n
+
+    half = orig_n >> 1
+    zeros = [ctx.zero] * pad_length
+
+    if pad_length > 0:
+        if orig_n % 2 == 0:
+            nyquist_half = converted_values[half] / 2
+            converted_values = (
+                converted_values[:half] 
+                + [nyquist_half] 
+                + zeros 
+                + [nyquist_half] 
+                + converted_values[half + 1:]
+                )
+        else:
+            converted_values = (
+                converted_values[:half + 1] 
+                + zeros 
+                + converted_values[half + 1:]
+                )
+
+    result = _fft_iterative(ctx, converted_values, True)
+
+    scale = ctx.convert(padded_n)
+    result = [val / scale for val in result]
+
+    return result

--- a/mpmath/calculus/fft.py
+++ b/mpmath/calculus/fft.py
@@ -21,7 +21,7 @@ def _fft_cooley_tuckey(ctx, values, inverse=False):
         for _ in range(num_bits):
             rev <<= 1
             rev |= (i & 1)
-            i >>= 1           
+            i >>= 1
         transformed[rev] = val
 
     sign = ctx.one if inverse else -ctx.one

--- a/mpmath/calculus/fft.py
+++ b/mpmath/calculus/fft.py
@@ -1,10 +1,8 @@
-import math
-
 from .calculus import defun
 
-def _fft_iterative(ctx, values, inverse=False):
+def _fft_cooley_tuckey(ctx, values, inverse=False):
     """
-    This function implements the Cooley-Tukey FFT algorithm iteratively. It computes the Fast Fourier Transform (or Inverse FFT) of a sequence of complex numbers.
+    This function implements the Radix-2 Cooley-Tukey FFT algorithm iteratively. It computes the Fast Fourier Transform (or Inverse FFT) of a sequence of complex numbers.
     The input sequence must have a length that is a power of 2.
 
     https://en.wikipedia.org/wiki/Cooley%E2%80%93Tukey_FFT_algorithm
@@ -49,85 +47,44 @@ def _fft_iterative(ctx, values, inverse=False):
 # TODO: Add support for non-power-of-two lengths using Bluestein's algorithm or similar methods.
 
 @defun
-def fft(ctx, values, pad_to_power_of_two=False):
-    r"""Computes the Fast Fourier Transform (or Inverse FFT) with optional zero-padding.
-    If ``pad_to_power_of_two=True``, the time domain sequence is automatically zero-padded at the end to the next power of 2 if its length is not already a power of 2.
-    Raises NotImplementedError if the input sequence length is not a power of 2 and ``pad_to_power_of_two`` is False.
+def fft(ctx, values):
+    r"""Computes the Discrete Fourier Transform (DFT) of a sequence using the Radix-2 Cooley-Tukey FFT algorithm.
+    Raises NotImplementedError if the input sequence length is not a power of 2.
     """
-    orig_n = len(values)
-    if orig_n == 0:
+    n = len(values)
+    if n == 0:
         return []
 
-    is_power_of_two = (orig_n & (orig_n - 1)) == 0
+    is_power_of_two = (n & (n - 1)) == 0
 
     if not is_power_of_two:
-        if not pad_to_power_of_two:
-            raise NotImplementedError("FFT is only implemented for lengths that are powers of 2. Use pad_to_power_of_two=True to automatically pad the input sequence.")
-
-        padded_n = 1 << math.ceil(math.log2(orig_n))
-    else:
-        padded_n = orig_n
+        raise NotImplementedError(f"FFT is only implemented for lengths that are powers of 2, got length: {n}")
 
     converted_values = [ctx.convert(v) for v in values]
-    pad_length = padded_n - orig_n
 
-    if padded_n > orig_n:
-        converted_values.extend([ctx.zero] * pad_length)
-
-    result = _fft_iterative(ctx, converted_values, False)
+    result = _fft_cooley_tuckey(ctx, converted_values, False)
 
     return result
 
 @defun
-def invfft(ctx, values, pad_to_power_of_two=False):
-    r"""Computes the inverse discrete Fourier transform of a sequence with optional zero-padding.
-    If ``pad_to_power_of_two=True``, the frequency domain sequence is automatically center zero-padded with Nyquist-bin splitting to the next power of 2 if its length is not already a power of 2.
-    The Nyquist-bin splitting is done by taking the value at the Nyquist frequency (if it exists) and splitting it evenly between the positive and negative Nyquist bins in the padded sequence.
-    Raises NotImplementedError if the input sequence length is not a power of 2 and ``pad_to_power_of_two`` is False.
-    The output is scaled by the length of the original input sequence to ensure that the inverse transform correctly recovers the original time-domain sequence.
+def invfft(ctx, values):
+    r"""Computes the inverse Discrete Fourier Transform (IDFT) of a sequence using the Radix-2 Cooley-Tukey FFT algorithm.
+    Raises NotImplementedError if the input sequence length is not a power of 2.
     """
 
-    orig_n = len(values)
-    if orig_n == 0:
+    n = len(values)
+    if n == 0:
         return []
 
-    is_power_of_two = (orig_n & (orig_n - 1)) == 0
+    is_power_of_two = (n & (n - 1)) == 0
 
     if not is_power_of_two:
-        if not pad_to_power_of_two:
-            raise NotImplementedError("Inverse FFT is only implemented for lengths that are powers of 2. Use pad_to_power_of_two=True to automatically pad the input sequence.")
-
-        padded_n = 1 << math.ceil(math.log2(orig_n))
-    else:
-        padded_n = orig_n
+        raise NotImplementedError(f"Inverse FFT is only implemented for lengths that are powers of 2, got length: {n}")
 
     converted_values = [ctx.convert(v) for v in values]
-    pad_length = padded_n - orig_n
 
-    half = orig_n >> 1
+    result = _fft_cooley_tuckey(ctx, converted_values, True)
 
-    if pad_length > 0:
-        if orig_n % 2 == 0:
-            zeros = [ctx.zero] * (pad_length - 1)
-            nyquist_half = converted_values[half] / 2
-            converted_values = (
-                converted_values[:half]
-                + [nyquist_half]
-                + zeros
-                + [nyquist_half]
-                + converted_values[half + 1:]
-                )
-        else:
-            zeros = [ctx.zero] * pad_length
-            converted_values = (
-                converted_values[:half + 1]
-                + zeros
-                + converted_values[half + 1:]
-                )
-
-    result = _fft_iterative(ctx, converted_values, True)
-
-    scale = ctx.convert(orig_n)
-    result = [val / scale for val in result]
+    result = [val / n for val in result]
 
     return result

--- a/mpmath/calculus/fft.py
+++ b/mpmath/calculus/fft.py
@@ -2,31 +2,16 @@ import math
 
 from .calculus import defun
 
-def _fft_recursive(ctx, values, inverse=False):
-    n = len(values)
-
-    if n == 1:
-        return values
-
-    sign = 1 if inverse else -1
-
-    even = _fft_recursive(ctx, values[0::2], inverse)
-    odd = _fft_recursive(ctx, values[1::2], inverse)
-    root = ctx.exp(sign * 2 * ctx.pi * ctx.j / n)
-    factor = ctx.one
-    half = n // 2
-    transformed = [ctx.zero] * n
-    for k in range(half):
-        term = factor * odd[k]
-        transformed[k] = even[k] + term
-        transformed[k + half] = even[k] - term
-        factor *= root
-    return transformed
-
 def _fft_iterative(ctx, values, inverse=False):
+    """
+    This function implements the Cooley-Tukey FFT algorithm iteratively. It computes the Fast Fourier Transform (or Inverse FFT) of a sequence of complex numbers.
+    The input sequence must have a length that is a power of 2. If the length is not a power of 2, the function raises a NotImplementedError.
+
+    https://en.wikipedia.org/wiki/Cooley%E2%80%93Tukey_FFT_algorithm#Data_reordering,_bit_reversal,_and_in-place_algorithms
+    """
     n = len(values)
     if n <= 1:
-        return list(values)
+        return values
 
     # Bit-Reversal Permutation
     transformed = [ctx.zero] * n
@@ -43,7 +28,7 @@ def _fft_iterative(ctx, values, inverse=False):
 
     length = 2
     while length <= n:
-        half = length >> 1
+        half = length // 2
         w_len = ctx.exp(sign * two_pi_j / length)
 
         for i in range(0, n, length):
@@ -51,21 +36,20 @@ def _fft_iterative(ctx, values, inverse=False):
             for j in range(half):
                 u = transformed[i + j]
                 v = transformed[i + j + half] * w
-                
+
                 transformed[i + j] = u + v
                 transformed[i + j + half] = u - v
-                
+
                 w *= w_len
 
-        length = length << 1
+        length <<= 1
 
     return transformed
 
 @defun
 def fft(ctx, values, pad_to_power_of_two=False):
     r"""Computes the Fast Fourier Transform (or Inverse FFT) with optional zero-padding.
-
-    If ``pad_to_power_of_two=True``, the input sequence is automatically zero-padded to the next power of 2 if its length is not already a power of 2.
+    If ``pad_to_power_of_two=True``, the time domain sequence is automatically zero-padded at the end to the next power of 2 if its length is not already a power of 2.
     """
     orig_n = len(values)
     if orig_n == 0:
@@ -94,7 +78,7 @@ def fft(ctx, values, pad_to_power_of_two=False):
 @defun
 def invfft(ctx, values, pad_to_power_of_two=False):
     r"""Computes the inverse discrete Fourier transform of a sequence with optional zero-padding.
-    If ``pad_to_power_of_two=True``, the input sequence is automatically zero-padded to the next power of 2 if its length is not already a power of 2.
+    If ``pad_to_power_of_two=True``, the frequency domain sequence is automatically zero-padded with Nyquist-bin splitting to the next power of 2 if its length is not already a power of 2.
     """
 
     orig_n = len(values)
@@ -115,22 +99,23 @@ def invfft(ctx, values, pad_to_power_of_two=False):
     pad_length = padded_n - orig_n
 
     half = orig_n >> 1
-    zeros = [ctx.zero] * pad_length
 
     if pad_length > 0:
         if orig_n % 2 == 0:
+            zeros = [ctx.zero] * (pad_length - 1)
             nyquist_half = converted_values[half] / 2
             converted_values = (
-                converted_values[:half] 
-                + [nyquist_half] 
-                + zeros 
-                + [nyquist_half] 
+                converted_values[:half]
+                + [nyquist_half]
+                + zeros
+                + [nyquist_half]
                 + converted_values[half + 1:]
                 )
         else:
+            zeros = [ctx.zero] * pad_length
             converted_values = (
-                converted_values[:half + 1] 
-                + zeros 
+                converted_values[:half + 1]
+                + zeros
                 + converted_values[half + 1:]
                 )
 

--- a/mpmath/calculus/fft.py
+++ b/mpmath/calculus/fft.py
@@ -1,3 +1,5 @@
+import math
+
 from .calculus import defun
 
 def _fft_recursive(ctx, values, inverse=False):
@@ -22,26 +24,43 @@ def _fft_recursive(ctx, values, inverse=False):
     return transformed
 
 @defun
-def fft(ctx, values, inverse=False):
-    r"""Computes the discrete Fourier transform of a sequence.
+def fft(ctx, values, inverse=False, pad_to_power_of_two=False):
+    r"""Computes the Fast Fourier Transform (or Inverse FFT) with optional zero-padding.
 
     If ``inverse=True``, computes the inverse transform and normalizes the
     result by the sequence length.
+    If ``pad_to_power_of_two=True``, the input sequence is automatically zero-padded to the next power of 2 if its length is not already a power of 2.
     """
-    n = len(values)
-    if n == 0:
+    orig_n = len(values)
+    if orig_n == 0:
         return []
-    if n & (n - 1) != 0:
-        raise ValueError("Length of input must be a power of 2.")
+
+    is_power_of_two = (orig_n & (orig_n - 1)) == 0
+
+    if not is_power_of_two:
+        if not pad_to_power_of_two:
+            raise ValueError(f"Length of input ({orig_n}) must be a power of 2.")
+
+        padded_n = 1 << math.ceil(math.log2(orig_n))
+    else:
+        padded_n = orig_n
 
     converted_values = [ctx.convert(v) for v in values]
-    transformed = _fft_recursive(ctx, converted_values, inverse=inverse)
-    if inverse and transformed:
-        n = len(transformed)
-        transformed = [value / n for value in transformed]
-    return transformed
+
+    if padded_n > orig_n:
+        converted_values.extend([ctx.zero] * (padded_n - orig_n))
+
+    result = _fft_recursive(ctx, converted_values, inverse)
+
+    if inverse:
+        scale = ctx.convert(padded_n)
+        result = [val / scale for val in result]
+
+    return result
 
 @defun
-def ifft(ctx, values):
-    r"""Computes the inverse discrete Fourier transform of a sequence."""
-    return fft(ctx, values, inverse=True)
+def ifft(ctx, values, pad_to_power_of_two=False):
+    r"""Computes the inverse discrete Fourier transform of a sequence with optional zero-padding.
+    If ``pad_to_power_of_two=True``, the input sequence is automatically zero-padded to the next power of 2 if its length is not already a power of 2.
+    """
+    return fft(ctx, values, inverse=True, pad_to_power_of_two=pad_to_power_of_two)

--- a/mpmath/calculus/fft.py
+++ b/mpmath/calculus/fft.py
@@ -5,9 +5,9 @@ from .calculus import defun
 def _fft_iterative(ctx, values, inverse=False):
     """
     This function implements the Cooley-Tukey FFT algorithm iteratively. It computes the Fast Fourier Transform (or Inverse FFT) of a sequence of complex numbers.
-    The input sequence must have a length that is a power of 2. If the length is not a power of 2, the function raises a NotImplementedError.
+    The input sequence must have a length that is a power of 2.
 
-    https://en.wikipedia.org/wiki/Cooley%E2%80%93Tukey_FFT_algorithm#Data_reordering,_bit_reversal,_and_in-place_algorithms
+    https://en.wikipedia.org/wiki/Cooley%E2%80%93Tukey_FFT_algorithm
     """
     n = len(values)
     if n <= 1:
@@ -46,10 +46,13 @@ def _fft_iterative(ctx, values, inverse=False):
 
     return transformed
 
+# TODO: Add support for non-power-of-two lengths using Bluestein's algorithm or similar methods.
+
 @defun
 def fft(ctx, values, pad_to_power_of_two=False):
     r"""Computes the Fast Fourier Transform (or Inverse FFT) with optional zero-padding.
     If ``pad_to_power_of_two=True``, the time domain sequence is automatically zero-padded at the end to the next power of 2 if its length is not already a power of 2.
+    Raises NotImplementedError if the input sequence length is not a power of 2 and ``pad_to_power_of_two`` is False.
     """
     orig_n = len(values)
     if orig_n == 0:
@@ -78,7 +81,10 @@ def fft(ctx, values, pad_to_power_of_two=False):
 @defun
 def invfft(ctx, values, pad_to_power_of_two=False):
     r"""Computes the inverse discrete Fourier transform of a sequence with optional zero-padding.
-    If ``pad_to_power_of_two=True``, the frequency domain sequence is automatically zero-padded with Nyquist-bin splitting to the next power of 2 if its length is not already a power of 2.
+    If ``pad_to_power_of_two=True``, the frequency domain sequence is automatically center zero-padded with Nyquist-bin splitting to the next power of 2 if its length is not already a power of 2.
+    The Nyquist-bin splitting is done by taking the value at the Nyquist frequency (if it exists) and splitting it evenly between the positive and negative Nyquist bins in the padded sequence.
+    Raises NotImplementedError if the input sequence length is not a power of 2 and ``pad_to_power_of_two`` is False.
+    The output is scaled by the length of the original input sequence to ensure that the inverse transform correctly recovers the original time-domain sequence.
     """
 
     orig_n = len(values)
@@ -121,7 +127,7 @@ def invfft(ctx, values, pad_to_power_of_two=False):
 
     result = _fft_iterative(ctx, converted_values, True)
 
-    scale = ctx.convert(padded_n)
+    scale = ctx.convert(orig_n)
     result = [val / scale for val in result]
 
     return result

--- a/mpmath/calculus/fft.py
+++ b/mpmath/calculus/fft.py
@@ -57,7 +57,8 @@ def fft(ctx, values):
 
     is_power_of_two = (n & (n - 1)) == 0
     if not is_power_of_two:
-        raise NotImplementedError(f"FFT is only implemented for lengths that are powers of 2, got length: {n}")
+        raise NotImplementedError("FFT is only implemented for lengths that "
+                                  f"are powers of 2, got length: {n}")
 
     converted_values = [ctx.convert(v) for v in values]
     return _fft_cooley_tuckey(ctx, converted_values, False)
@@ -75,7 +76,8 @@ def invfft(ctx, values):
 
     is_power_of_two = (n & (n - 1)) == 0
     if not is_power_of_two:
-        raise NotImplementedError(f"Inverse FFT is only implemented for lengths that are powers of 2, got length: {n}")
+        raise NotImplementedError("Inverse FFT is only implemented for lengths that "
+                                  f"are powers of 2, got length: {n}")
 
     converted_values = [ctx.convert(v) for v in values]
     result = _fft_cooley_tuckey(ctx, converted_values, True)

--- a/mpmath/tests/test_calculus.py
+++ b/mpmath/tests/test_calculus.py
@@ -1,10 +1,12 @@
+import random
+
 import pytest
 
 from mpmath import (arange, chebyfit, cos, cosm, differint, e, euler, exp,
-                    expm, fourier, fourierval, inf, invertlaplace, j, limit,
-                    log, matrix, mp, fp, mpf, norm, pade, pi, polyroots, polyval,
-                    sin, sinm, sqrt, logm, fft, invfft)
-import random
+                    expm, fft, fourier, fourierval, inf, invertlaplace, invfft,
+                    j, limit, log, logm, matrix, mp, mpf, norm, pade, pi,
+                    polyroots, polyval, sin, sinm, sqrt)
+
 
 def test_approximation():
     f = lambda x: cos(2-2*x)/x
@@ -292,6 +294,10 @@ def test_fft():
     assert all(a.ae(b) for a, b in zip(spectrum, expected))
     assert mp.chop(invfft(spectrum)) == [1, 2, 3, 4]
 
+    spectrum = fft([1, j, -1, -j])
+    expected = [0, 4, 0, 0]
+    assert all(a.ae(b) for a, b in zip(spectrum, expected))
+
     random.seed(42)
     # test that fft and invfft are inverses of each other
     x = [mp.rand() for _ in range(8)]
@@ -301,6 +307,10 @@ def test_fft():
     X = [mp.rand() for _ in range(8)]
     recovered = fft(invfft(X))
     assert all(a.ae(b) for a, b in zip(recovered, X))
+
+    x = invfft([4, 1 - 1j, 0, 1 + 1j])
+    expected = [1.5, 1.5, 0.5, 0.5]
+    assert all(a.ae(b) for a, b in zip(x, expected))
 
     assert invfft([]) == []
     pytest.raises(NotImplementedError, lambda: invfft([1, 2, 3]))

--- a/mpmath/tests/test_calculus.py
+++ b/mpmath/tests/test_calculus.py
@@ -282,7 +282,6 @@ def test_fft():
     assert fft([1]) == [1]
     pytest.raises(NotImplementedError, lambda: fft([1, 2, 3]))
     assert fft([1, 0, 0, 0]) == [1, 1, 1, 1]
-    assert fft([1, 0, 0], pad_to_power_of_two=True) == [1, 1, 1, 1]
 
     spectrum = fft([0, 1, 0, 0])
     expected = [1, -1j, -1, 1j]
@@ -305,16 +304,10 @@ def test_fft():
 
     assert invfft([]) == []
     pytest.raises(NotImplementedError, lambda: invfft([1, 2, 3]))
-    assert invfft([3, 0, 0], pad_to_power_of_two=True) == [1, 1, 1, 1]
-
-    # test that invfft correctly handles Nyquist-bin splitting when padding
-    res = invfft([0, 3, 0, 0, 0, 3], pad_to_power_of_two=True)
-    expected = [1.0, 0.71, 0.0, -0.71, -1.0, -0.71, -0.0, 0.71]
-    assert all(a.ae(b, 1e-2) for a, b in zip(res, expected))
 
     # test parseval's theorem
     x = [mp.rand() for _ in range(64)]
-    X = fft(x, True)
+    X = fft(x)
     time_energy = sum(abs(complex(v)) ** 2 for v in x)
     freq_energy = sum(abs(complex(v)) ** 2 for v in X) / 64
     assert abs(time_energy - freq_energy) < 1e-10

--- a/mpmath/tests/test_calculus.py
+++ b/mpmath/tests/test_calculus.py
@@ -3,7 +3,7 @@ import pytest
 from mpmath import (arange, chebyfit, cos, cosm, differint, e, euler, exp,
                     expm, fourier, fourierval, inf, invertlaplace, j, limit,
                     log, matrix, mp, mpf, norm, pade, pi, polyroots, polyval,
-                    sin, sinm, sqrt, logm)
+                    sin, sinm, sqrt, logm, fft, ifft)
 
 
 def test_approximation():
@@ -276,3 +276,15 @@ def test_logm():
     # Test for zero matrix
     A = [[0, 0], [0, 0]]
     pytest.raises(ValueError, lambda: logm(A))
+
+def test_fft():
+    assert fft([1, 0, 0, 0]) == [1, 1, 1, 1]
+
+    spectrum = fft([0, 1, 0, 0])
+    expected = [1, -1j, -1, 1j]
+    assert all(a.ae(b) for a, b in zip(spectrum, expected))
+
+    spectrum = fft([1, 2, 3, 4])
+    expected = [10, -2 + 2j, -2, -2 - 2j]
+    assert all(a.ae(b) for a, b in zip(spectrum, expected))
+    assert mp.chop(ifft(spectrum)) == [1, 2, 3, 4]

--- a/mpmath/tests/test_calculus.py
+++ b/mpmath/tests/test_calculus.py
@@ -279,6 +279,7 @@ def test_logm():
 
 def test_fft():
     assert fft([]) == []
+    assert fft([1]) == [1]
     pytest.raises(NotImplementedError, lambda: fft([1, 2, 3]))
     assert fft([1, 0, 0, 0]) == [1, 1, 1, 1]
     assert fft([1, 0, 0], pad_to_power_of_two=True) == [1, 1, 1, 1]
@@ -291,3 +292,10 @@ def test_fft():
     expected = [10, -2 + 2j, -2, -2 - 2j]
     assert all(a.ae(b) for a, b in zip(spectrum, expected))
     assert mp.chop(invfft(spectrum)) == [1, 2, 3, 4]
+
+    assert invfft([]) == []
+    pytest.raises(NotImplementedError, lambda: invfft([1, 2, 3]))
+    assert invfft([1, 0, 0], pad_to_power_of_two=True) == [0.25, 0.25, 0.25, 0.25]
+    expected = [1, 1, 1, 0.5, 0, 0.5, 1, 1]
+    res = fft(invfft([1, 1, 1, 1, 1, 1], pad_to_power_of_two=True))
+    assert all(a.ae(b) for a, b in zip(res, expected))

--- a/mpmath/tests/test_calculus.py
+++ b/mpmath/tests/test_calculus.py
@@ -1,6 +1,6 @@
-import random
-
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 from mpmath import (arange, chebyfit, cos, cosm, differint, e, euler, exp,
                     expm, fft, fourier, fourierval, inf, invertlaplace, invfft,
@@ -298,16 +298,6 @@ def test_fft():
     expected = [0, 4, 0, 0]
     assert all(a.ae(b) for a, b in zip(spectrum, expected))
 
-    random.seed(42)
-    # test that fft and invfft are inverses of each other
-    x = [mp.rand() for _ in range(8)]
-    recovered = invfft(fft(x))
-    assert all(a.ae(b) for a, b in zip(recovered, x))
-
-    X = [mp.rand() for _ in range(8)]
-    recovered = fft(invfft(X))
-    assert all(a.ae(b) for a, b in zip(recovered, X))
-
     x = invfft([4, 1 - 1j, 0, 1 + 1j])
     expected = [1.5, 1.5, 0.5, 0.5]
     assert all(a.ae(b) for a, b in zip(x, expected))
@@ -316,8 +306,31 @@ def test_fft():
     pytest.raises(NotImplementedError, lambda: invfft([1, 2, 3]))
 
     # test parseval's theorem
-    x = [mp.rand() for _ in range(64)]
+    x = [0.25 + 2.0j, -0.5, 0.75 - 1.0j, -1.0 - 8.0j, 0.5, 0.125 + 0.65j, -0.75, 1.25 + 2.5j]
     X = fft(x)
     time_energy = sum(abs(complex(v)) ** 2 for v in x)
-    freq_energy = sum(abs(complex(v)) ** 2 for v in X) / 64
-    assert abs(time_energy - freq_energy) < 1e-10
+    freq_energy = sum(abs(complex(v)) ** 2 for v in X) / 8
+    assert abs(time_energy - freq_energy) < 1e-12
+
+@st.composite
+def power_of_two_signals(draw):
+    size = draw(st.sampled_from([1, 2, 4, 8, 16]))
+    return draw(st.lists(
+        st.complex_numbers(
+            min_magnitude=0,
+            max_magnitude=10,
+            allow_nan=False,
+            allow_infinity=False,
+        ),
+        min_size=size,
+        max_size=size,
+    ))
+
+@given(x=power_of_two_signals())
+def test_fft_randomized_complex(x):
+    # test that fft and invfft are inverses of each other for random complex inputs
+    recovered = invfft(fft(x))
+    assert all(mp.almosteq(a, b, rel_eps=1e-12) for a, b in zip(recovered, x))
+
+    recovered = fft(invfft(x))
+    assert all(mp.almosteq(a, b, rel_eps=1e-12) for a, b in zip(recovered, x))

--- a/mpmath/tests/test_calculus.py
+++ b/mpmath/tests/test_calculus.py
@@ -3,7 +3,7 @@ import pytest
 from mpmath import (arange, chebyfit, cos, cosm, differint, e, euler, exp,
                     expm, fourier, fourierval, inf, invertlaplace, j, limit,
                     log, matrix, mp, mpf, norm, pade, pi, polyroots, polyval,
-                    sin, sinm, sqrt, logm, fft, ifft)
+                    sin, sinm, sqrt, logm, fft, invfft)
 
 
 def test_approximation():
@@ -279,7 +279,7 @@ def test_logm():
 
 def test_fft():
     assert fft([]) == []
-    pytest.raises(ValueError, lambda: fft([1, 2, 3]))
+    pytest.raises(NotImplementedError, lambda: fft([1, 2, 3]))
     assert fft([1, 0, 0, 0]) == [1, 1, 1, 1]
     assert fft([1, 0, 0], pad_to_power_of_two=True) == [1, 1, 1, 1]
 
@@ -290,4 +290,4 @@ def test_fft():
     spectrum = fft([1, 2, 3, 4])
     expected = [10, -2 + 2j, -2, -2 - 2j]
     assert all(a.ae(b) for a, b in zip(spectrum, expected))
-    assert mp.chop(ifft(spectrum)) == [1, 2, 3, 4]
+    assert mp.chop(invfft(spectrum)) == [1, 2, 3, 4]

--- a/mpmath/tests/test_calculus.py
+++ b/mpmath/tests/test_calculus.py
@@ -2,9 +2,9 @@ import pytest
 
 from mpmath import (arange, chebyfit, cos, cosm, differint, e, euler, exp,
                     expm, fourier, fourierval, inf, invertlaplace, j, limit,
-                    log, matrix, mp, mpf, norm, pade, pi, polyroots, polyval,
+                    log, matrix, mp, fp, mpf, norm, pade, pi, polyroots, polyval,
                     sin, sinm, sqrt, logm, fft, invfft)
-
+import random
 
 def test_approximation():
     f = lambda x: cos(2-2*x)/x
@@ -293,9 +293,28 @@ def test_fft():
     assert all(a.ae(b) for a, b in zip(spectrum, expected))
     assert mp.chop(invfft(spectrum)) == [1, 2, 3, 4]
 
+    random.seed(42)
+    # test that fft and invfft are inverses of each other
+    x = [mp.rand() for _ in range(8)]
+    recovered = invfft(fft(x))
+    assert all(a.ae(b) for a, b in zip(recovered, x))
+
+    X = [mp.rand() for _ in range(8)]
+    recovered = fft(invfft(X))
+    assert all(a.ae(b) for a, b in zip(recovered, X))
+
     assert invfft([]) == []
     pytest.raises(NotImplementedError, lambda: invfft([1, 2, 3]))
-    assert invfft([1, 0, 0], pad_to_power_of_two=True) == [0.25, 0.25, 0.25, 0.25]
-    expected = [1, 1, 1, 0.5, 0, 0.5, 1, 1]
-    res = fft(invfft([1, 1, 1, 1, 1, 1], pad_to_power_of_two=True))
-    assert all(a.ae(b) for a, b in zip(res, expected))
+    assert invfft([3, 0, 0], pad_to_power_of_two=True) == [1, 1, 1, 1]
+
+    # test that invfft correctly handles Nyquist-bin splitting when padding
+    res = invfft([0, 3, 0, 0, 0, 3], pad_to_power_of_two=True)
+    expected = [1.0, 0.71, 0.0, -0.71, -1.0, -0.71, -0.0, 0.71]
+    assert all(a.ae(b, 1e-2) for a, b in zip(res, expected))
+
+    # test parseval's theorem
+    x = [mp.rand() for _ in range(64)]
+    X = fft(x, True)
+    time_energy = sum(abs(complex(v)) ** 2 for v in x)
+    freq_energy = sum(abs(complex(v)) ** 2 for v in X) / 64
+    assert abs(time_energy - freq_energy) < 1e-10

--- a/mpmath/tests/test_calculus.py
+++ b/mpmath/tests/test_calculus.py
@@ -278,7 +278,10 @@ def test_logm():
     pytest.raises(ValueError, lambda: logm(A))
 
 def test_fft():
+    assert fft([]) == []
+    pytest.raises(ValueError, lambda: fft([1, 2, 3]))
     assert fft([1, 0, 0, 0]) == [1, 1, 1, 1]
+    assert fft([1, 0, 0], pad_to_power_of_two=True) == [1, 1, 1, 1]
 
     spectrum = fft([0, 1, 0, 0])
     expected = [1, -1j, -1, 1j]

--- a/mpmath/tests/test_calculus.py
+++ b/mpmath/tests/test_calculus.py
@@ -330,7 +330,7 @@ def power_of_two_signals(draw):
 def test_fft_randomized_complex(x):
     # test that fft and invfft are inverses of each other for random complex inputs
     recovered = invfft(fft(x))
-    assert all(mp.almosteq(a, b, rel_eps=1e-12) for a, b in zip(recovered, x))
+    assert all(a.ae(b) for a, b in zip(recovered, x))
 
     recovered = fft(invfft(x))
-    assert all(mp.almosteq(a, b, rel_eps=1e-12) for a, b in zip(recovered, x))
+    assert all(a.ae(b) for a, b in zip(recovered, x))


### PR DESCRIPTION
Addresses #707 

Implements the `Radix-2 Cooley-Tukey` Fast Fourier Transform (FFT) algorithm to compute the discrete fourier transform (DFT) and inverse discrete fourier transform (IDFT) of a signal.

### Key Changes:
- Added iterative Radix-2 Cooley-Tukey FFT for power-of-two input lengths signals.
- Implemented `fft(x)` and `invfft(X)` for calculating forward and inverse DFT.
- Added unit tests along with docstrings and usage examples.

### Design Decisions & Next Steps
- No zero-padding: After a long discussion, we decided not to use optional zero-padding and Inputs are currently restricted to lengths of powers of 2 ($N = 2^k$).
- Future Work: Support for arbitrary input sizes via Bluestein's algorithm or similar approaches.