### PR TITLE
Add bluestein's algorithm for arbitrary length fft calculation

### DIFF
--- a/mpmath/calculus/fft.py
+++ b/mpmath/calculus/fft.py
@@ -2,7 +2,7 @@ from .calculus import defun
 
 
 def _is_power_of_two(n):
-    return n > 0 and (n & (n - 1)) == 0
+    return (n & (n - 1)) == 0
 
 def _next_power_of_two(n):
     return 1 << (n - 1).bit_length()
@@ -55,22 +55,25 @@ def _fft_cooley_tuckey(ctx, values, inverse=False):
 
 
 def _fft_convolve(ctx, values_a, values_b):
+    """
+    Computes the convolution of two sequences using the Fast Fourier Transform (FFT).
+    """
     size = _next_power_of_two(len(values_a) + len(values_b) - 1)
     padded_a = values_a + [ctx.zero] * (size - len(values_a))
     padded_b = values_b + [ctx.zero] * (size - len(values_b))
-    with ctx.extraprec(10):
-        spectrum_a = _fft_cooley_tuckey(ctx, padded_a)
-        spectrum_b = _fft_cooley_tuckey(ctx, padded_b)
-        spectrum_product = [a * b for a, b in zip(spectrum_a, spectrum_b)]
-        result = _fft_cooley_tuckey(ctx, spectrum_product, True)
+
+    spectrum_a = _fft_cooley_tuckey(ctx, padded_a)
+    spectrum_b = _fft_cooley_tuckey(ctx, padded_b)
+    spectrum_product = [a * b for a, b in zip(spectrum_a, spectrum_b)]
+    result = _fft_cooley_tuckey(ctx, spectrum_product, True)
     return [value / size for value in result]
 
 def _fft_bluestein(ctx, values, inverse=False):
     """
-    This function implements Bluestein's algorithm for computing the Fast Fourier Transform (or Inverse Fast Fourier Transform)
-    of a sequence of complex numbers of arbitrary length.
+    This function implements Bluestein's algorithm for computing the Fast Fourier Transform (or Inverse Fast Fourier Transform) of a sequence of complex numbers of arbitrary length.
 
     https://en.wikipedia.org/wiki/Chirp_Z-transform
+    https://edukatesengkang.com/2026/09/01/how-to-learn-bluesteins-fft-algorithm-chirp-multiplication-convolution-arbitrary-length-dfts-and-prime-size-fourier-transforms/
     """
     n = len(values)
 
@@ -92,8 +95,7 @@ def fft(ctx, values):
     r"""
     Computes the Discrete Fourier Transform (DFT) of a sequence.
 
-    Uses the radix-2 Cooley-Tukey algorithm for power-of-two lengths and
-    Bluestein's algorithm for all other lengths.
+    Uses the radix-2 Cooley-Tukey algorithm for power-of-two lengths and Bluestein's algorithm for all other lengths.
 
     **Examples**
 
@@ -105,19 +107,19 @@ def fft(ctx, values):
     [(2.0 + 4.0j), (0.0 + 0.0j)]
     >>> mp.fft([1, 2, 3, 4])
     [10.0, (-2.0 + 2.0j), -2.0, (-2.0 - 2.0j)]
-    >>> mp.fft([1, 2, 1])
-    [(4.0 + 0.0j), (-0.5 - 0.866025403784439j), (-0.5 + 0.866025403784438j)]
+    >>> [mp.chop(x) for x in mp.fft([1, 2, 1])]
+    [4.0, (-0.5 - 0.866025403784439j), (-0.5 + 0.866025403784439j)]
     """
     n = len(values)
     if n == 0:
         return []
 
     converted_values = [ctx.convert(v) for v in values]
-    if _is_power_of_two(n):
-        with ctx.extraprec(10):
+    with ctx.extraprec(10):
+        if _is_power_of_two(n):
             result = _fft_cooley_tuckey(ctx, converted_values)
-    else:
-        result = _fft_bluestein(ctx, converted_values)
+        else:
+            result = _fft_bluestein(ctx, converted_values)
     return [+v for v in result]
 
 @defun
