### PR TITLE
Optimize conversion from Weierstrass invariants to half-periods

### DIFF
--- a/mpmath/functions/elliptic.py
+++ b/mpmath/functions/elliptic.py
@@ -1718,30 +1718,34 @@ def g2g3from(ctx, q=None, m=None, k=None, tau=None, qbar=None,
         "g2g3from", q, m, k, tau, qbar, g2, g3, omega1, omega2)
     with ctx.extraprec(10):
         if g2 is not None:
-            return +ctx.convert(g2), +ctx.convert(g3)
-        if omega1 is None:
-            tau = ctx.taufrom(q=q, m=m, k=k, tau=tau, qbar=qbar)
-            if ctx.im(tau) <= 0:
-                raise ValueError("g2g3from: tau must be in upper half-plane")
-            omega1 = ctx.one/2
-            omega2 = tau/2
+            g2 = ctx.convert(g2)
+            g3 = ctx.convert(g3)
         else:
-            omega1 = ctx.convert(omega1)
-            omega2 = ctx.convert(omega2)
-        if ctx.im(omega2/omega1) <= 0:
-            raise ValueError("g2g3from: omega ratio must be "
-                             "in upper half-plane")
-        tau = omega2 / omega1
-        q = ctx.qfrom(tau=tau)
-        j2 = ctx.jtheta(2, 0, q)
-        j3 = ctx.jtheta(3, 0, q)
-        factor = ctx.pi / (2 * omega1)
-        g2 = (ctx.mpf(4)/3) * factor**4 * (j2**8 - (j2*j3)**4 + j3**8)
-        g3 = ((ctx.mpf(8)/27) * factor**6 *
-              (j2**12 - (ctx.mpf(3)/2*j2**8*j3**4 +
-                         ctx.mpf(3)/2*j2**4*j3**8) +
-               j3**12))
-        return +g2, +g3
+            if omega1 is None:
+                tau = ctx.taufrom(q=q, m=m, k=k, tau=tau, qbar=qbar)
+                if ctx.im(tau) <= 0:
+                    raise ValueError("g2g3from: tau must be in upper "
+                                     "half-plane")
+                omega1 = ctx.one/2
+                omega2 = tau/2
+            else:
+                omega1 = ctx.convert(omega1)
+                omega2 = ctx.convert(omega2)
+            if ctx.im(omega2/omega1) <= 0:
+                raise ValueError("g2g3from: omega ratio must be "
+                                 "in upper half-plane")
+            tau = omega2 / omega1
+            q = ctx.qfrom(tau=tau)
+            j2 = ctx.jtheta(2, 0, q)
+            j3 = ctx.jtheta(3, 0, q)
+            factor = ctx.pi / (2 * omega1)
+            g2 = ((ctx.mpf(4)/3) * factor**4 *
+                  (j2**8 - (j2*j3)**4 + j3**8))
+            g3 = ((ctx.mpf(8)/27) * factor**6 *
+                  (j2**12 - (ctx.mpf(3)/2*j2**8*j3**4 +
+                             ctx.mpf(3)/2*j2**4*j3**8) +
+                   j3**12))
+    return +g2, +g3
 
 @defun
 def omega1omega2from(ctx, q=None, m=None, k=None, tau=None, qbar=None,
@@ -1778,23 +1782,28 @@ def omega1omega2from(ctx, q=None, m=None, k=None, tau=None, qbar=None,
     """
     _validate_weierstrass_parameter_args(
         "omega1omega2from", q, m, k, tau, qbar, g2, g3, omega1, omega2)
-    with ctx.extraprec(10):
-        if omega1 is not None:
+    if omega1 is not None:
+        with ctx.extraprec(10):
             omega1 = ctx.convert(omega1)
             omega2 = ctx.convert(omega2)
             if ctx.im(omega2/omega1) <= 0:
                 raise ValueError("omega1omega2from: omega ratio must be "
                                  "in upper half-plane")
-            return +omega1, +omega2
-        if g2 is None:
+        return +omega1, +omega2
+    if g2 is None:
+        with ctx.extraprec(10):
             tau = ctx.taufrom(q=q, m=m, k=k, tau=tau, qbar=qbar)
             if ctx.im(tau) <= 0:
                 raise ValueError("omega1omega2from: tau must be in upper "
                                  "half-plane")
-            return +(ctx.one/2), +(tau/2)
+            omega1 = ctx.one/2
+            omega2 = tau/2
+        return +omega1, +omega2
 
+    with ctx.extraprec(10):
         g2 = ctx.convert(g2)
         g3 = ctx.convert(g3)
+        periods = None
 
         if g2 == 0:
             omegaA = (g3 ** (ctx.mpf(-1)/ctx.mpf(6)) *
@@ -1850,41 +1859,52 @@ def omega1omega2from(ctx, q=None, m=None, k=None, tau=None, qbar=None,
                     # For m <= 1/2 the standard rectangular basis is already
                     # reduced. For m > 1/2 apply its S-transform directly.
                     if m <= ctx.one/2:
-                        return +real_period, +(ctx.j*imaginary_period)
-                    return +(-ctx.j*imaginary_period), +real_period
+                        periods = (real_period,
+                                   ctx.j*imaginary_period)
+                    else:
+                        periods = (-ctx.j*imaginary_period, real_period)
+                else:
+                    # One real root and a conjugate pair. Real Cardano radicals
+                    # followed by a quadratic transformation express both
+                    # periods using complete elliptic integrals with real
+                    # parameters.
+                    root_discriminant = ctx.sqrt(-real_discriminant/1728)
+                    exponent = ctx.mpf(1)/3
+                    u3 = real_g3/8 + root_discriminant
+                    v3 = real_g3/8 - root_discriminant
+                    u = ctx.sign(u3)*abs(u3)**exponent
+                    v = ctx.sign(v3)*abs(v3)**exponent
+                    real_root = u+v
+                    root_real_part = 3*real_root/2
+                    root_imaginary_part = ctx.sqrt(3)*(u-v)/2
+                    H = ctx.sqrt(root_real_part**2 +
+                                 root_imaginary_part**2)
+                    m = (H-root_real_part)/(2*H)
+                    sqrt_H = ctx.sqrt(H)
+                    real_period = ctx.ellipk(m)/sqrt_H
+                    imaginary_part = ctx.ellipk(1-m)/(2*sqrt_H)
 
-                # One real root and a conjugate pair. Real Cardano radicals
-                # followed by a quadratic transformation express both periods
-                # using complete elliptic integrals with real parameters.
-                root_discriminant = ctx.sqrt(-real_discriminant/1728)
-                exponent = ctx.mpf(1)/3
-                u3 = real_g3/8 + root_discriminant
-                v3 = real_g3/8 - root_discriminant
-                u = ctx.sign(u3)*abs(u3)**exponent
-                v = ctx.sign(v3)*abs(v3)**exponent
-                real_root = u+v
-                root_real_part = 3*real_root/2
-                root_imaginary_part = ctx.sqrt(3)*(u-v)/2
-                H = ctx.sqrt(root_real_part**2 + root_imaginary_part**2)
-                m = (H-root_real_part)/(2*H)
-                sqrt_H = ctx.sqrt(H)
-                real_period = ctx.ellipk(m)/sqrt_H
-                imaginary_part = ctx.ellipk(1-m)/(2*sqrt_H)
-
-                # These bases directly implement the documented fundamental-
-                # domain and simultaneous-sign conventions in each real
-                # symmetry region, so no generic PSL(2,Z) reduction is needed.
-                if real_g2 > 0:
-                    if real_g3 > 0:
-                        return (+real_period,
-                                +(real_period/2 + ctx.j*imaginary_part))
-                    return (+(-2*ctx.j*imaginary_part),
-                            +(real_period/2-ctx.j*imaginary_part))
-                if real_g3 > 0:
-                    return (+(real_period/2+ctx.j*imaginary_part),
-                            +(-real_period/2+ctx.j*imaginary_part))
-                return (+(real_period/2-ctx.j*imaginary_part),
-                        +(real_period/2+ctx.j*imaginary_part))
+                    # These bases directly implement the documented
+                    # fundamental-domain and simultaneous-sign conventions in
+                    # each real symmetry region, so no generic PSL(2,Z)
+                    # reduction is needed.
+                    if real_g2 > 0:
+                        if real_g3 > 0:
+                            periods = (
+                                real_period,
+                                real_period/2 + ctx.j*imaginary_part)
+                        else:
+                            periods = (
+                                -2*ctx.j*imaginary_part,
+                                real_period/2-ctx.j*imaginary_part)
+                    elif real_g3 > 0:
+                        periods = (
+                            real_period/2+ctx.j*imaginary_part,
+                            -real_period/2+ctx.j*imaginary_part)
+                    else:
+                        periods = (
+                            real_period/2-ctx.j*imaginary_part,
+                            real_period/2+ctx.j*imaginary_part)
             else:
                 # Solve the original cubic directly. This obtains both the
                 # elliptic parameter and its scale together, avoiding inverse
@@ -1907,35 +1927,39 @@ def omega1omega2from(ctx, q=None, m=None, k=None, tau=None, qbar=None,
                           (2*ctx.agm(1, ctx.sqrt(m))*sqrt_D))
                 tau = omegaB/omegaA
 
-        if g2 != 0 and g3 != 0:
-            a, b, c, d = ctx._reduce_psl2z(tau)
-            omega1 = d*omegaA + c*omegaB
-            omega2 = b*omegaA + a*omegaB
+        if periods is None:
+            if g2 != 0 and g3 != 0:
+                a, b, c, d = ctx._reduce_psl2z(tau)
+                omega1 = d*omegaA + c*omegaB
+                omega2 = b*omegaA + a*omegaB
+            else:
+                omega1, omega2 = omegaA, omegaB
+
+            # Remove sub-precision components introduced by inverse-j branch
+            # arithmetic before applying conventions on symmetry boundaries.
+            omega1 = ctx.chop(omega1)
+            omega2 = ctx.chop(omega2)
+            tau = omega2/omega1
+            # Identify equivalent points on the vertical and circular
+            # boundaries of the fundamental domain without recomputing the
+            # period ratio.
+            if ctx.almosteq(ctx.re(tau), -ctx.one/2):
+                omega2 += omega1
+                tau += 1
+            if ctx.almosteq(abs(tau), ctx.one) and ctx.re(tau) < 0:
+                omega1, omega2 = omega2, -omega1
+
+            # The invariants do not distinguish a basis from its simultaneous
+            # negation. Place omega1 in the right half-plane, with the negative
+            # imaginary axis included as its boundary.
+            real = ctx.re(omega1)
+            if ((real < 0 and not ctx.almosteq(real, 0)) or
+                    (ctx.almosteq(real, 0) and ctx.im(omega1) > 0)):
+                omega1 = -omega1
+                omega2 = -omega2
         else:
-            omega1, omega2 = omegaA, omegaB
-
-        # Remove sub-precision components introduced by inverse-j branch
-        # arithmetic before applying conventions on symmetry boundaries.
-        omega1 = ctx.chop(omega1)
-        omega2 = ctx.chop(omega2)
-        tau = omega2/omega1
-        # Identify equivalent points on the vertical and circular boundaries
-        # of the fundamental domain without recomputing the period ratio.
-        if ctx.almosteq(ctx.re(tau), -ctx.one/2):
-            omega2 += omega1
-            tau += 1
-        if ctx.almosteq(abs(tau), ctx.one) and ctx.re(tau) < 0:
-            omega1, omega2 = omega2, -omega1
-
-        # The invariants do not distinguish a basis from its simultaneous
-        # negation. Place omega1 in the right half-plane, with the negative
-        # imaginary axis included as its boundary.
-        real = ctx.re(omega1)
-        if ((real < 0 and not ctx.almosteq(real, 0)) or
-                (ctx.almosteq(real, 0) and ctx.im(omega1) > 0)):
-            omega1 = -omega1
-            omega2 = -omega2
-        return +omega1, +omega2
+            omega1, omega2 = periods
+    return +omega1, +omega2
 
 
 # ============================================================================

--- a/mpmath/functions/elliptic.py
+++ b/mpmath/functions/elliptic.py
@@ -1660,31 +1660,6 @@ def _roots_from_omega(ctx, omega1, omega2):
     return e1, e2, e3
 
 
-def _canonicalize_weierstrass_periods(ctx, omega1, omega2):
-    """Choose a deterministic orientation for a reduced period basis."""
-    tau = omega2 / omega1
-
-    # Identify the vertical edges of the fundamental domain.
-    if ctx.almosteq(ctx.re(tau), -ctx.one/2):
-        omega2 += omega1
-        tau = omega2 / omega1
-
-    # Identify equivalent points on the circular boundary.
-    if ctx.almosteq(abs(tau), ctx.one) and ctx.re(tau) < 0:
-        omega1, omega2 = omega2, -omega1
-
-    # The invariants do not distinguish a basis from its simultaneous
-    # negation. Follow the usual convention of placing omega1 in the right
-    # half-plane, using the negative imaginary axis as the boundary.
-    real = ctx.re(omega1)
-    if ((real < 0 and not ctx.almosteq(real, 0)) or
-            (ctx.almosteq(real, 0) and ctx.im(omega1) > 0)):
-        omega1 = -omega1
-        omega2 = -omega2
-
-    return omega1, omega2
-
-
 def _eisenstein_E4_E6(ctx, tau):
     """
     Eisenstein E-series of weight 4 and 6.
@@ -1693,9 +1668,13 @@ def _eisenstein_E4_E6(ctx, tau):
     q = ctx.qfrom(tau=tau)
     j2 = ctx.jtheta(2, 0, q)
     j3 = ctx.jtheta(3, 0, q)
-    j4 = ctx.jtheta(4, 0, q)
-    E4 = (j2**8 + j3**8 + j4**8) / 2
-    E6 = (-3*j2**8 * (j3**4 + j4**4) + (j3**12 + j4**12)) / 2
+    j24 = j2**4
+    j34 = j3**4
+    # Jacobi's identity j3**4 = j2**4 + j4**4 eliminates one
+    # comparatively expensive theta-constant evaluation.
+    E4 = j24**2 - j24*j34 + j34**2
+    E6 = (j24**3 - ctx.mpf(3)/2*j24**2*j34 -
+          ctx.mpf(3)/2*j24*j34**2 + j34**3)
     return E4, E6
 
 def _eisenstein_G4_G6(ctx, tau):
@@ -1706,6 +1685,7 @@ def _eisenstein_G4_G6(ctx, tau):
     G4 = 2 * ctx.zeta(4) * E4
     G6 = 2 * ctx.zeta(6) * E6
     return G4, G6
+
 
 # ============================================================================
 # Weierstrass parameter conversion functions
@@ -1820,17 +1800,113 @@ def omega1omega2from(ctx, q=None, m=None, k=None, tau=None, qbar=None,
             omegaA = (g3 ** (ctx.mpf(-1)/ctx.mpf(6)) *
                       ctx.gamma(ctx.mpf(1)/ctx.mpf(3))**3 / (4*ctx.pi))
             tau = ctx.mpc(ctx.mpf(1)/ctx.mpf(2), ctx.sqrt(3)/2)
+            omegaB = tau * omegaA
         elif g3 == 0:
-            tau = ctx.taufrom(g2=g2, g3=g3)
-            G4, G6 = _eisenstein_G4_G6(ctx, tau)
-            omegaA = (ctx.j * (ctx.mpf(15)/(4*g2) * G4) **
+            # Lemniscatic closed form, written to preserve the principal
+            # fourth-root branch used by the former Eisenstein calculation.
+            lemniscatic = (ctx.gamma(ctx.mpf(1)/4)**2 /
+                           (4*ctx.sqrt(ctx.pi)))
+            omegaA = (ctx.j * (lemniscatic**4/g2) **
                       (ctx.mpf(1)/ctx.mpf(4)))
+            tau = ctx.j
+            omegaB = tau * omegaA
         else:
-            tau = ctx.taufrom(g2=g2, g3=g3)
-            G4, G6 = _eisenstein_G4_G6(ctx, tau)
-            omegaA = ctx.sqrt(g2/g3 * G6/G4 * ctx.mpf(7)/ctx.mpf(12))
+            discriminant = g2**3 - 27*g3**2
+            g2_term = abs(g2)**3
+            g3_term = 27*abs(g3)**2
+            shape_ratio = min(g2_term, g3_term) / max(g2_term, g3_term)
 
-        omegaB = tau * omegaA
+            # Direct root formulas are singular at the cusp and ill-conditioned
+            # near J=0 and J=1. Retain the Eisenstein scale formula there so
+            # small nonzero invariants are not discarded by cancellation.
+            if discriminant == 0 or shape_ratio < ctx.ldexp(1, -20):
+                tau = ctx.taufrom(g2=g2, g3=g3)
+                G4, G6 = _eisenstein_G4_G6(ctx, tau)
+                omegaA = ctx.sqrt(g2/g3 * G6/G4 *
+                                  ctx.mpf(7)/ctx.mpf(12))
+                omegaB = tau * omegaA
+            elif ctx.im(g2) == 0 and ctx.im(g3) == 0:
+                real_g2 = ctx.re(g2)
+                real_g3 = ctx.re(g3)
+                real_discriminant = ctx.re(discriminant)
+                if real_discriminant > 0:
+                    # Three real roots. A trigonometric solution avoids the
+                    # complex intermediate values in Cardano's formula. The
+                    # ordered roots give a real elliptic parameter m.
+                    root_scale = ctx.sqrt(real_g2/3)
+                    cosine = (3*ctx.sqrt(3)*real_g3 /
+                              (real_g2*ctx.sqrt(real_g2)))
+                    cosine = min(ctx.one, max(-ctx.one, cosine))
+                    theta = ctx.acos(cosine)/3
+                    e1 = root_scale*ctx.cos(theta)
+                    e2 = root_scale*ctx.cos(theta-2*ctx.pi/3)
+                    e3 = root_scale*ctx.cos(theta+2*ctx.pi/3)
+                    D = e1-e3
+                    m = (e2-e3)/D
+                    sqrt_D = ctx.sqrt(D)
+                    real_period = ctx.ellipk(m)/sqrt_D
+                    imaginary_period = ctx.ellipk(1-m)/sqrt_D
+
+                    # For m <= 1/2 the standard rectangular basis is already
+                    # reduced. For m > 1/2 apply its S-transform directly.
+                    if m <= ctx.one/2:
+                        return +real_period, +(ctx.j*imaginary_period)
+                    return +(-ctx.j*imaginary_period), +real_period
+
+                # One real root and a conjugate pair. Real Cardano radicals
+                # followed by a quadratic transformation express both periods
+                # using complete elliptic integrals with real parameters.
+                root_discriminant = ctx.sqrt(-real_discriminant/1728)
+                exponent = ctx.mpf(1)/3
+                u3 = real_g3/8 + root_discriminant
+                v3 = real_g3/8 - root_discriminant
+                u = ctx.sign(u3)*abs(u3)**exponent
+                v = ctx.sign(v3)*abs(v3)**exponent
+                real_root = u+v
+                root_real_part = 3*real_root/2
+                root_imaginary_part = ctx.sqrt(3)*(u-v)/2
+                H = ctx.sqrt(root_real_part**2 + root_imaginary_part**2)
+                m = (H-root_real_part)/(2*H)
+                sqrt_H = ctx.sqrt(H)
+                real_period = ctx.ellipk(m)/sqrt_H
+                imaginary_part = ctx.ellipk(1-m)/(2*sqrt_H)
+
+                # These bases directly implement the documented fundamental-
+                # domain and simultaneous-sign conventions in each real
+                # symmetry region, so no generic PSL(2,Z) reduction is needed.
+                if real_g2 > 0:
+                    if real_g3 > 0:
+                        return (+real_period,
+                                +(real_period/2 + ctx.j*imaginary_part))
+                    return (+(-2*ctx.j*imaginary_part),
+                            +(real_period/2-ctx.j*imaginary_part))
+                if real_g3 > 0:
+                    return (+(real_period/2+ctx.j*imaginary_part),
+                            +(-real_period/2+ctx.j*imaginary_part))
+                return (+(real_period/2-ctx.j*imaginary_part),
+                        +(real_period/2+ctx.j*imaginary_part))
+            else:
+                # Solve the original cubic directly. This obtains both the
+                # elliptic parameter and its scale together, avoiding inverse
+                # j followed by a separate reconstruction of e1-e3.
+                root_discriminant = ctx.sqrt(-discriminant/1728)
+                u3 = g3/8 + root_discriminant
+                u = u3**(ctx.mpf(1)/3)
+                v = g2/(12*u)
+                cube_root_unity = ctx.expjpi(ctx.mpf(2)/3)
+                cube_root_unity2 = -1-cube_root_unity
+                e1 = u+v
+                e2 = cube_root_unity*u + cube_root_unity2*v
+                e3 = cube_root_unity2*u + cube_root_unity*v
+                D = e1-e3
+                m = (e2-e3)/D
+                sqrt_D = ctx.sqrt(D)
+                omegaA = (ctx.pi /
+                          (2*ctx.agm(1, ctx.sqrt(1-m))*sqrt_D))
+                omegaB = (ctx.j*ctx.pi /
+                          (2*ctx.agm(1, ctx.sqrt(m))*sqrt_D))
+                tau = omegaB/omegaA
+
         if g2 != 0 and g3 != 0:
             a, b, c, d = ctx._reduce_psl2z(tau)
             omega1 = d*omegaA + c*omegaB
@@ -1838,8 +1914,27 @@ def omega1omega2from(ctx, q=None, m=None, k=None, tau=None, qbar=None,
         else:
             omega1, omega2 = omegaA, omegaB
 
-        omega1, omega2 = _canonicalize_weierstrass_periods(
-            ctx, omega1, omega2)
+        # Remove sub-precision components introduced by inverse-j branch
+        # arithmetic before applying conventions on symmetry boundaries.
+        omega1 = ctx.chop(omega1)
+        omega2 = ctx.chop(omega2)
+        tau = omega2/omega1
+        # Identify equivalent points on the vertical and circular boundaries
+        # of the fundamental domain without recomputing the period ratio.
+        if ctx.almosteq(ctx.re(tau), -ctx.one/2):
+            omega2 += omega1
+            tau += 1
+        if ctx.almosteq(abs(tau), ctx.one) and ctx.re(tau) < 0:
+            omega1, omega2 = omega2, -omega1
+
+        # The invariants do not distinguish a basis from its simultaneous
+        # negation. Place omega1 in the right half-plane, with the negative
+        # imaginary axis included as its boundary.
+        real = ctx.re(omega1)
+        if ((real < 0 and not ctx.almosteq(real, 0)) or
+                (ctx.almosteq(real, 0) and ctx.im(omega1) > 0)):
+            omega1 = -omega1
+            omega2 = -omega2
         return +omega1, +omega2
 
 

--- a/mpmath/tests/test_elliptic.py
+++ b/mpmath/tests/test_elliptic.py
@@ -1065,6 +1065,32 @@ def test_weierstrass_half_periods_direct_agm_roundtrip():
                 assert abs(tau) >= 1 - tol
 
 
+def test_weierstrass_parameter_conversion_normalization():
+    with mp.workprec(100):
+        high_precision = sqrt(2)
+
+    with mp.workprec(53):
+        invariant_results = [
+            g2g3from(g2=high_precision, g3=high_precision + 1),
+            g2g3from(tau=mpc('0.3', '1.2')),
+            g2g3from(omega1=high_precision,
+                     omega2=j*high_precision),
+        ]
+        period_results = [
+            omega1omega2from(omega1=high_precision,
+                             omega2=j*high_precision),
+            omega1omega2from(tau=mpc('0.3', '1.2')),
+            omega1omega2from(g2=12, g3=1),
+            omega1omega2from(g2=60, g3=140),
+            omega1omega2from(g2=1 + 2*j, g3=3 - 4*j),
+            omega1omega2from(g2=1, g3=0),
+            omega1omega2from(g2=0, g3=1),
+        ]
+
+        for result in invariant_results + period_results:
+            assert result == tuple(+value for value in result)
+
+
 def test_weierstrass_period_method_switch_is_continuous():
     mp.dps = 50
     threshold = ldexp(1, -20)

--- a/mpmath/tests/test_elliptic.py
+++ b/mpmath/tests/test_elliptic.py
@@ -1021,6 +1021,7 @@ def test_kleinjinv():
                   eps=eps*1000)
     assert mpc_ae(kleinjinv(1), j, eps=eps*1000)
 
+
 def test_taufrom_weierstrass_invariants():
     mp.dps = 30
 
@@ -1031,6 +1032,67 @@ def test_taufrom_weierstrass_invariants():
     assert mpc_ae(kleinj(recovered_tau), kleinj(tau), eps=eps*1000)
     pytest.raises(ValueError, lambda: taufrom(g2=g2))
     pytest.raises(ValueError, lambda: taufrom(g3=g3))
+
+
+def test_weierstrass_half_periods_direct_agm_roundtrip():
+    base_cases = [
+        (60, 140), (12, 1), (12, -1), (4, 1), (4, -1),
+        (1, 1), (1, -1), (10, 5), (100, 1), (-4, 1), (-4, -1),
+        (1 + 2*j, 3 - 4*j),
+    ]
+
+    for dps in [15, 30, 80]:
+        with mp.workdps(dps):
+            # Recompute these phases at the active precision. They exercise
+            # the fallback's vertical and circular boundary normalization.
+            cases = base_cases + [
+                (mpf('0.01')*exp(j*pi/6), exp(j*pi/4)),
+                (exp(-j*pi/6), mpf('0.0001')*exp(-3*j*pi/4)),
+            ]
+            for g2, g3 in cases:
+                omega1, omega2 = omega1omega2from(g2=g2, g3=g3)
+                actual_g2, actual_g3 = g2g3from(
+                    omega1=omega1, omega2=omega2)
+                tol = mp.eps*10000
+                assert mp.almosteq(actual_g2, g2,
+                                   rel_eps=tol, abs_eps=tol)
+                assert mp.almosteq(actual_g3, g3,
+                                   rel_eps=tol, abs_eps=tol)
+
+                tau = omega2/omega1
+                assert tau.imag > 0
+                assert abs(tau.real) <= mpf('0.5') + tol
+                assert abs(tau) >= 1 - tol
+
+
+def test_weierstrass_period_method_switch_is_continuous():
+    mp.dps = 50
+    threshold = ldexp(1, -20)
+
+    # The internal method switches when the ratio between |g2|**3 and
+    # 27*|g3|**2 crosses this threshold. Exercise both the J=0 and J=1
+    # sides and ensure the canonical period basis does not jump.
+    families = [
+        lambda ratio: ((27*ratio)**(mpf(1)/3), mpf(1)),
+        lambda ratio: (mpf(1), sqrt(ratio/27)),
+    ]
+    for make_invariants in families:
+        below = make_invariants(threshold*(1-mpf('1e-8')))
+        above = make_invariants(threshold*(1+mpf('1e-8')))
+        periods_below = omega1omega2from(g2=below[0], g3=below[1])
+        periods_above = omega1omega2from(g2=above[0], g3=above[1])
+
+        for value_below, value_above in zip(periods_below, periods_above):
+            assert mp.almosteq(value_below, value_above,
+                               rel_eps=mpf('1e-8'), abs_eps=mpf('1e-8'))
+
+        for invariants, periods in [(below, periods_below),
+                                    (above, periods_above)]:
+            actual = g2g3from(omega1=periods[0], omega2=periods[1])
+            assert mp.almosteq(actual[0], invariants[0],
+                               rel_eps=mp.eps*10000)
+            assert mp.almosteq(actual[1], invariants[1],
+                               rel_eps=mp.eps*10000)
 
 def test_taufrom_half_periods():
     mp.dps = 30


### PR DESCRIPTION
## Motivation

Passing `g2, g3` directly is a popular and natural way to evaluate the Weierstrass elliptic functions. For repeated evaluations, precomputing `omega1, omega2` remains the fastest approach, since otherwise the conversion from invariants to half-periods is performed on every call. However, it would be useful to reduce the timing difference between these two interfaces.

This PR optimizes the internal conversion performed by `omega1omega2from(g2=..., g3=...)`. It does not change the public API, function signatures, documented period conventions, or accepted inputs.

## Approach

Previously, the general conversion recovered `tau` through the inverse Klein j-invariant and then reconstructed the period scale using Eisenstein series and theta constants.

The optimized implementation instead obtains the elliptic parameter and period scale together:

- For real invariants with three real cubic roots, it uses the trigonometric cubic solution followed by complete elliptic integrals.
- For real invariants with one real root, it uses real Cardano radicals and a quadratic transformation, keeping the elliptic-integral calculations real.
- For generic complex invariants, it solves the cubic directly and constructs the periods using AGM formulas.
- The lemniscatic case uses its closed-form period.
- Near the cusp and elliptic points, where the direct root formulas become singular or ill-conditioned, it retains the previous inverse-j/Eisenstein route as a fallback.
- The fallback Eisenstein calculation uses Jacobi's theta identity to avoid one theta-constant evaluation.

The resulting basis is reduced and oriented according to the existing `omega1omega2from` convention.

## Timings

These are median wall-clock timings at 50 decimal digits using Python 3.13.4 on macOS arm64, with five timing repeats.

### Half-period conversion

| Input cases | Before (ms/call) | After (ms/call) | Speedup |
|---|---:|---:|---:|
| Mean of 10 generic real cases | 0.937 | 0.112 | 8.4x |
| Representative generic complex case | 0.918 | 0.550 | 1.7x |

### Relative cost of passing invariants

The following table reports time when passing `g2`, `g3` / time when passing precomputed `omega1`, `omega2`.

A value of `1.00x` would mean that passing `g2, g3` adds no measurable conversion overhead. For example, `2.38x` means that the call using `g2, g3` took 2.38 times as long as the corresponding call using precomputed periods. Lower values are therefore better.

Each column is the mean ratio across the same 10 generic real invariant pairs:

- **Before**: the ratio using the implementation on `master`.
- **After**: the ratio using this optimized implementation.

| Function | Before | After |
|---|---:|---:|
| `weierp` | 2.38x | 1.28x |
| `weierpprime` | 1.74x | 1.17x |
| `weiersigma` | 2.81x | 1.32x |
| `weierzeta` | 2.11x | 1.21x |

Precomputing `omega1, omega2` therefore remains worthwhile for repeated calculations, but using the direct `g2, g3` interface is substantially less expensive as a result of this PR.

## Validation against Wolfram Engine

The optimized `omega1omega2from(g2=..., g3=...)` was compared with Wolfram Engine's `WeierstrassHalfPeriods[{g2, g3}]` at 60 decimal digits.

The 245 deterministic cases comprised:

- 100 random real invariant pairs;
- 100 random complex invariant pairs;
- 5 fixed and special cases;
- 24 cases on both sides of the direct/Eisenstein fallback threshold;
- 16 cases approaching the discriminant-zero cusp from both sides.

| Result | Cases |
|---|---:|
| Same ordered and signed period pair | 244 |
| Equivalent period basis | 1 |
| Failures | 0 |
| Total | 245 |

The maximum relative error among the 244 direct matches was `1.754314e-35`.

The sole equivalent-basis result was the lemniscatic case `(g2, g3) = (1, 0)`. If Wolfram returns `(w1, w2)`, mpmath returns `(-w2, w1)`. This is a determinant-one change of basis representing the same period lattice, with `tau = i`. It is also present on master and does not constitute a change in expected output.

#### Comparison with Wolfram Engine Timings

The following timings use the same 10 real and 10 complex invariant pairs, with 50-digit approximate inputs:

| Case group | mpmath mean | Wolfram mean | Comparison |
|---|---:|---:|---:|
| Generic real invariants | 0.112 ms/call | 0.152 ms/call | mpmath is approximately 1.36x faster |
| Generic complex invariants | 0.562 ms/call | 0.229 ms/call | Wolfram is approximately 2.45x faster |

### Possible future work

The complex path constructs the periods using two complex AGM evaluations. These account for approximately 0.241 ms of the 0.571 ms measured for the complete complex conversion, or about 42% of its runtime.

The current [`mpc_agm` implementation](https://github.com/mpmath/mpmath/blob/master/mpmath/libmp/libhyper.py#L1010-L1037) already contains explicit TODO items to:

- check that convergence works as intended;
- optimize the implementation;
- select a nonarbitrary branch.

In particular, `mpc_agm` uses generic complex arithmetic and repeatedly computes complex absolute values when checking convergence. Profiling identified this as the largest individual cost in the complex invariant-to-period path.

Optimizing `mpc_agm` is therefore a promising direction for future work, although it would not account for the entire difference from Wolfram. The remaining cost includes complex cubic radicals, square roots, root construction, modular-basis reduction, and other Python-level multiprecision operations.

## Tests

The added tests cover:

- round trips from invariants to periods and back at several precisions;
- real and complex invariants in the different discriminant regions;
- reduction of the resulting period ratio to the fundamental domain;
- continuity across the threshold between the direct and fallback methods.

The focused elliptic test file passes:

```text
51 passed
```

## AI use declaration

OpenAI GPT-5, through Codex, was used to assist with investigating the performance bottlenecks, implementing the optimization, developing tests and benchmark scripts, running and interpreting the Wolfram Engine comparison. I designed the scope of the PR, suggested things to explore, reviewed all generated changes and results, and ran test suites.

## Reproducibility

Below is a minimal timing script to compare this branch and master. It shows comparable numbers to the tables reported above.

```
git switch master
python my_data/benchmark_omega1omega2from_pyperf.py -o /tmp/omega-master.json

git switch omega-period-optimize-pr
python my_data/benchmark_omega1omega2from_pyperf.py -o /tmp/omega-pr.json

python -m pyperf compare_to \
    /tmp/omega-master.json \
    /tmp/omega-pr.json \
    --table
```

```python
#!/usr/bin/env python3
"""Benchmark invariant-to-half-period conversion for real and complex cases."""

import subprocess
import time

import pyperf

import mpmath
from mpmath import mp, mpc, mpf, omega1omega2from


mp.dps = 50

REAL_CASES = [
    (mpf(60), mpf(140)),
    (mpf(12), mpf(1)),
    (mpf(12), mpf(-1)),
    (mpf(4), mpf(1)),
    (mpf(4), mpf(-1)),
    (mpf(1), mpf(1)),
    (mpf(1), mpf(-1)),
    (mpf(10), mpf(5)),
    (mpf(100), mpf(1)),
    (mpf(-4), mpf(1)),
]

COMPLEX_CASES = [
    (mpc(1, 2), mpc(3, -4)),
    (mpc(-2, 1), mpc('0.5', 3)),
    (mpc(5, -7), mpc(-3, -2)),
    (mpc(2, '0.25'), mpc(-1, '1.5')),
    (mpc(-6, -2), mpc(4, '0.75')),
    (mpc('0.125', 3), mpc('-2.5', '0.5')),
    (mpc(10, 1), mpc(1, -8)),
    (mpc(-1, '0.1'), mpc('-0.25', -2)),
    (mpc(3, -5), mpc(7, 2)),
    (mpc(-4, 6), mpc(-5, 3)),
]


def bench_cases(loops, cases):
    start = time.perf_counter()
    for _ in range(loops):
        for g2, g3 in cases:
            omega1omega2from(g2=g2, g3=g3)
    return time.perf_counter() - start


revision = subprocess.check_output(
    ['git', 'rev-parse', '--short', 'HEAD'], text=True).strip()
runner = pyperf.Runner(metadata={
    'mpmath_revision': revision,
    'mpmath_file': mpmath.__file__,
    'mpmath_dps': mp.dps,
})
runner.bench_time_func(
    'omega1omega2from: real mean', bench_cases, REAL_CASES,
    inner_loops=len(REAL_CASES))
runner.bench_time_func(
    'omega1omega2from: complex mean', bench_cases, COMPLEX_CASES,
    inner_loops=len(COMPLEX_CASES))
```