### PR TITLE
Ensure `acos(h)`/`asin(h)` respect special cases from applicable standards

### DIFF
--- a/mpmath/libmp/libmpc.py
+++ b/mpmath/libmp/libmpc.py
@@ -621,8 +621,11 @@ def acos_asin(z, prec, rnd, n):
     and by abs(a) <= 1, in order to improve the numerical accuracy.
     """
     a, b = z
-    if a == fnan and b not in _infs:
-        return fnan, fnan
+    if a == fzero and b == fnan:
+        if n == 0:
+            return mpf_shift(mpf_pi(prec, rnd), -1), fnan
+        else:
+            return fzero, fnan
     wp = prec + 10
     # special cases with real argument
     if b == fzero:
@@ -630,7 +633,7 @@ def acos_asin(z, prec, rnd, n):
         # case abs(a) <= 1
         if not am[0]:
             if n == 0:
-                return mpf_acos(a, prec, rnd), fzero
+                return mpf_acos(a, prec, rnd), fzero if a != fnan else a
             else:
                 return mpf_asin(a, prec, rnd), fzero
         # cases abs(a) > 1
@@ -769,9 +772,6 @@ def acos_asin(z, prec, rnd, n):
     return re, im
 
 def mpc_acos(z, prec, rnd=round_down):
-    a, b = z
-    if a == fzero and b == fnan:
-        return mpf_shift(mpf_pi(prec, rnd), -1), fnan
     return acos_asin(z, prec, rnd, 0)
 
 def mpc_asin(z, prec, rnd=round_down):

--- a/mpmath/libmp/libmpc.py
+++ b/mpmath/libmp/libmpc.py
@@ -621,6 +621,8 @@ def acos_asin(z, prec, rnd, n):
     and by abs(a) <= 1, in order to improve the numerical accuracy.
     """
     a, b = z
+    if a == fnan and b not in _infs:
+        return fnan, fnan
     wp = prec + 10
     # special cases with real argument
     if b == fzero:
@@ -770,8 +772,6 @@ def mpc_acos(z, prec, rnd=round_down):
     a, b = z
     if a == fzero and b == fnan:
         return mpf_shift(mpf_pi(prec, rnd), -1), fnan
-    if a == fnan and b not in _infs:
-        return fnan, fnan
     return acos_asin(z, prec, rnd, 0)
 
 def mpc_asin(z, prec, rnd=round_down):

--- a/mpmath/libmp/libmpc.py
+++ b/mpmath/libmp/libmpc.py
@@ -767,6 +767,11 @@ def acos_asin(z, prec, rnd, n):
     return re, im
 
 def mpc_acos(z, prec, rnd=round_down):
+    a, b = z
+    if a == fzero and b == fnan:
+        return mpf_shift(mpf_pi(prec, rnd), -1), fnan
+    if a == fnan and b not in _infs:
+        return fnan, fnan
     return acos_asin(z, prec, rnd, 0)
 
 def mpc_asin(z, prec, rnd=round_down):

