### PR TITLE
Cache Weierstrass half-period conversions with a bounded LRU cache

### DIFF
--- a/mpmath/functions/elliptic.py
+++ b/mpmath/functions/elliptic.py
@@ -68,7 +68,7 @@ applicable (:func:`~mpmath.qfrom`, :func:`~mpmath.mfrom`,
 
 """
 
-from .functions import defun, defun_wrapped
+from .functions import defun, defun_lru_cache, defun_wrapped
 
 @defun_wrapped
 def eta(ctx, tau):
@@ -1838,7 +1838,7 @@ def g2g3from(ctx, q=None, m=None, k=None, tau=None, qbar=None,
                    j3**12))
     return +g2, +g3
 
-@defun
+@defun_lru_cache(maxsize=16)
 def omega1omega2from(ctx, q=None, m=None, k=None, tau=None, qbar=None,
                      g2=None, g3=None, omega1=None, omega2=None):
     r"""
@@ -2049,10 +2049,6 @@ def weierp(ctx, z, g2=None, g3=None, tau=None, omega1=None, omega2=None):
 
     The periods of `\wp` are `2\omega_1` and `2\omega_2`. Thus the
     `\tau` parameterization corresponds to periods `1` and `\tau`.
-
-    For repeated evaluation with the same invariants, it is faster to compute
-    the half-periods once with :func:`~mpmath.omega1omega2from` and pass
-    them using the ``omega1`` and ``omega2`` keywords.
 
     **Examples**
 

--- a/mpmath/functions/functions.py
+++ b/mpmath/functions/functions.py
@@ -1,3 +1,28 @@
+from functools import lru_cache, wraps
+from inspect import signature
+from typing import Any, cast
+
+
+def _ctx_lru_cache(ctx, f, maxsize):
+    """Cache *f* by its arguments and the context's current precision."""
+    @lru_cache(maxsize=maxsize)
+    def cached(_prec, /, *args, **kwargs):
+        # lru_cache includes _prec in its key, preventing a value computed at
+        # one precision from being reused at another. The calculation itself
+        # reads the same precision from ctx, so it need not otherwise use it.
+        _ = _prec
+        return f(*args, **kwargs)
+
+    @wraps(f)
+    def f_cached(*args, **kwargs):
+        return cached(ctx.prec, *args, **kwargs)
+
+    # This wrapper is stored directly on a context instance, so wraps alone
+    # would expose the unbound function's leading ctx parameter.
+    cast(Any, f_cached).__signature__ = signature(f)
+    return f_cached
+
+
 class SpecialFunctions:
     """
     This class implements special functions using high-level code.
@@ -7,12 +32,17 @@ class SpecialFunctions:
     "builtins" or "low-level" functions.
     """
     defined_functions = {}
+    lru_cache_functions = {}
 
     def __init__(self):
         cls = self.__class__
         for name in cls.defined_functions:
             f, wrap = cls.defined_functions[name]
             cls._wrap_specfun(name, f, wrap)
+            if name in cls.lru_cache_functions:
+                maxsize = cls.lru_cache_functions[name]
+                setattr(self, name, _ctx_lru_cache(
+                    self, getattr(self, name), maxsize))
 
         self._misc_const_cache = {}
 
@@ -60,6 +90,14 @@ def defun_wrapped(f):
 def defun(f):
     SpecialFunctions.defined_functions[f.__name__] = f, False
     return f
+
+def defun_lru_cache(maxsize):
+    """Register a function with a per-context LRU cache."""
+    def decorator(f):
+        SpecialFunctions.defined_functions[f.__name__] = f, False
+        SpecialFunctions.lru_cache_functions[f.__name__] = maxsize
+        return f
+    return decorator
 
 def defun_static(f):
     setattr(SpecialFunctions, f.__name__, f)

--- a/mpmath/tests/test_elliptic.py
+++ b/mpmath/tests/test_elliptic.py
@@ -11,7 +11,9 @@ Author of the first version: M.T. Taschuk
 
 """
 
+import inspect
 import random
+from typing import Any
 
 import pytest
 
@@ -1201,6 +1203,58 @@ def test_weierstrass_conversions_with_weierp():
     omega1, omega2 = omega1omega2from(g2=g2, g3=g3)
     assert mpc_ae(weierp(z, g2=g2, g3=g3),
                   weierp(z, omega1=omega1, omega2=omega2), eps=eps*1000)
+
+
+def test_omega1omega2from_lru_cache(monkeypatch):
+    from mpmath.functions import elliptic
+
+    ctx: Any = mp.clone()
+    cached = ctx.omega1omega2from
+    expected_signature = inspect.signature(
+        elliptic.omega1omega2from.__get__(ctx, type(ctx)))
+    assert inspect.signature(cached) == expected_signature
+    calls = []
+    original = elliptic._validate_weierstrass_parameter_args
+
+    def counted(*args, **kwargs):
+        calls.append(None)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        elliptic, "_validate_weierstrass_parameter_args", counted)
+
+    first = cached(g2=60, g3=140)
+    second = cached(g2=60, g3=140)
+    assert first == second
+    assert len(calls) == 1
+
+    ctx.prec -= 10
+    cached(g2=60, g3=140)
+    assert len(calls) == 2
+    ctx.prec += 10
+    cached(g2=60, g3=140)
+    assert len(calls) == 2
+
+    cached(g2=4, g3=1)
+    cached(g2=60, g3=140)
+    assert len(calls) == 3
+
+    other_ctx: Any = mp.clone()
+    other_ctx.omega1omega2from(g2=60, g3=140)
+    assert len(calls) == 4
+
+    capacity_ctx: Any = mp.clone()
+    capacity_cached = capacity_ctx.omega1omega2from
+    taus = [mpc(k, 1) for k in range(17)]
+    before = len(calls)
+    for tau in taus[:16]:
+        capacity_cached(tau=tau)
+    capacity_cached(tau=taus[0])
+    capacity_cached(tau=taus[16])
+    capacity_cached(tau=taus[0])
+    capacity_cached(tau=taus[1])
+    assert len(calls) - before == 18
+
 
 def test_weierstrass_periodicity():
     mp.dps = 30

--- a/mpmath/tests/test_functions.py
+++ b/mpmath/tests/test_functions.py
@@ -1,4 +1,5 @@
 import cmath
+import inspect
 import math
 import random
 
@@ -15,6 +16,7 @@ from mpmath import (acos, acosh, acot, acoth, acsc, acsch, arange, arg, asec,
                     nthroot, phi, pi, power, powm1, radians, rand, re, root,
                     sec, sech, sign, sin, sinc, sincpi, sinh, sinpi, sqrt, tan,
                     tanh, twinprime, unitroots)
+from mpmath.functions.functions import _ctx_lru_cache
 from mpmath.libmp import (MPZ, ComplexResult, from_int, mpf_gt, mpf_lt,
                           mpf_mul, mpf_pow_int, mpf_sqrt, round_ceiling,
                           round_down, round_nearest, round_up)
@@ -26,6 +28,41 @@ def mpc_ae(a, b, eps=eps):
     res = res and a.real.ae(b.real, eps)
     res = res and a.imag.ae(b.imag, eps)
     return res
+
+
+def test_ctx_lru_cache():
+    ctx = mp.clone()
+    ctx.prec = 80
+    calls = []
+
+    def f(x):
+        calls.append(x)
+        return ctx.mpf(x) / 3
+
+    cached = _ctx_lru_cache(ctx, f, maxsize=2)
+    assert inspect.signature(cached) == inspect.signature(f)
+
+    first = cached(1)
+    assert cached(1) == first
+    cached(2)
+    cached(1)
+    cached(3)
+    cached(1)
+    cached(2)
+    assert calls == [1, 2, 3, 2]
+
+    ctx.prec = 60
+    cached(2)
+    cached(2)
+    assert calls == [1, 2, 3, 2, 2]
+
+    ctx.prec = 80
+    cached(2)
+    assert calls == [1, 2, 3, 2, 2]
+
+    ctx.prec = 100
+    cached(2)
+    assert calls == [1, 2, 3, 2, 2, 2]
 
 #----------------------------------------------------------------------------
 # Constants and functions


### PR DESCRIPTION
## Summary

This PR adds a bounded, precision-aware LRU cache to `omega1omega2from`.

The Weierstrass functions internally convert their lattice parameters to half-periods. When several function values are evaluated using the same invariants `(g2, g3)`, that relatively expensive conversion was previously repeated for every value of `z`.

The new `defun_lru_cache` decorator:

- Creates a separate cache for each mpmath context.
- Includes the context precision in the cache key, preventing results calculated at one precision from being reused at another.
- Retains the 16 most recently used argument combinations.
- Preserves the wrapped function's public signature.
- Uses `functools.lru_cache` for established and predictable eviction behaviour.

`omega1omega2from` now uses this decorator. Consequently, `weierp`, `weierpprime`, `weiersigma`, and `weierzeta` benefit automatically when a process works repeatedly with a small collection of lattices.

The existing documentation recommendation to precompute and pass `(omega1, omega2)` for repeated evaluations is removed because repeated `(g2, g3)` evaluation is now effectively at parity with the explicit-period path.

## Performance

The benchmark compared this branch with `master` using Python 3.13.4 on Apple Silicon at 50 decimal digits. Results are medians from warmed runs over nine generic real and ten complex lattices.

### Conversion and cache overhead

| Cases | Operation | Master | PR | Change |
|---|---|---:|---:|---:|
| Real | Repeated `(g2, g3)` | 111.29 µs | 0.70 µs | -99.4% |
| Real | Repeated `(omega1, omega2)` | 6.25 µs | 1.50 µs | -76.1% |
| Real | Cycling 17 period pairs | 6.27 µs | 8.18 µs | +30.4% |
| Complex | Repeated `(g2, g3)` | 540.51 µs | 1.38 µs | -99.7% |
| Complex | Repeated `(omega1, omega2)` | 9.89 µs | 2.05 µs | -79.3% |
| Complex | Cycling 17 period pairs | 6.29 µs | 8.20 µs | +30.5% |

Cycling 17 distinct period pairs exceeds the 16-entry capacity, deliberately producing cache misses. The measured miss cost is approximately 1.9 µs per call. This is small compared with the invariant-to-period conversion avoided by a hit.

### Cache trade-off

A forced LRU miss increased the inexpensive explicit-period path from about 6.3 µs to 8.2 µs. Although this is a 30% increase, the absolute overhead is only around 1.9 µs. It is much less significant for invariant conversions, which take roughly 111–541 µs without caching, and one subsequent hit recovers more than the miss overhead.

The LRU also produced faster hits than the earlier `memoize_last` prototype. Real invariant lookups fell from 1.72 to 0.70 µs and complex lookups from 2.11 to 1.38 µs. This is likely because `functools.lru_cache` performs most lookup work in optimized C, while `memoize_last` handled key comparison and precision logic in Python.

The trade-off is therefore a small miss penalty and up to 16 cached entries per context, in exchange for faster hits and support for several interleaved lattices.

### Why not use `lru_cache` directly?

`omega1omega2from` is registered dynamically on each mpmath context, and its results depend on that context’s current precision. The wrapper creates a separate cache for each context, adds the precision to the cache key, and preserves the function’s public signature. Applying `lru_cache` directly would not provide those behaviours.

### Weierstrass function evaluation

Each call uses the same `(g2, g3)` but a different `z`.

| Function | Real master | Real PR | Change | Complex master | Complex PR | Change |
|---|---:|---:|---:|---:|---:|---:|
| `weierp` | 604.67 µs | 478.09 µs | -20.9% | 1274.84 µs | 693.66 µs | -45.6% |
| `weierpprime` | 1031.76 µs | 906.37 µs | -12.2% | 1889.47 µs | 1304.79 µs | -30.9% |
| `weiersigma` | 505.59 µs | 378.81 µs | -25.1% | 1129.66 µs | 551.15 µs | -51.2% |
| `weierzeta` | 745.48 µs | 619.43 µs | -16.9% | 1467.76 µs | 878.53 µs | -40.1% |

On the PR branch, repeated `(g2, g3)` evaluations were effectively at parity with evaluations using precomputed `(omega1, omega2)`.

### Repeated 100-point sweeps

The ranges below cover two representative real and two representative complex lattices, each evaluated at 100 different values of `z`.

| Function | Real speedup | Complex speedup |
|---|---:|---:|
| `weierp` | 1.22–1.26x | 1.76–1.79x |
| `weierpprime` | 1.13–1.14x | 1.41–1.44x |
| `weiersigma` | 1.28–1.33x | 2.01–2.02x |
| `weierzeta` | 1.18–1.20x | 1.61–1.62x |

One real case, `g2=-4` and `g3=1`, was reported separately and excluded from the generic-real averages. Its period ratio lies on the modular boundary `abs(tau)=1`, where an existing theta modular-reduction boundary effect can dominate the timing. This behaviour is present on `master` and is independent of the cache.

<details>
<summary>Minimal reproduction benchmark</summary>

Save the following as `bench_weierstrass_lru.py` in the repository root and run it once on `master` and once on this branch:

```python
import statistics
import timeit

from mpmath import (
    mp,
    omega1omega2from,
    weierp,
    weierpprime,
    weiersigma,
    weierzeta,
)

mp.dps = 50

CASES = [
    ("real", mp.mpf(60), mp.mpf(140)),
    ("complex", mp.mpc(1, 2), mp.mpc(3, -4)),
]
FUNCTIONS = [weierp, weierpprime, weiersigma, weierzeta]
LRU_SIZE = 16


def median_time(callable_, number):
    callable_()  # Warm the path before timing.
    samples = timeit.repeat(callable_, number=number, repeat=5)
    return statistics.median(samples) / number


def sample_points(omega1, omega2, count=100):
    golden = (mp.sqrt(5) - 1) / 2
    return [
        2 * (
            (
                mp.mpf("0.1")
                + mp.mpf("0.8") * (k + mp.mpf("0.5")) / count
            ) * omega1
            + (
                mp.mpf("0.1")
                + mp.mpf("0.8")
                * mp.frac((k + mp.mpf("0.5")) * golden)
            ) * omega2
        )
        for k in range(count)
    ]


for label, g2, g3 in CASES:
    invariants = {"g2": g2, "g3": g3}
    omega1, omega2 = omega1omega2from(**invariants)
    periods = {"omega1": omega1, "omega2": omega2}
    points = sample_points(omega1, omega2)

    invariant_time = median_time(
        lambda: omega1omega2from(**invariants), 100
    )
    period_time = median_time(
        lambda: omega1omega2from(**periods), 100
    )
    print(
        f"{label}: conversion g2/g3={invariant_time * 1e6:.2f} us, "
        f"omega1/omega2={period_time * 1e6:.2f} us"
    )

    # Seventeen entries exceed the PR's 16-entry cache, measuring misses.
    churn_periods = [
        {
            "omega1": mp.mpf("0.75") + mp.mpf(k) / 100,
            "omega2": (mp.mpf("0.75") + mp.mpf(k) / 100)
            * mp.mpc("0.1", "1.1"),
        }
        for k in range(LRU_SIZE + 1)
    ]

    def churning_conversions():
        for churn_period in churn_periods:
            omega1omega2from(**churn_period)

    churn_time = (
        median_time(churning_conversions, 10) / len(churn_periods)
    )
    print(
        f"{label}: cycling 17 periods="
        f"{churn_time * 1e6:.2f} us/call"
    )

    for function in FUNCTIONS:
        def invariant_sweep():
            for z in points:
                function(z, **invariants)

        def period_sweep():
            for z in points:
                function(z, **periods)

        # Check that the two parameterizations agree before timing them.
        for z in points:
            assert mp.almosteq(
                function(z, **invariants),
                function(z, **periods),
                rel_eps=100 * mp.eps,
                abs_eps=100 * mp.eps,
            )

        invariant_sweep_time = median_time(invariant_sweep, 1)
        period_sweep_time = median_time(period_sweep, 1)
        print(
            f"  {function.__name__}: "
            f"g2/g3={invariant_sweep_time * 1e3:.2f} ms, "
            f"omega1/omega2={period_sweep_time * 1e3:.2f} ms"
        )
```

The script was run successfully against the implementation in this PR. Exact timings will vary by machine.

</details>

## Tests

Tests cover:

- Cache hits for identical arguments.
- LRU retention and eviction.
- The exact 16-entry capacity.
- Precision as part of the cache key.
- Reuse when returning to an earlier precision while its entry remains cached.
- Separation between mpmath contexts.
- Preservation of the wrapped function signature.
- Integration with `omega1omega2from`.

The targeted function and elliptic tests pass:

```text
110 passed
```

## AI use declaration

OpenAI Codex was used to assist with implementation, test development, benchmark design and execution, and drafting this PR description. I reviewed the code, tests, benchmark methodology, and reported results.