@@ -125,8 +127,7 @@ def invfft(ctx, values):
     r"""
     Computes the inverse Discrete Fourier Transform (IDFT) of a sequence.
 
-    Uses the radix-2 Cooley-Tukey algorithm for power-of-two lengths and
-    Bluestein's algorithm for all other lengths.
+    Uses the radix-2 Cooley-Tukey algorithm for power-of-two lengths and Bluestein's algorithm for all other lengths.
 
     **Examples**
 
@@ -145,9 +146,9 @@ def invfft(ctx, values):
         return []
 
     converted_values = [ctx.convert(v) for v in values]
-    if _is_power_of_two(n):
-        with ctx.extraprec(10):
+    with ctx.extraprec(10):
+        if _is_power_of_two(n):
             result = _fft_cooley_tuckey(ctx, converted_values, True)
-    else:
-        result = _fft_bluestein(ctx, converted_values, True)
+        else:
+            result = _fft_bluestein(ctx, converted_values, True)
     return [val / n for val in result]

--- a/mpmath/calculus/fft.py
+++ b/mpmath/calculus/fft.py
@@ -1,5 +1,12 @@
 from .calculus import defun
 
+
+def _is_power_of_two(n):
+    return n > 0 and (n & (n - 1)) == 0
+
+def _next_power_of_two(n):
+    return 1 << (n - 1).bit_length()
+
 def _fft_cooley_tuckey(ctx, values, inverse=False):
     """
     This function implements the Radix-2 Cooley-Tukey FFT algorithm iteratively.
@@ -46,12 +53,47 @@ def _fft_cooley_tuckey(ctx, values, inverse=False):
 
     return transformed
 
+
+def _fft_convolve(ctx, values_a, values_b):
+    size = _next_power_of_two(len(values_a) + len(values_b) - 1)
+    padded_a = values_a + [ctx.zero] * (size - len(values_a))
+    padded_b = values_b + [ctx.zero] * (size - len(values_b))
+    with ctx.extraprec(10):
+        spectrum_a = _fft_cooley_tuckey(ctx, padded_a)
+        spectrum_b = _fft_cooley_tuckey(ctx, padded_b)
+        spectrum_product = [a * b for a, b in zip(spectrum_a, spectrum_b)]
+        result = _fft_cooley_tuckey(ctx, spectrum_product, True)
+    return [value / size for value in result]
+
+def _fft_bluestein(ctx, values, inverse=False):
+    """
+    This function implements Bluestein's algorithm for computing the Fast Fourier Transform (or Inverse Fast Fourier Transform)
+    of a sequence of complex numbers of arbitrary length.
+
+    https://en.wikipedia.org/wiki/Chirp_Z-transform
+    """
+    n = len(values)
+
+    sign = ctx.one if inverse else -ctx.one
+    chirp = [ctx.expjpi(sign * j * j / n) for j in range(n)]
+
+    a = [values[j] * chirp[j] for j in range(n)]
+    b = [ctx.zero] * (2 * n - 1)
+    center = n - 1
+    for j in range(n):
+        b[center + j] = ctx.expjpi(-sign * j * j / n)
+        b[center - j] = ctx.expjpi(-sign * j * j / n)
+
+    convolution = _fft_convolve(ctx, a, b)
+    return [convolution[n - 1 + k] * chirp[k] for k in range(n)]
+
 @defun
 def fft(ctx, values):
     r"""
     Computes the Discrete Fourier Transform (DFT) of a sequence.
 
-    Raises NotImplementedError if the input sequence length is not a power of 2.
+    Uses the radix-2 Cooley-Tukey algorithm for power-of-two lengths and
+    Bluestein's algorithm for all other lengths.
 
     **Examples**
 
@@ -63,19 +105,19 @@ def fft(ctx, values):
     [(2.0 + 4.0j), (0.0 + 0.0j)]
     >>> mp.fft([1, 2, 3, 4])
     [10.0, (-2.0 + 2.0j), -2.0, (-2.0 - 2.0j)]
+    >>> mp.fft([1, 2, 1])
+    [(4.0 + 0.0j), (-0.5 - 0.866025403784439j), (-0.5 + 0.866025403784438j)]
     """
     n = len(values)
     if n == 0:
         return []
 
-    is_power_of_two = (n & (n - 1)) == 0
-    if not is_power_of_two:
-        raise NotImplementedError("FFT is only implemented for lengths that "
-                                  f"are powers of 2, got length: {n}")
-
     converted_values = [ctx.convert(v) for v in values]
-    with ctx.extraprec(10):
-        result = _fft_cooley_tuckey(ctx, converted_values)
+    if _is_power_of_two(n):
+        with ctx.extraprec(10):
+            result = _fft_cooley_tuckey(ctx, converted_values)
+    else:
+        result = _fft_bluestein(ctx, converted_values)
     return [+v for v in result]
 
 @defun
@@ -83,7 +125,8 @@ def invfft(ctx, values):
     r"""
     Computes the inverse Discrete Fourier Transform (IDFT) of a sequence.
 
-    Raises NotImplementedError if the input sequence length is not a power of 2.
+    Uses the radix-2 Cooley-Tukey algorithm for power-of-two lengths and
+    Bluestein's algorithm for all other lengths.
 
     **Examples**
 
@@ -94,17 +137,17 @@ def invfft(ctx, values):
     >>> x = [1, 2, 3, 4]
     >>> mp.invfft(mp.fft(x))
     [(1.0 + 0.0j), (2.0 + 0.0j), (3.0 + 0.0j), (4.0 + 0.0j)]
+    >>> mp.invfft(mp.fft([1.0 + 1.0j, 2.0 + 2.0j, 3.0 + 3.0j]))
+    [(1.0 + 1.0j), (2.0 + 2.0j), (3.0 + 3.0j)]
     """
     n = len(values)
     if n == 0:
         return []
 
