### PR TITLE
Cache last Weierstrass half-period conversion

### DIFF
--- a/docs/general.rst
+++ b/docs/general.rst
@@ -230,6 +230,10 @@ Performance and debugging
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. autofunction:: mpmath.memoize
 
+:func:`~mpmath.memoize_last`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autofunction:: mpmath.memoize_last
+
 :func:`~mpmath.maxcalls`
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 .. autofunction:: mpmath.maxcalls

--- a/mpmath/__init__.py
+++ b/mpmath/__init__.py
@@ -33,6 +33,7 @@ workdps = mp.workdps
 autoprec = mp.autoprec
 maxcalls = mp.maxcalls
 memoize = mp.memoize
+memoize_last = mp.memoize_last
 
 mag = mp.mag
 

--- a/mpmath/ctx_base.py
+++ b/mpmath/ctx_base.py
@@ -1,5 +1,6 @@
 import random
 from operator import gt, lt
+from typing import Any
 
 from . import libmp
 from .calculus.calculus import CalculusMethods
@@ -517,6 +518,53 @@ class StandardBaseContext(Context,
                     return +cvalue
             value = f(*args, **kwargs)
             f_cache[key] = (prec, value)
+            return value
+        f_cached.__name__ = f.__name__
+        f_cached.__doc__ = f.__doc__
+        return f_cached
+
+    def memoize_last(ctx, f):
+        """
+        Return a wrapped copy of *f* that caches only its most recently
+        computed value. Values are reused only if the cached precision is
+        equal to or higher than the working precision.
+
+        Unlike :meth:`memoize`, which retains a value for every distinct set
+        of arguments, this method replaces the cached value whenever the
+        arguments change. It is useful when repeated consecutive calls are
+        expected but an unbounded cache is undesirable::
+
+            >>> from mpmath import maxcalls, memoize_last, mp, sin
+            >>> mp.pretty = True
+            >>> f = memoize_last(maxcalls(sin, 2))
+            >>> f(2)
+            0.909297426825682
+            >>> f(2)
+            0.909297426825682
+            >>> f(3)
+            0.141120008059867
+            >>> f(2)
+            Traceback (most recent call last):
+              ...
+            NoConvergence: maxcalls: function evaluated 2 times
+        """
+        last: tuple[Any, int, Any] | None = None
+
+        def f_cached(*args, **kwargs):
+            nonlocal last
+            if kwargs:
+                key = args, tuple(kwargs.items())
+            else:
+                key = args
+            prec = ctx.prec
+            if last is not None:
+                ckey, cprec, cvalue = last
+                if key == ckey and cprec >= prec:
+                    if type(cvalue) is tuple:
+                        return tuple(+value for value in cvalue)
+                    return +cvalue
+            value = f(*args, **kwargs)
+            last = key, prec, value
             return value
         f_cached.__name__ = f.__name__
         f_cached.__doc__ = f.__doc__

--- a/mpmath/functions/elliptic.py
+++ b/mpmath/functions/elliptic.py
@@ -1838,9 +1838,8 @@ def g2g3from(ctx, q=None, m=None, k=None, tau=None, qbar=None,
                    j3**12))
     return +g2, +g3
 
