### PR TITLE
Optimize weierpprime using theta duplication

### DIFF
--- a/mpmath/functions/elliptic.py
+++ b/mpmath/functions/elliptic.py
@@ -2066,12 +2066,8 @@ def _weierpprime_data(ctx, omega1, omega2):
     """Return the lattice-dependent data used by ``weierpprime``."""
     q = ctx.qfrom(tau=omega2 / omega1)
     j10p = ctx.jtheta(1, 0, q, 1)
-    j20 = ctx.jtheta(2, 0, q)
-    j30 = ctx.jtheta(3, 0, q)
-    j40 = ctx.jtheta(4, 0, q)
-    k0 = j10p**3 / (j20 * j30 * j40)
     z_scale = ctx.pi / (2 * omega1)
-    coefficient = -ctx.pi**3 * k0 / (4 * omega1**3)
+    coefficient = -(ctx.pi * j10p / (2 * omega1))**3
     return q, z_scale, coefficient
 
 @defun
@@ -2192,11 +2188,8 @@ def weierpprime(ctx, z, g2=None, g3=None, tau=None,
     q, z_scale, coefficient = ctx._weierpprime_data(omega1, omega2)
     z1 = z * z_scale
     j1z1 = ctx.jtheta(1, z1, q)
-    j2z1 = ctx.jtheta(2, z1, q)
-    j3z1 = ctx.jtheta(3, z1, q)
-    j4z1 = ctx.jtheta(4, z1, q)
-    kz = j2z1 * j3z1 * j4z1 / j1z1**3
-    return coefficient * kz
+    j1z2 = ctx.jtheta(1, 2 * z1, q)
+    return coefficient * j1z2 / j1z1**4
 
 @defun_wrapped
 def weiersigma(ctx, z, g2=None, g3=None, tau=None,

--- a/mpmath/tests/test_elliptic.py
+++ b/mpmath/tests/test_elliptic.py
@@ -844,6 +844,20 @@ def test_weierstrass_g2g3_differential_equation():
         pp = weierpprime(z, g2=g2, g3=g3)
         assert mpc_ae(pp**2, 4*p**3 - g2*p - g3, eps=eps*1000)
 
+def test_weierstrass_pprime_sigma_duplication():
+    # https://dlmf.nist.gov/23.10#E10
+    mp.dps = 30
+
+    cases = [
+        (mpf('0.3'), mpf(60), mpf(140)),
+        (mpf('0.2') + j/10, mpc(1, 2), mpc(3, -4)),
+    ]
+    for z, g2, g3 in cases:
+        expected = -weiersigma(2*z, g2=g2, g3=g3)
+        expected /= weiersigma(z, g2=g2, g3=g3)**4
+        assert mpc_ae(weierpprime(z, g2=g2, g3=g3), expected,
+                      eps=eps*1000)
+
 def test_weierstrass_parameter_conversions():
     mp.dps = 30
 
@@ -1185,11 +1199,18 @@ def test_weierstrass_half_period_values_are_cubic_roots():
         weierp(omega2, omega1=omega1, omega2=omega2),
         weierp(omega1 + omega2, omega1=omega1, omega2=omega2),
     ]
+    half_period_derivatives = [
+        weierpprime(omega1, omega1=omega1, omega2=omega2),
+        weierpprime(omega2, omega1=omega1, omega2=omega2),
+        weierpprime(omega1 + omega2, omega1=omega1, omega2=omega2),
+    ]
 
     for value in half_period_values:
         assert mpc_ae(4*value**3 - g2*value - g3, 0,
                       eps=eps*1000)
         assert min(abs(value - root) for root in roots) < eps*1000
+    for value in half_period_derivatives:
+        assert mpc_ae(value, 0, eps=eps*1000)
     for root in roots:
         assert min(abs(value - root) for value in half_period_values) < eps*1000
 


### PR DESCRIPTION
## Summary

Optimize `weierpprime` using an equivalent theta duplication identity that reduces the number of z-dependent theta function calls from four to two.

The `weierpprime` tests are also enhanced beyond the minimum required for coverage by validating the equivalent identity involving `weiersigma` and checking that the half-periods are zeros of `weierpprime`.

## Theory

The formula https://dlmf.nist.gov/20.7#E10 shows the equivalence between the old theta formula and the new method. The new approach relates to $\wp'$  via https://dlmf.nist.gov/23.10#E10 and https://dlmf.nist.gov/23.10#E10. 

## Performance

This table compares `master` at `08041f8d` with `optimize-weierpprime` at `cf3c47af`. The optimized implementation uses the sigma duplication identity to reduce each `weierpprime` evaluation from four z-dependent theta functions to `theta1(v)` and `theta1(2*v)`.

Each benchmark evaluates 100 varying arguments with fixed `g2` and `g3` at 50 decimal digits. Times are reported per `weierpprime` call.

| Case | `g2` | `g3` | master | optimize-weierpprime | Improvement |
|---|---:|---:|---:|---:|---:|
| real-01 | `60` | `140` | 627.24 us | 387.13 us | 1.62x faster |
| real-02 | `4` | `1` | 591.66 us | 357.34 us | 1.66x faster |
| real-03 | `-4` | `1` | 1631.30 us | 907.85 us | 1.80x faster |
| complex-01 | `1+2j` | `3-4j` | 790.82 us | 476.25 us | 1.66x faster |
| complex-02 | `-2+1j` | `0.5+3j` | 786.94 us | 473.58 us | 1.66x faster |
| complex-03 | `5-7j` | `-3-2j` | 772.49 us | 463.33 us | 1.67x faster |
| Geometric mean | — | — | (ref) | — | **1.68x faster** |

<details>
<summary>Minimal reproduction benchmark</summary>

Save the following as `benchmark_weierpprime_duplication_pyperf.py` in the repository root and run it once on `master` and once on this branch:

```python
#!/usr/bin/env python3
"""Benchmark repeated weierpprime evaluations with fixed invariants."""

import subprocess
import time

import pyperf

import mpmath
from mpmath import mp, omega1omega2from, weierpprime


mp.dps = 50
POINT_COUNT = 100
GOLDEN_RATIO_CONJUGATE = (mp.sqrt(5) - 1) / 2

CASES = (
    ("real-01", mp.mpf(60), mp.mpf(140)),
    ("real-02", mp.mpf(4), mp.mpf(1)),
    ("real-03", mp.mpf(-4), mp.mpf(1)),
    ("complex-01", mp.mpc(1, 2), mp.mpc(3, -4)),
    ("complex-02", mp.mpc(-2, 1), mp.mpc("0.5", 3)),
    ("complex-03", mp.mpc(5, -7), mp.mpc(-3, -2)),
)


def lattice_points(g2, g3):
    omega1, omega2 = omega1omega2from(g2=g2, g3=g3)
    points = []
    for index in range(POINT_COUNT):
        a = mp.mpf("0.1") + mp.mpf("0.8") * (
            index + mp.mpf("0.5")
        ) / POINT_COUNT
        b = mp.mpf("0.1") + mp.mpf("0.8") * mp.frac(
            (index + mp.mpf("0.5")) * GOLDEN_RATIO_CONJUGATE
        )
        points.append(2 * (a * omega1 + b * omega2))
    return points


def bench_weierpprime(loops, points, g2, g3):
    start = time.perf_counter()
    for _ in range(loops):
        for z in points:
            weierpprime(z, g2=g2, g3=g3)
    return time.perf_counter() - start


revision = subprocess.check_output(
    ["git", "rev-parse", "--short", "HEAD"], text=True
).strip()
runner = pyperf.Runner(metadata={
    "mpmath_revision": revision,
    "mpmath_file": mpmath.__file__,
    "mpmath_dps": mp.dps,
    "points_per_parameter": POINT_COUNT,
})

for case_name, g2, g3 in CASES:
    runner.bench_time_func(
        "weierpprime: %s" % case_name,
        bench_weierpprime,
        lattice_points(g2, g3),
        g2,
        g3,
        inner_loops=POINT_COUNT,
    )
```

To run it:
```
git switch master
python benchmark_weierpprime_duplication_pyperf.py -o master.json

git switch optimize-weierpprime
python benchmark_weierpprime_duplication_pyperf.py -o optimized.json

python -m pyperf compare_to master.json optimized.json \
    --table --table-format md
```

The script was run successfully against the implementation in this PR. Exact timings will vary by machine.

</details>

## AI use declaration

OpenAI Codex was used to assist with implementation, benchmark design and execution. I identified the need and the opportunity, designed the experiment, reviewed the code and benchmark methodology, and reported results.