-    is_power_of_two = (n & (n - 1)) == 0
-    if not is_power_of_two:
-        raise NotImplementedError("Inverse FFT is only implemented for lengths that "
-                                  f"are powers of 2, got length: {n}")
-
     converted_values = [ctx.convert(v) for v in values]
-    with ctx.extraprec(10):
-        result = _fft_cooley_tuckey(ctx, converted_values, True)
+    if _is_power_of_two(n):
+        with ctx.extraprec(10):
+            result = _fft_cooley_tuckey(ctx, converted_values, True)
+    else:
+        result = _fft_bluestein(ctx, converted_values, True)
     return [val / n for val in result]

--- a/mpmath/tests/test_calculus.py
+++ b/mpmath/tests/test_calculus.py
@@ -297,24 +297,24 @@ def test_fft():
     expected = [sum(x[n] * omega ** (n * k) for n in range(len(x))) for k in range(len(x))]
     spectrum = fft(x)
     assert all(a.ae(b, abs_eps=1e-14) for a, b in zip(spectrum, expected))
-    assert all(a.ae(b, abs_eps=1e-14) for a, b in zip(invfft(spectrum), x))
+    assert all(a.ae(b) for a, b in zip(invfft(spectrum), x))
 
     spectrum = fft([0, 1, 0, 0])
     expected = [1, -1j, -1, 1j]
-    assert all(a.ae(b, abs_eps=1e-14) for a, b in zip(spectrum, expected))
+    assert all(a.ae(b) for a, b in zip(spectrum, expected))
 
     spectrum = fft([1, 2, 3, 4])
     expected = [10, -2 + 2j, -2, -2 - 2j]
-    assert all(a.ae(b, abs_eps=1e-14) for a, b in zip(spectrum, expected))
+    assert all(a.ae(b) for a, b in zip(spectrum, expected))
     assert mp.chop(invfft(spectrum)) == [1, 2, 3, 4]
 
     spectrum = fft([1, j, -1, -j])
     expected = [0, 4, 0, 0]
-    assert all(a.ae(b, abs_eps=1e-14) for a, b in zip(spectrum, expected))
+    assert all(a.ae(b) for a, b in zip(spectrum, expected))
 
     x = invfft([4, 1 - 1j, 0, 1 + 1j])
     expected = [1.5, 1.5, 0.5, 0.5]
-    assert all(a.ae(b, abs_eps=1e-14) for a, b in zip(x, expected))
+    assert all(a.ae(b) for a, b in zip(x, expected))
 
     assert invfft([]) == []
 
@@ -350,7 +350,7 @@ def signals(draw):
 def test_fft_randomized_complex(x):
     # test that fft and invfft are inverses of each other for random complex inputs
     recovered = invfft(fft(x))
-    assert all(a.ae(b, abs_eps=1e-14) for a, b in zip(recovered, x))
+    assert all(a.ae(b) for a, b in zip(recovered, x))
 
     recovered = fft(invfft(x))
-    assert all(a.ae(b, abs_eps=1e-14) for a, b in zip(recovered, x))
+    assert all(a.ae(b) for a, b in zip(recovered, x))