-@defun
-def omega1omega2from(ctx, q=None, m=None, k=None, tau=None, qbar=None,
-                     g2=None, g3=None, omega1=None, omega2=None):
+def _omega1omega2from(ctx, q=None, m=None, k=None, tau=None, qbar=None,
+                      g2=None, g3=None, omega1=None, omega2=None):
     r"""
     Returns the Weierstrass half-periods `(\omega_1, \omega_2)`, given
     any of `q, m, k, \tau, \bar{q}`, both invariants `g_2, g_3`, or both
@@ -2026,6 +2025,24 @@ def omega1omega2from(ctx, q=None, m=None, k=None, tau=None, qbar=None,
     return +omega1, +omega2
 
 
+@defun
+def omega1omega2from(ctx, q=None, m=None, k=None, tau=None, qbar=None,
+                     g2=None, g3=None, omega1=None, omega2=None):
+    try:
+        cached = ctx._omega1omega2from_cached
+    except AttributeError:
+        def compute(q=None, m=None, k=None, tau=None, qbar=None,
+                    g2=None, g3=None, omega1=None, omega2=None):
+            return _omega1omega2from(
+                ctx, q, m, k, tau, qbar, g2, g3, omega1, omega2)
+        cached = ctx.memoize_last(compute)
+        ctx._omega1omega2from_cached = cached
+    return cached(q, m, k, tau, qbar, g2, g3, omega1, omega2)
+
+
+omega1omega2from.__doc__ = _omega1omega2from.__doc__
+
+
 # ============================================================================
 # Main Weierstrass Elliptic Functions
 # ============================================================================
@@ -2049,10 +2066,6 @@ def weierp(ctx, z, g2=None, g3=None, tau=None, omega1=None, omega2=None):
 
     The periods of `\wp` are `2\omega_1` and `2\omega_2`. Thus the
     `\tau` parameterization corresponds to periods `1` and `\tau`.
-
-    For repeated evaluation with the same invariants, it is faster to compute
-    the half-periods once with :func:`~mpmath.omega1omega2from` and pass
-    them using the ``omega1`` and ``omega2`` keywords.
 
     **Examples**
 

--- a/mpmath/tests/test_basic_ops.py
+++ b/mpmath/tests/test_basic_ops.py
@@ -346,6 +346,35 @@ def test_monitor():
     assert a[0] == ((3,), {})
     assert b[0] == 9
 
+
+def test_memoize_last():
+    ctx = mp.clone()
+    calls = []
+
+    def f(x):
+        calls.append(x)
+        return ctx.mpf(x) / 3
+
+    cached = ctx.memoize_last(f)
+    ctx.prec = 80
+    first = cached(2)
+    assert cached(2) == first
+    assert calls == [2]
+
+    third = cached(x=3)
+    assert cached(x=3) == third
+    cached(2)
+    assert calls == [2, 3, 2]
+
+    ctx.prec = 60
+    assert cached(2) == +first
+    assert calls == [2, 3, 2]
+
+    ctx.prec = 100
+    cached(2)
+    assert calls == [2, 3, 2, 2]
+
+
 def test_nint_distance():
     assert nint_distance(mpf(-3)) == (-3, -inf)
     assert nint_distance(mpc(-3)) == (-3, -inf)

--- a/mpmath/tests/test_elliptic.py
+++ b/mpmath/tests/test_elliptic.py
@@ -1202,6 +1202,39 @@ def test_weierstrass_conversions_with_weierp():
     assert mpc_ae(weierp(z, g2=g2, g3=g3),
                   weierp(z, omega1=omega1, omega2=omega2), eps=eps*1000)
 
+
+def test_omega1omega2from_last_value_cache(monkeypatch):
+    from mpmath.functions import elliptic
+
+    ctx = mp.clone()
+    calls = []
+    original = elliptic._omega1omega2from
+
+    def counted(*args, **kwargs):
+        calls.append(None)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(elliptic, "_omega1omega2from", counted)
+
+    first = ctx.omega1omega2from(g2=60, g3=140)
+    second = ctx.omega1omega2from(g2=60, g3=140)
+    assert first == second
+    assert len(calls) == 1
+
+    ctx.prec -= 10
+    ctx.omega1omega2from(g2=60, g3=140)
+    assert len(calls) == 1
+    ctx.prec += 10
+
+    ctx.omega1omega2from(g2=4, g3=1)
+    ctx.omega1omega2from(g2=60, g3=140)
+    assert len(calls) == 3
+
+    ctx.prec += 10
+    ctx.omega1omega2from(g2=60, g3=140)
+    assert len(calls) == 4
+
+
 def test_weierstrass_periodicity():
     mp.dps = 30
 


### PR DESCRIPTION
*Note*: There is an important optional refactor of this implementation as explained at the bottom of this description. That should be reviewed in unison with this PR as it may be preferred.

## Summary

This PR adds a precision-aware, single-entry cache for conversions from Weierstrass invariants `(g2, g3)` to half-periods `(omega1, omega2)`.

All Weierstrass functions internally require the half-periods. Previously, evaluating a function at several different `z` values with the same invariants repeated the relatively expensive invariant-to-period conversion on every call. This is a common workload when working with one elliptic curve or lattice.

The new `ctx.memoize_last` helper:

- Retains only the most recently computed value, so the cache cannot grow.
- Reuses a value only at the same or lower working precision.
- Rounds cached values to the current precision when reused.
- Replaces the entry immediately when the arguments change.
- Is attached per context, avoiding shared global state.

`omega1omega2from` uses this helper, so repeated calls using either the same invariants or the same explicit periods benefit automatically. 

As either input to `omega1omega2from` is effectively at parity for repeated `z` values over the same lattice, advising to prefer `omega1, omega2` is removed from documentation. An important side effect is that downstream packages such as `sympy` could build on the `mpmath` implementation using only `g2, g3` symbolically and not pay a computational penalty by not implementing `omega1, omega2` support.

## Alternatives considered

The existing `memoize` function was considered but not used for two reasons. The first was that it was not intended here that the cache should grow indefinitely, it is only intended to store the last result to avoid any memory related issues. It was kept to storing one single result to avoid documenting and implementing any complicated rules and procedure for managing ejection from the cache. Secondly, the stand-alone `memoize_last` implementation de-risks impacting performance on the existing usage of `memoize` which seems to be limited to zeta zeroes currently. It is conceivable this `memoize_last` could be reused elsewhere, thus it is managed centrally in `ctx_base.py`. It follows the logic of the existing `memoize` closely.

## Performance

Benchmarks used Python 3.13.4 on Apple Silicon at 50 decimal digits. Timings are medians of warmed runs.

The real averages cover nine generic real lattices. One unit-circle-boundary case was excluded because an existing theta-function modular-reduction boundary effect makes it unrepresentative; that behavior is present on `master` and is independent of this cache.

### Weierstrass function evaluation

Each call used the same `(g2, g3)` as the preceding call but a different `z`.

| Function | Real master | Real PR | Change | Complex master | Complex PR | Change |
|---|---:|---:|---:|---:|---:|---:|
| `weierp` | 627.11 µs | 494.66 µs | -21.1% | 1304.62 µs | 708.67 µs | -45.7% |
| `weierpprime` | 1066.16 µs | 934.89 µs | -12.3% | 1937.13 µs | 1330.75 µs | -31.3% |
| `weiersigma` | 527.76 µs | 392.25 µs | -25.7% | 1159.54 µs | 565.30 µs | -51.2% |
| `weierzeta` | 772.56 µs | 639.05 µs | -17.3% | 1502.47 µs | 901.12 µs | -40.0% |

On the PR branch, passing repeated `(g2, g3)` is effectively at parity with passing precomputed `(omega1, omega2)`.

### Cache behavior and miss overhead

| Cases | Operation | Master | PR | Change |
|---|---|---:|---:|---:|
| Real mean | Repeated `(g2, g3)` conversion | 114.98 µs | 1.72 µs | -98.5% |
| Real mean | Repeated `(omega1, omega2)` normalization | 6.42 µs | 1.72 µs | -73.2% |
| Real mean | Alternating-period cache misses | 6.24 µs | 6.81 µs | +9.1% |
| Complex mean | Repeated `(g2, g3)` conversion | 554.76 µs | 2.11 µs | -99.6% |
| Complex mean | Repeated `(omega1, omega2)` normalization | 10.16 µs | 2.10 µs | -79.3% |
| Complex mean | Alternating-period cache misses | 8.11 µs | 8.88 µs | +9.4% |

The miss overhead is approximately 0.6–0.8 µs in these measurements. In exchange, a repeated invariant conversion is reduced by roughly 98.5–99.6%.

### Repeated 100-point sweeps

These ranges cover two representative real and two representative complex lattices, with 100 different `z` values per sweep.

| Function | Real speedup | Complex speedup |
|---|---:|---:|
| `weierp` | 1.21–1.27x | 1.77–1.78x |
| `weierpprime` | 1.12–1.15x | 1.43–1.44x |
| `weiersigma` | 1.27–1.33x | 1.99–2.01x |
| `weierzeta` | 1.18–1.21x | 1.63–1.64x |

### Wolfram Engine cross-check

As an independent numerical check, `weierp` was compared with Wolfram Engine for four invariant pairs and eight `z` values per pair at 50 decimal digits.

| Invariants | mpmath PR | Wolfram Engine | mpmath / Wolfram |
|---|---:|---:|---:|
| `g2=60`, `g3=140` | 447.06 µs | 248.09 µs | 1.80x |
| `g2=4`, `g3=1` | 339.38 µs | 183.08 µs | 1.85x |
| `g2=1+2j`, `g3=3-4j` | 688.45 µs | 345.33 µs | 1.99x |
| `g2=-2+1j`, `g3=0.5+3j` | 588.82 µs | 349.01 µs | 1.69x |

Some general improvement to the `mpmath` implementation is perhaps still possible but it is competetive. All 32 values agreed to the requested precision. The largest scaled relative error was `6.05e-51`.

<details>
<summary>Minimal reproduction benchmark</summary>

Save this as `bench_weierstrass_cache.py` and run it from the repository root on `master` and on this branch. It uses one representative real lattice and one representative complex lattice. Exact timings will vary by machine, but the repeated-invariant improvement should be visible.

```python
import statistics
import timeit

from mpmath import (
    mp,
    omega1omega2from,
    weierp,
    weierpprime,
    weiersigma,
    weierzeta,
)

mp.dps = 50

CASES = [
    ("real", mp.mpf(60), mp.mpf(140)),
    ("complex", mp.mpc(1, 2), mp.mpc(3, -4)),
]

FUNCTIONS = [
    ("weierp", weierp),
    ("weierpprime", weierpprime),
    ("weiersigma", weiersigma),
    ("weierzeta", weierzeta),
]


def median_time(function, number):
    function()  # warm up
    samples = timeit.repeat(function, number=number, repeat=5)
    return statistics.median(samples) / number


def sample_points(omega1, omega2, count=100):
    golden = (mp.sqrt(5) - 1) / 2
    points = []
    for index in range(count):
        a = mp.mpf("0.1") + mp.mpf("0.8") * (index + mp.mpf("0.5")) / count
        b = mp.mpf("0.1") + mp.mpf("0.8") * mp.frac(
            (index + mp.mpf("0.5")) * golden
        )
        points.append(2 * (a * omega1 + b * omega2))
    return points


for case, g2, g3 in CASES:
    parameters = {"g2": g2, "g3": g3}
    omega1, omega2 = omega1omega2from(**parameters)
    points = sample_points(omega1, omega2)

    conversion = median_time(
        lambda: omega1omega2from(**parameters),
        number=100,
    )
    print(f"{case}: conversion = {conversion * 1e6:.2f} us/call")

    for name, function in FUNCTIONS:
        def sweep():
            for z in points:
                function(z, **parameters)

        elapsed = median_time(sweep, number=1)
        print(
            f"{case}: {name} = {elapsed * 1e3:.2f} ms/sweep "
            f"({elapsed / len(points) * 1e6:.2f} us/z)"
        )
```

</details>

## Tests

The targeted tests cover both the generic cache abstraction and its use by the Weierstrass conversion:

- Identical arguments produce a cache hit.
- A different argument evicts the previous entry.
- A cached higher-precision value can be reused at lower precision.
- Raising the working precision forces recomputation.
- Tuple-valued results are rounded correctly on reuse.
- `omega1omega2from` uses the per-context cache.

```text
103 passed
```

## AI use declaration

OpenAI Codex was used to assist with implementation, test development, benchmark design and execution, and drafting this PR description. I reviewed the code, tests, benchmark methodology, and reported results.

## Optional Refactor

I have also prepared an optional decorator-based implementation:
HeskethGD/mpmath#1.

That PR is based on this branch, so its diff contains only the decorator refactor. My preference is that version, but this PR can proceed unchanged if the central registration change in the subsequent PR is considered too broad.

The main reasoning for the decorator refactor version is the observation that using the `memoize_last` function as it is written in this PR is perhaps more verbose than it needs to be and thus reusing it in several places might be a bit awkward. In contrast, the decorator version is considerably simpler.