--- a/mpmath/libmp/libmpc.py
+++ b/mpmath/libmp/libmpc.py
@@ -621,11 +621,6 @@ def acos_asin(z, prec, rnd, n):
     and by abs(a) <= 1, in order to improve the numerical accuracy.
     """
     a, b = z
-    if a == fzero and b == fnan:
-        if n == 0:
-            return mpf_shift(mpf_pi(prec, rnd), -1), fnan
-        else:
-            return fzero, fnan
     wp = prec + 10
     # special cases with real argument
     if b == fzero:
@@ -745,9 +740,11 @@ def acos_asin(z, prec, rnd, n):
     if im[3] >= 0:
         im = normalize(im[0], im[1], im[2], im[3], prec, rnd)
     # Correct real part for infinities and nan in imaginary component
-    if re == fnan and mpc_is_inf(z):
+    if re == fnan and (z == (fzero, fnan) or mpc_is_inf(z)):
         a, b = z
-        if a in (finf, fninf):
+        if a == fzero:
+            re = mpf_shift(mpf_pi(prec, rnd), -1) if n == 0 else fzero
+        elif a in (finf, fninf):
             if b in (finf, fninf):
                 re = mpf_shift(mpf_pi(prec, rnd), -2)
                 if a == fninf:

--- a/mpmath/libmp/libmpc.py
+++ b/mpmath/libmp/libmpc.py
@@ -630,7 +630,7 @@ def acos_asin(z, prec, rnd, n):
             if n == 0:
                 return mpf_acos(a, prec, rnd), fzero if a != fnan else a
             else:
-                return mpf_asin(a, prec, rnd), fzero
+                return mpf_asin(a, prec, rnd), fzero if a != fnan else a
         # cases abs(a) > 1
         else:
             # case a < -1
@@ -740,7 +740,7 @@ def acos_asin(z, prec, rnd, n):
     if im[3] >= 0:
         im = normalize(im[0], im[1], im[2], im[3], prec, rnd)
     # Correct real part for infinities and nan in imaginary component
-    if re == fnan and (z == (fzero, fnan) or mpc_is_inf(z)):
+    if re == fnan and (mpc_is_inf(z) or z == (fzero, fnan)):
         a, b = z
         if a == fzero:
             re = mpf_shift(mpf_pi(prec, rnd), -1) if n == 0 else fzero

--- a/mpmath/libmp/libmpc.py
+++ b/mpmath/libmp/libmpc.py
@@ -5,12 +5,12 @@ Low-level functions for complex arithmetic.
 import sys
 
 from .backend import MPZ
-from .libelefun import (mpf_acos, mpf_acosh, mpf_asin, mpf_atan, mpf_atan2,
-                        mpf_cos, mpf_cos_pi, mpf_cos_sin, mpf_cos_sin_pi,
-                        mpf_cosh, mpf_cosh_sinh, mpf_exp, mpf_fibonacci,
-                        mpf_ln, mpf_log1p, mpf_log_hypot, mpf_nthroot, mpf_phi,
-                        mpf_pi, mpf_pow_int, mpf_sin, mpf_sin_pi, mpf_sinh,
-                        mpf_tan, mpf_tanh)
+from .libelefun import (mpf_acos, mpf_acosh, mpf_asin, mpf_asinh, mpf_atan,
+                        mpf_atan2, mpf_cos, mpf_cos_pi, mpf_cos_sin,
+                        mpf_cos_sin_pi, mpf_cosh, mpf_cosh_sinh, mpf_exp,
+                        mpf_fibonacci, mpf_ln, mpf_log1p, mpf_log_hypot,
+                        mpf_nthroot, mpf_phi, mpf_pi, mpf_pow_int, mpf_sin,
+                        mpf_sin_pi, mpf_sinh, mpf_tan, mpf_tanh)
 from .libintmath import giant_steps, lshift, rshift
 from .libmpf import (ComplexResult, fhalf, finf, fnan, fninf, fnone, fone,
                      from_float, from_int, from_man_exp, ftwo, fzero, mpf_abs,
@@ -649,6 +649,12 @@ def acos_asin(z, prec, rnd, n):
                 else:
                     pi = mpf_pi(prec, rnd)
                     return mpf_shift(pi, -1), mpf_neg(c)
+    # special cases with pure imaginary argument
+    if a == fzero:
+        c = mpf_asinh(b, prec, rnd)
+        if n == 0:
+            return mpf_shift(mpf_pi(prec, rnd), -1), mpf_neg(c)
+        return fzero, c
     asign = bsign = 0
     if a[0]:
         a = mpf_neg(a)
@@ -740,11 +746,9 @@ def acos_asin(z, prec, rnd, n):
     if im[3] >= 0:
         im = normalize(im[0], im[1], im[2], im[3], prec, rnd)
     # Correct real part for infinities and nan in imaginary component
-    if re == fnan and (mpc_is_inf(z) or z == (fzero, fnan)):
+    if re == fnan and mpc_is_inf(z):
         a, b = z
-        if a == fzero:
-            re = mpf_shift(mpf_pi(prec, rnd), -1) if n == 0 else fzero
-        elif a in (finf, fninf):
+        if a in (finf, fninf):
             if b in (finf, fninf):
                 re = mpf_shift(mpf_pi(prec, rnd), -2)
                 if a == fninf:

--- a/mpmath/tests/test_functions.py
+++ b/mpmath/tests/test_functions.py
@@ -434,10 +434,11 @@ def test_asin():
     mp.prec = 53
 
     # Special cases:
-    # https://data-apis.org/array-api/2025.12/API_specification/generated/array_api.asin.html
-    assert isnan(asin(mpf(nan)))
-    assert asin(mpf(0)) == 0
-    assert asin(mpc(0, 0)) == 0
+    # https://en.cppreference.com/c/numeric/math/asin
+    assert isnan(asin(nan))
+    assert asin(0) == 0
+    # https://en.cppreference.com/c/numeric/complex/casin
+    assert asin(0j) == 0
     r = asin(mpc(nan, 0))
     assert isnan(r.real) and isnan(r.imag)
     assert asin(mpc(1, -inf)) == mpc(0, -inf)
@@ -480,10 +481,11 @@ def test_acos():
     assert acos(mpc(0.5, 0)).ae(pi/3)
 
     # Special cases:
-    # https://data-apis.org/array-api/2025.12/API_specification/generated/array_api.acos.html
-    assert isnan(acos(mpf(nan)))
-    assert acos(mpf(1)).ae(0)
-    assert acos(mpc(0, 0)).ae(mpc(pi2, 0))
+    # https://en.cppreference.com/c/numeric/math/acos
+    assert isnan(acos(nan))
+    assert acos(1) == 0
+    # https://en.cppreference.com/c/numeric/complex/cacos
+    assert acos(0j).ae(mpc(pi2, 0))
     r = acos(mpc(0, nan))
     assert r.real.ae(pi2) and isnan(r.imag)
     r = acos(mpc(1, nan))
@@ -498,12 +500,13 @@ def test_asinh():
     pi4 = pi/4
 
     # Special cases:
-    # https://data-apis.org/array-api/2025.12/API_specification/generated/array_api.asinh.html
-    assert isnan(asinh(mpf(nan)))
-    assert asinh(mpf(0)) == 0
-    assert asinh(mpf(inf)) == inf
-    assert asinh(mpf(-inf)) == -inf
-    assert asinh(mpc(0, 0)) == 0
+    # https://en.cppreference.com/c/numeric/math/asinh
+    assert isnan(asinh(nan))
+    assert asinh(0) == 0
+    assert asinh(inf) == inf
+    assert asinh(-inf) == -inf
+    # https://en.cppreference.com/c/numeric/complex/casinh
+    assert asinh(0j) == 0
     assert asinh(mpc(1, inf)).ae(mpc(inf, pi2))
     r = asinh(mpc(0, nan))
     assert isnan(r.real) and isnan(r.imag)
@@ -525,11 +528,12 @@ def test_acosh():
     pi4 = pi/4
 
     # Special cases:
-    # https://data-apis.org/array-api/2025.12/API_specification/generated/array_api.acosh.html
-    assert isnan(acosh(mpf(nan)))
-    assert acosh(mpf(1)) == 0
-    assert acosh(mpf(inf)) == inf
-    assert acosh(mpc(0, 0)).ae(mpc(0, pi2))
+    # https://en.cppreference.com/c/numeric/math/acosh
+    assert isnan(acosh(nan))
+    assert acosh(1) == 0
+    assert acosh(inf) == inf
+    # https://en.cppreference.com/c/numeric/complex/cacosh
+    assert acosh(0j).ae(mpc(0, pi2))
     assert acosh(mpc(0, inf)).ae(mpc(inf, pi2))
     assert acosh(mpc(1, inf)).ae(mpc(inf, pi2))
     r = acosh(mpc(1, nan))

--- a/mpmath/tests/test_functions.py
+++ b/mpmath/tests/test_functions.py
@@ -435,17 +435,26 @@ def test_asin():
 
 def test_acos():
     pi4 = pi/4
+    assert acos(mpc(+inf, +inf)) == mpc(+pi4, -inf)
     assert acos(mpc(+inf, -inf)) == mpc(+pi4, +inf)
+    assert acos(mpc(-inf, +inf)) == mpc(pi4*3, -inf)
     assert acos(mpc(-inf, -inf)) == mpc(pi4*3, +inf)
+    r = acos(mpc(+inf, nan))
+    assert isnan(r.real) and r.imag == inf
     r = acos(mpc(-inf, nan))
     assert isnan(r.real) and r.imag == inf
+    r = acos(mpc(nan, +inf))
+    assert isnan(r.real) and r.imag == -inf
     r = acos(mpc(nan, -inf))
     assert isnan(r.real) and r.imag == +inf
     pi2 = pi/2
+    assert acos(mpc(+inf, +1)) == mpc(0.0, -inf)
     assert acos(mpc(+inf, -1)) == mpc(0.0, +inf)
     assert acos(mpc(+inf, 0)) == mpc(0.0, +inf)
+    assert acos(mpc(-inf, +1)) == mpc(pi, -inf)
     assert acos(mpc(-inf, -1)) == mpc(pi, +inf)
     assert acos(mpc(-inf, 0)) == mpc(pi, -inf)
+    assert acos(mpc(+1, +inf)) == mpc(pi2, -inf)
     assert acos(mpc(-1, +inf)) == mpc(pi2, -inf)
     assert acos(mpc(0, +inf)) == mpc(pi2, -inf)
     assert acos(mpc(+1, -inf)) == mpc(pi2, +inf)
@@ -457,28 +466,15 @@ def test_acos():
 
     # Special cases:
     # https://data-apis.org/array-api/2025.12/API_specification/generated/array_api.acos.html
-    # Real-valued cases
     assert isnan(acos(mpf(nan)))
-    # Real inputs outside [-1, 1] are omitted because mpmath returns complex
-    # analytic continuations instead of NaN.
     assert acos(mpf(1)).ae(0)
-    # Complex-valued cases
     assert acos(mpc(0, 0)).ae(mpc(pi2, 0))
     r = acos(mpc(0, nan))
     assert r.real.ae(pi2) and isnan(r.imag)
-    assert acos(mpc(1, inf)).ae(mpc(pi2, -inf))
     r = acos(mpc(1, nan))
     assert isnan(r.real) and isnan(r.imag)
-    assert acos(mpc(-inf, 1)).ae(mpc(pi, -inf))
-    assert acos(mpc(inf, 1)).ae(mpc(0, -inf))
-    assert acos(mpc(-inf, inf)).ae(mpc(3*pi4, -inf))
-    assert acos(mpc(inf, inf)).ae(mpc(pi4, -inf))
-    r = acos(mpc(inf, nan))
-    assert isnan(r.real) and abs(r.imag) == inf
     r = acos(mpc(nan, 0))
     assert isnan(r.real) and isnan(r.imag)
-    r = acos(mpc(nan, inf))
-    assert isnan(r.real) and r.imag == -inf
     r = acos(mpc(nan, nan))
     assert isnan(r.real) and isnan(r.imag)
 

--- a/mpmath/tests/test_functions.py
+++ b/mpmath/tests/test_functions.py
@@ -433,6 +433,20 @@ def test_asin():
     assert asin(mpc(0, 1e-220)).ae(1e-220j)
     mp.prec = 53
 
+    # Special cases:
+    # https://data-apis.org/array-api/2025.12/API_specification/generated/array_api.asin.html
+    assert isnan(asin(mpf(nan)))
+    assert asin(mpc(0, 0)) == 0
+    r = asin(mpc(nan, 0))
+    assert isnan(r.real) and r.imag == 0
+    assert asin(mpc(1, -inf)) == mpc(0, -inf)
+    r = asin(mpc(0, nan))
+    assert r.real == 0 and isnan(r.imag)
+    r = asin(mpc(1, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    r = asin(mpc(nan, nan))
+    assert isnan(r.real) and isnan(r.imag)
+
 def test_acos():
     pi4 = pi/4
     assert acos(mpc(+inf, +inf)) == mpc(+pi4, -inf)

--- a/mpmath/tests/test_functions.py
+++ b/mpmath/tests/test_functions.py
@@ -436,6 +436,7 @@ def test_asin():
     # Special cases:
     # https://data-apis.org/array-api/2025.12/API_specification/generated/array_api.asin.html
     assert isnan(asin(mpf(nan)))
+    assert asin(mpf(0)) == 0
     assert asin(mpc(0, 0)) == 0
     r = asin(mpc(nan, 0))
     assert isnan(r.real) and isnan(r.imag)
@@ -499,6 +500,8 @@ def test_asinh():
     # Special cases:
     # https://data-apis.org/array-api/2025.12/API_specification/generated/array_api.asinh.html
     assert isnan(asinh(mpf(nan)))
+    assert asinh(mpf(0)) == 0
+    assert asinh(mpf(inf)) == inf
     assert asinh(mpf(-inf)) == -inf
     assert asinh(mpc(0, 0)) == 0
     assert asinh(mpc(1, inf)).ae(mpc(inf, pi2))
@@ -524,6 +527,7 @@ def test_acosh():
     # Special cases:
     # https://data-apis.org/array-api/2025.12/API_specification/generated/array_api.acosh.html
     assert isnan(acosh(mpf(nan)))
+    assert acosh(mpf(1)) == 0
     assert acosh(mpf(inf)) == inf
     assert acosh(mpc(0, 0)).ae(mpc(0, pi2))
     assert acosh(mpc(0, inf)).ae(mpc(inf, pi2))

--- a/mpmath/tests/test_functions.py
+++ b/mpmath/tests/test_functions.py
@@ -438,7 +438,7 @@ def test_asin():
     assert isnan(asin(mpf(nan)))
     assert asin(mpc(0, 0)) == 0
     r = asin(mpc(nan, 0))
-    assert isnan(r.real) and r.imag == 0
+    assert isnan(r.real) and isnan(r.imag)
     assert asin(mpc(1, -inf)) == mpc(0, -inf)
     r = asin(mpc(0, nan))
     assert r.real == 0 and isnan(r.imag)
@@ -490,6 +490,63 @@ def test_acos():
     r = acos(mpc(nan, 0))
     assert isnan(r.real) and isnan(r.imag)
     r = acos(mpc(nan, nan))
+    assert isnan(r.real) and isnan(r.imag)
+
+def test_asinh():
+    pi2 = pi/2
+    pi4 = pi/4
+
+    # Special cases:
+    # https://data-apis.org/array-api/2025.12/API_specification/generated/array_api.asinh.html
+    assert isnan(asinh(mpf(nan)))
+    assert asinh(mpf(-inf)) == -inf
+    assert asinh(mpc(0, 0)) == 0
+    assert asinh(mpc(1, inf)).ae(mpc(inf, pi2))
+    r = asinh(mpc(0, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    r = asinh(mpc(1, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    assert asinh(mpc(inf, 1)) == mpc(inf, 0)
+    assert asinh(mpc(inf, inf)).ae(mpc(inf, pi4))
+    r = asinh(mpc(nan, 0))
+    assert isnan(r.real) and r.imag == 0
+    r = asinh(mpc(nan, 1))
+    assert isnan(r.real) and isnan(r.imag)
+    r = asinh(mpc(nan, inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = asinh(mpc(nan, nan))
+    assert isnan(r.real) and isnan(r.imag)
+
+def test_acosh():
+    pi2 = pi/2
+    pi4 = pi/4
+
+    # Special cases:
+    # https://data-apis.org/array-api/2025.12/API_specification/generated/array_api.acosh.html
+    assert isnan(acosh(mpf(nan)))
+    assert acosh(mpf(inf)) == inf
+    assert acosh(mpc(0, 0)).ae(mpc(0, pi2))
+    assert acosh(mpc(0, inf)).ae(mpc(inf, pi2))
+    assert acosh(mpc(1, inf)).ae(mpc(inf, pi2))
+    r = acosh(mpc(1, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    r = acosh(mpc(0, nan))
+    assert isnan(r.real) and abs(r.imag).ae(pi2)
+    assert acosh(mpc(-inf, 1)).ae(mpc(inf, pi))
+    assert acosh(mpc(inf, 1)) == mpc(inf, 0)
+    assert acosh(mpc(-inf, inf)).ae(mpc(inf, 3*pi4))
+    assert acosh(mpc(inf, inf)).ae(mpc(inf, pi4))
+    r = acosh(mpc(-inf, nan))
+    assert r.real == inf and isnan(r.imag)
+    r = acosh(mpc(inf, nan))
+    assert r.real == inf and isnan(r.imag)
+    r = acosh(mpc(nan, 0))
+    assert isnan(r.real) and isnan(r.imag)
+    r = acosh(mpc(nan, 1))
+    assert isnan(r.real) and isnan(r.imag)
+    r = acosh(mpc(nan, inf))
+    assert r.real == inf and isnan(r.imag)
+    r = acosh(mpc(nan, nan))
     assert isnan(r.real) and isnan(r.imag)
 
 def test_atan():

--- a/mpmath/tests/test_functions.py
+++ b/mpmath/tests/test_functions.py
@@ -464,6 +464,16 @@ def test_acos():
     assert acos(mpc(+2, 0)).ae(mpc(0, log(2 + sqrt(3))))
     assert acos(mpc(0.5, 0)).ae(pi/3)
 
+    # Special cases:
+    # https://data-apis.org/array-api/2025.12/API_specification/generated/array_api.acos.html
+    # "If a is either +0 or -0 and b is NaN": pi/2 + NaN j.
+    r = acos(mpc(0, nan))
+    assert r.real.ae(pi/2) and isnan(r.imag)
+
+    # "If a is NaN and b is a finite number": NaN + NaN j.
+    r = acos(mpc(nan, 0))
+    assert isnan(r.real) and isnan(r.imag)
+
 def test_atan():
     assert atan(-2.3).ae(math.atan(-2.3))
     assert atan(1e-50) == 1e-50

--- a/mpmath/tests/test_functions.py
+++ b/mpmath/tests/test_functions.py
@@ -435,26 +435,17 @@ def test_asin():
 
 def test_acos():
     pi4 = pi/4
-    assert acos(mpc(+inf, +inf)) == mpc(+pi4, -inf)
     assert acos(mpc(+inf, -inf)) == mpc(+pi4, +inf)
-    assert acos(mpc(-inf, +inf)) == mpc(pi4*3, -inf)
     assert acos(mpc(-inf, -inf)) == mpc(pi4*3, +inf)
-    r = acos(mpc(+inf, nan))
-    assert isnan(r.real) and r.imag == inf
     r = acos(mpc(-inf, nan))
     assert isnan(r.real) and r.imag == inf
-    r = acos(mpc(nan, +inf))
-    assert isnan(r.real) and r.imag == -inf
     r = acos(mpc(nan, -inf))
     assert isnan(r.real) and r.imag == +inf
     pi2 = pi/2
-    assert acos(mpc(+inf, +1)) == mpc(0.0, -inf)
     assert acos(mpc(+inf, -1)) == mpc(0.0, +inf)
     assert acos(mpc(+inf, 0)) == mpc(0.0, +inf)
-    assert acos(mpc(-inf, +1)) == mpc(pi, -inf)
     assert acos(mpc(-inf, -1)) == mpc(pi, +inf)
     assert acos(mpc(-inf, 0)) == mpc(pi, -inf)
-    assert acos(mpc(+1, +inf)) == mpc(pi2, -inf)
     assert acos(mpc(-1, +inf)) == mpc(pi2, -inf)
     assert acos(mpc(0, +inf)) == mpc(pi2, -inf)
     assert acos(mpc(+1, -inf)) == mpc(pi2, +inf)
@@ -466,12 +457,29 @@ def test_acos():
 
     # Special cases:
     # https://data-apis.org/array-api/2025.12/API_specification/generated/array_api.acos.html
-    # "If a is either +0 or -0 and b is NaN": pi/2 + NaN j.
+    # Real-valued cases
+    assert isnan(acos(mpf(nan)))
+    # Real inputs outside [-1, 1] are omitted because mpmath returns complex
+    # analytic continuations instead of NaN.
+    assert acos(mpf(1)).ae(0)
+    # Complex-valued cases
+    assert acos(mpc(0, 0)).ae(mpc(pi2, 0))
     r = acos(mpc(0, nan))
-    assert r.real.ae(pi/2) and isnan(r.imag)
-
-    # "If a is NaN and b is a finite number": NaN + NaN j.
+    assert r.real.ae(pi2) and isnan(r.imag)
+    assert acos(mpc(1, inf)).ae(mpc(pi2, -inf))
+    r = acos(mpc(1, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    assert acos(mpc(-inf, 1)).ae(mpc(pi, -inf))
+    assert acos(mpc(inf, 1)).ae(mpc(0, -inf))
+    assert acos(mpc(-inf, inf)).ae(mpc(3*pi4, -inf))
+    assert acos(mpc(inf, inf)).ae(mpc(pi4, -inf))
+    r = acos(mpc(inf, nan))
+    assert isnan(r.real) and abs(r.imag) == inf
     r = acos(mpc(nan, 0))
+    assert isnan(r.real) and isnan(r.imag)
+    r = acos(mpc(nan, inf))
+    assert isnan(r.real) and r.imag == -inf
+    r = acos(mpc(nan, nan))
     assert isnan(r.real) and isnan(r.imag)
 
 def test_atan():


### PR DESCRIPTION
As discussed in gh-1172, this PR resolves the disagreement between `acos`'s current behavior and that specified in the [array API standard](https://data-apis.org/array-api/2025.12/API_specification/generated/array_api.acos.html).

Because it is my first contribution, this PR is intended to be minimal and follow nearby patterns as closely as possible. Let me know what you'd prefer to see in the future and I'll make it so.

A more complete version, which tests _all_ the special cases from the standard - not just the ones that were failing - can be seen at:
https://github.com/mdhaber/mpmath/pull/new/fix_all_acos_special_cases
I'd prefer to go that route with this and future PRs (for other trig, hyperbolic trig, etc.), but it is more to review, so I decided to submit the minimal version. Let me know which direction you'd prefer. I've marked this as draft in the meantime.

When working on SciPy or MPArray, I never let AI draft my code. I did here because the changes are very mechanical. Of course, it (GPT 5.6 Sol, medium effort) made many mistakes, but I think I fixed it all up so it is compact and consistent with the existing code.