--- a/mpmath/tests/test_calculus.py
+++ b/mpmath/tests/test_calculus.py
@@ -1,5 +1,5 @@
 import pytest
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from mpmath import (arange, chebyfit, cos, cosm, differint, e, euler, exp,
@@ -296,25 +296,25 @@ def test_fft():
     omega = mp.expjpi(-2 / len(x))
     expected = [sum(x[n] * omega ** (n * k) for n in range(len(x))) for k in range(len(x))]
     spectrum = fft(x)
-    assert all(a.ae(b) for a, b in zip(spectrum, expected))
-    assert all(a.ae(b) for a, b in zip(invfft(spectrum), x))
+    assert all(a.ae(b, abs_eps=1e-14) for a, b in zip(spectrum, expected))
+    assert all(a.ae(b, abs_eps=1e-14) for a, b in zip(invfft(spectrum), x))
 
     spectrum = fft([0, 1, 0, 0])
     expected = [1, -1j, -1, 1j]
-    assert all(a.ae(b) for a, b in zip(spectrum, expected))
+    assert all(a.ae(b, abs_eps=1e-14) for a, b in zip(spectrum, expected))
 
     spectrum = fft([1, 2, 3, 4])
     expected = [10, -2 + 2j, -2, -2 - 2j]
-    assert all(a.ae(b) for a, b in zip(spectrum, expected))
+    assert all(a.ae(b, abs_eps=1e-14) for a, b in zip(spectrum, expected))
     assert mp.chop(invfft(spectrum)) == [1, 2, 3, 4]
 
     spectrum = fft([1, j, -1, -j])
     expected = [0, 4, 0, 0]
-    assert all(a.ae(b) for a, b in zip(spectrum, expected))
+    assert all(a.ae(b, abs_eps=1e-14) for a, b in zip(spectrum, expected))
 
     x = invfft([4, 1 - 1j, 0, 1 + 1j])
     expected = [1.5, 1.5, 0.5, 0.5]
-    assert all(a.ae(b) for a, b in zip(x, expected))
+    assert all(a.ae(b, abs_eps=1e-14) for a, b in zip(x, expected))
 
     assert invfft([]) == []
 
@@ -332,8 +332,8 @@ def test_fft():
     assert abs(time_energy - freq_energy) < 1e-12
 
 @st.composite
-def power_of_two_signals(draw):
-    size = draw(st.sampled_from([1, 2, 4, 8, 16]))
+def signals(draw):
+    size = draw(st.sampled_from([1, 2, 3, 4, 7, 8, 9, 13, 16, 25]))
     return draw(st.lists(
         st.complex_numbers(
             min_magnitude=0,
@@ -345,11 +345,12 @@ def power_of_two_signals(draw):
         max_size=size,
     ))
 
-@given(x=power_of_two_signals())
+@given(x=signals())
+@settings(deadline=None)
 def test_fft_randomized_complex(x):
     # test that fft and invfft are inverses of each other for random complex inputs
     recovered = invfft(fft(x))
-    assert all(a.ae(b) for a, b in zip(recovered, x))
+    assert all(a.ae(b, abs_eps=1e-14) for a, b in zip(recovered, x))
 
     recovered = fft(invfft(x))
-    assert all(a.ae(b) for a, b in zip(recovered, x))
+    assert all(a.ae(b, abs_eps=1e-14) for a, b in zip(recovered, x))

--- a/mpmath/tests/test_calculus.py
+++ b/mpmath/tests/test_calculus.py
@@ -290,8 +290,14 @@ def test_logm():
 def test_fft():
     assert fft([]) == []
     assert fft([1]) == [1]
-    pytest.raises(NotImplementedError, lambda: fft([1, 2, 3]))
     assert fft([1, 0, 0, 0]) == [1, 1, 1, 1]
+
+    x = [1, 2+2j, 2, 3+3j, 3]
+    omega = mp.expjpi(-2 / len(x))
+    expected = [sum(x[n] * omega ** (n * k) for n in range(len(x))) for k in range(len(x))]
+    spectrum = fft(x)
+    assert all(a.ae(b) for a, b in zip(spectrum, expected))
+    assert all(a.ae(b) for a, b in zip(invfft(spectrum), x))
 
     spectrum = fft([0, 1, 0, 0])
     expected = [1, -1j, -1, 1j]
@@ -311,13 +317,18 @@ def test_fft():
     assert all(a.ae(b) for a, b in zip(x, expected))
 
     assert invfft([]) == []
-    pytest.raises(NotImplementedError, lambda: invfft([1, 2, 3]))
 
     # test parseval's theorem
     x = [0.25 + 2.0j, -0.5, 0.75 - 1.0j, -1.0 - 8.0j, 0.5, 0.125 + 0.65j, -0.75, 1.25 + 2.5j]
     X = fft(x)
     time_energy = sum(abs(complex(v)) ** 2 for v in x)
     freq_energy = sum(abs(complex(v)) ** 2 for v in X) / 8
+    assert abs(time_energy - freq_energy) < 1e-12
+
+    x = [0.25 + 2.0j, -0.5, 0.75 - 1.0j, -1.0 - 8.0j, 0.5, 0.125 + 0.65j, -0.75, 1.25 + 2.5j, -0.25 - 1.0j, 0.5]
+    X = fft(x)
+    time_energy = sum(abs(complex(v)) ** 2 for v in x)
+    freq_energy = sum(abs(complex(v)) ** 2 for v in X) / 10
     assert abs(time_energy - freq_energy) < 1e-12
 
 @st.composite


### PR DESCRIPTION
closes #707 
 
- Implemented the Bluestein's algorithm for fast fourier transform and inverse fast fourier trasform calculation.
- Now, the `fft()` and `invfft()` can handle any arbitrary input length signal.
- If the input signal has power-of-two length, cooley-tukey is used otherwise bluestein is used.

References:
1. [Wikipedia](https://en.wikipedia.org/wiki/Chirp_Z-transform)
2. https://edukatesengkang.com/2026/09/01/how-to-learn-bluesteins-fft-algorithm-chirp-multiplication-convolution-arbitrary-length-dfts-and-prime-size-fourier-transforms/