### PR TITLE
Ensure `exp`/`expm1` respect special cases from applicable standards

### DIFF
--- a/mpmath/libmp/libmpc.py
+++ b/mpmath/libmp/libmpc.py
@@ -424,6 +424,8 @@ def mpc_exp(z, prec, rnd=round_down):
         return mpf_cos_sin(b, prec, rnd)
     if b == fzero:
         return mpf_exp(a, prec, rnd), fzero
+    if a in _infs and b in _infs_nan:
+        return (fzero, fzero) if a == fninf else (finf, fnan)
     mag = mpf_exp(a, prec+4, rnd)
     c, s = mpf_cos_sin(b, prec+4, rnd)
     re = mpf_mul(mag, c, prec, rnd)

--- a/mpmath/tests/test_functions.py
+++ b/mpmath/tests/test_functions.py
@@ -3,10 +3,7 @@ import inspect
 import math
 import random
 
-import numpy as np
 import pytest
-from hypothesis import given, settings
-from hypothesis import strategies as st
 
 from mpmath import (acos, acosh, acot, acoth, acsc, acsch, arange, arg, asec,
                     asech, asin, asinh, atan, atan2, atanh, catalan, cbrt,
@@ -25,14 +22,6 @@ from mpmath.libmp import (MPZ, ComplexResult, from_int, mpf_gt, mpf_lt,
                           mpf_mul, mpf_pow_int, mpf_sqrt, round_ceiling,
                           round_down, round_nearest, round_up)
 from mpmath.libmp.libmpf import mpf_rand
-
-
-_exp_component_values = [
-    0.0, 1.0, -1.0, math.pi/4, -math.pi/4, 3*math.pi/4, -3*math.pi/4,
-    math.inf, -math.inf, math.nan]
-_exp_components = st.sampled_from(_exp_component_values)
-_exp_imag_components = st.one_of(st.none(), _exp_components)
-_exp_case_count = len(_exp_component_values) * (len(_exp_component_values) + 1)
 
 
 def mpc_ae(a, b, eps=eps):
@@ -287,19 +276,99 @@ def test_exp():
     assert exp(ln2 * 10).ae(1024)
     assert exp(2+2j).ae(cmath.exp(2+2j))
 
+    # Complex special cases:
+    # https://en.cppreference.com/c/numeric/complex/cexp
+    assert exp(0j) == 1
+    r = exp(mpc(0, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(1, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(1, -inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(1, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    assert exp(mpc(inf, 0)) == mpc(inf, 0)
+    assert exp(mpc(-inf, 0)) == 0
+    assert exp(mpc(-inf, 1)) == 0
+    assert exp(mpc(inf, pi/4)) == mpc(inf, inf)
+    assert exp(mpc(inf, 3*pi/4)) == mpc(-inf, inf)
+    assert exp(mpc(inf, -3*pi/4)) == mpc(-inf, -inf)
+    assert exp(mpc(inf, -pi/4)) == mpc(inf, -inf)
+    assert exp(mpc(-inf, inf)) == 0
+    assert exp(mpc(-inf, -inf)) == 0
+    r = exp(mpc(inf, inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = exp(mpc(inf, -inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    assert exp(mpc(-inf, nan)) == 0
+    r = exp(mpc(inf, nan))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = exp(mpc(nan, 0))
+    assert isnan(r.real) and r.imag == 0
+    r = exp(mpc(nan, 1))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(nan, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(nan, -inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(nan, nan))
+    assert isnan(r.real) and isnan(r.imag)
 
-@settings(max_examples=_exp_case_count + 1)
-@given(real=_exp_components, imag=_exp_imag_components)
-def test_exp_special_cases(real, imag):
-    if imag is None:
-        actual = float(exp(real))
-        expected = np.exp(float(real))
-    else:
-        actual = complex(exp(mpc(real, imag)))
-        with np.errstate(all='ignore'):
-            expected = np.exp(complex(real, imag))
-    np.testing.assert_allclose(actual, expected)
-
+    # All combinations of finite and special representative values.
+    assert exp(mpc(0, 0)) == 1
+    assert exp(mpc(0, 1)).ae(cmath.exp(1j))
+    assert exp(mpc(0, -1)).ae(cmath.exp(-1j))
+    r = exp(mpc(0, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(0, -inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(0, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    assert exp(mpc(1, 0)).ae(cmath.exp(1))
+    assert exp(mpc(1, 1)).ae(cmath.exp(1+1j))
+    assert exp(mpc(1, -1)).ae(cmath.exp(1-1j))
+    r = exp(mpc(1, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(1, -inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(1, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    assert exp(mpc(-1, 0)).ae(cmath.exp(-1))
+    assert exp(mpc(-1, 1)).ae(cmath.exp(-1+1j))
+    assert exp(mpc(-1, -1)).ae(cmath.exp(-1-1j))
+    r = exp(mpc(-1, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(-1, -inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(-1, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    assert exp(mpc(inf, 0)) == mpc(inf, 0)
+    assert exp(mpc(inf, 1)) == mpc(inf, inf)
+    assert exp(mpc(inf, -1)) == mpc(inf, -inf)
+    r = exp(mpc(inf, inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = exp(mpc(inf, -inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = exp(mpc(inf, nan))
+    assert abs(r.real) == inf and isnan(r.imag)
+    assert exp(mpc(-inf, 0)) == 0
+    assert exp(mpc(-inf, 1)) == 0
+    assert exp(mpc(-inf, -1)) == 0
+    assert exp(mpc(-inf, inf)) == 0
+    assert exp(mpc(-inf, -inf)) == 0
+    assert exp(mpc(-inf, nan)) == 0
+    r = exp(mpc(nan, 0))
+    assert isnan(r.real) and r.imag == 0
+    r = exp(mpc(nan, 1))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(nan, -1))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(nan, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(nan, -inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(nan, nan))
+    assert isnan(r.real) and isnan(r.imag)
 
 def test_issue_73():
     mp.dps = 512
@@ -1192,19 +1261,99 @@ def test_expm1():
     assert expm1(1e-50).ae(1e-50)
     assert (expm1(1e-10)*1e10).ae(1.00000000005)
 
+    # Other real special cases:
+    # https://en.cppreference.com/c/numeric/math/expm1
+    assert isnan(expm1(nan))
+    assert expm1(-inf) == -1
 
-@settings(max_examples=_exp_case_count + 1)
-@given(real=_exp_components, imag=_exp_imag_components)
-def test_expm1_special_cases(real, imag):
-    if imag is None:
-        actual = float(expm1(real))
-        expected = np.exp(float(real)) - 1
-    else:
-        actual = complex(expm1(mpc(real, imag)))
-        with np.errstate(all='ignore'):
-            expected = np.exp(complex(real, imag)) - 1
-    np.testing.assert_allclose(actual, expected)
+    # Complex special cases:
+    # https://en.cppreference.com/c/numeric/complex/cexp
+    # The expm1 results are the exp results minus 1.
+    assert expm1(0j) == 0
+    r = expm1(mpc(1, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(1, -inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(1, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    assert expm1(mpc(inf, 0)) == mpc(inf, 0)
+    assert expm1(mpc(-inf, 0)) == -1
+    assert expm1(mpc(-inf, 1)) == -1
+    assert expm1(mpc(inf, pi/4)) == mpc(inf, inf)
+    assert expm1(mpc(inf, 3*pi/4)) == mpc(-inf, inf)
+    assert expm1(mpc(inf, -3*pi/4)) == mpc(-inf, -inf)
+    assert expm1(mpc(inf, -pi/4)) == mpc(inf, -inf)
+    assert expm1(mpc(-inf, inf)) == -1
+    assert expm1(mpc(-inf, -inf)) == -1
+    r = expm1(mpc(inf, inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = expm1(mpc(inf, -inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    assert expm1(mpc(-inf, nan)) == -1
+    r = expm1(mpc(inf, nan))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = expm1(mpc(nan, 0))
+    assert isnan(r.real) and r.imag == 0
+    r = expm1(mpc(nan, 1))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(nan, nan))
+    assert isnan(r.real) and isnan(r.imag)
 
+    # All combinations of finite and special representative values.
+    assert expm1(mpc(0, 0)) == 0
+    assert expm1(mpc(0, 1)).ae(cmath.exp(1j)-1)
+    assert expm1(mpc(0, -1)).ae(cmath.exp(-1j)-1)
+    r = expm1(mpc(0, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(0, -inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(0, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    assert expm1(mpc(1, 0)).ae(cmath.exp(1)-1)
+    assert expm1(mpc(1, 1)).ae(cmath.exp(1+1j)-1)
+    assert expm1(mpc(1, -1)).ae(cmath.exp(1-1j)-1)
+    r = expm1(mpc(1, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(1, -inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(1, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    assert expm1(mpc(-1, 0)).ae(cmath.exp(-1)-1)
+    assert expm1(mpc(-1, 1)).ae(cmath.exp(-1+1j)-1)
+    assert expm1(mpc(-1, -1)).ae(cmath.exp(-1-1j)-1)
+    r = expm1(mpc(-1, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(-1, -inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(-1, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    assert expm1(mpc(inf, 0)) == mpc(inf, 0)
+    assert expm1(mpc(inf, 1)) == mpc(inf, inf)
+    assert expm1(mpc(inf, -1)) == mpc(inf, -inf)
+    r = expm1(mpc(inf, inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = expm1(mpc(inf, -inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = expm1(mpc(inf, nan))
+    assert abs(r.real) == inf and isnan(r.imag)
+    assert expm1(mpc(-inf, 0)) == -1
+    assert expm1(mpc(-inf, 1)) == -1
+    assert expm1(mpc(-inf, -1)) == -1
+    assert expm1(mpc(-inf, inf)) == -1
+    assert expm1(mpc(-inf, -inf)) == -1
+    assert expm1(mpc(-inf, nan)) == -1
+    r = expm1(mpc(nan, 0))
+    assert isnan(r.real) and r.imag == 0
+    r = expm1(mpc(nan, 1))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(nan, -1))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(nan, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(nan, -inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(nan, nan))
+    assert isnan(r.real) and isnan(r.imag)
 
 def test_log1p():
     assert log1p(0) == 0

--- a/mpmath/tests/test_functions.py
+++ b/mpmath/tests/test_functions.py
@@ -314,62 +314,6 @@ def test_exp():
     r = exp(mpc(nan, nan))
     assert isnan(r.real) and isnan(r.imag)
 
-    # All combinations of finite and special representative values.
-    assert exp(mpc(0, 0)) == 1
-    assert exp(mpc(0, 1)).ae(cmath.exp(1j))
-    assert exp(mpc(0, -1)).ae(cmath.exp(-1j))
-    r = exp(mpc(0, inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(0, -inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(0, nan))
-    assert isnan(r.real) and isnan(r.imag)
-    assert exp(mpc(1, 0)).ae(cmath.exp(1))
-    assert exp(mpc(1, 1)).ae(cmath.exp(1+1j))
-    assert exp(mpc(1, -1)).ae(cmath.exp(1-1j))
-    r = exp(mpc(1, inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(1, -inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(1, nan))
-    assert isnan(r.real) and isnan(r.imag)
-    assert exp(mpc(-1, 0)).ae(cmath.exp(-1))
-    assert exp(mpc(-1, 1)).ae(cmath.exp(-1+1j))
-    assert exp(mpc(-1, -1)).ae(cmath.exp(-1-1j))
-    r = exp(mpc(-1, inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(-1, -inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(-1, nan))
-    assert isnan(r.real) and isnan(r.imag)
-    assert exp(mpc(inf, 0)) == mpc(inf, 0)
-    assert exp(mpc(inf, 1)) == mpc(inf, inf)
-    assert exp(mpc(inf, -1)) == mpc(inf, -inf)
-    r = exp(mpc(inf, inf))
-    assert abs(r.real) == inf and isnan(r.imag)
-    r = exp(mpc(inf, -inf))
-    assert abs(r.real) == inf and isnan(r.imag)
-    r = exp(mpc(inf, nan))
-    assert abs(r.real) == inf and isnan(r.imag)
-    assert exp(mpc(-inf, 0)) == 0
-    assert exp(mpc(-inf, 1)) == 0
-    assert exp(mpc(-inf, -1)) == 0
-    assert exp(mpc(-inf, inf)) == 0
-    assert exp(mpc(-inf, -inf)) == 0
-    assert exp(mpc(-inf, nan)) == 0
-    r = exp(mpc(nan, 0))
-    assert isnan(r.real) and r.imag == 0
-    r = exp(mpc(nan, 1))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(nan, -1))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(nan, inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(nan, -inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(nan, nan))
-    assert isnan(r.real) and isnan(r.imag)
-
 def test_issue_73():
     mp.dps = 512
     a = exp(-1)
@@ -1295,62 +1239,6 @@ def test_expm1():
     r = expm1(mpc(nan, 0))
     assert isnan(r.real) and r.imag == 0
     r = expm1(mpc(nan, 1))
-    assert isnan(r.real) and isnan(r.imag)
-    r = expm1(mpc(nan, nan))
-    assert isnan(r.real) and isnan(r.imag)
-
-    # All combinations of finite and special representative values.
-    assert expm1(mpc(0, 0)) == 0
-    assert expm1(mpc(0, 1)).ae(cmath.exp(1j)-1)
-    assert expm1(mpc(0, -1)).ae(cmath.exp(-1j)-1)
-    r = expm1(mpc(0, inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = expm1(mpc(0, -inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = expm1(mpc(0, nan))
-    assert isnan(r.real) and isnan(r.imag)
-    assert expm1(mpc(1, 0)).ae(cmath.exp(1)-1)
-    assert expm1(mpc(1, 1)).ae(cmath.exp(1+1j)-1)
-    assert expm1(mpc(1, -1)).ae(cmath.exp(1-1j)-1)
-    r = expm1(mpc(1, inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = expm1(mpc(1, -inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = expm1(mpc(1, nan))
-    assert isnan(r.real) and isnan(r.imag)
-    assert expm1(mpc(-1, 0)).ae(cmath.exp(-1)-1)
-    assert expm1(mpc(-1, 1)).ae(cmath.exp(-1+1j)-1)
-    assert expm1(mpc(-1, -1)).ae(cmath.exp(-1-1j)-1)
-    r = expm1(mpc(-1, inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = expm1(mpc(-1, -inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = expm1(mpc(-1, nan))
-    assert isnan(r.real) and isnan(r.imag)
-    assert expm1(mpc(inf, 0)) == mpc(inf, 0)
-    assert expm1(mpc(inf, 1)) == mpc(inf, inf)
-    assert expm1(mpc(inf, -1)) == mpc(inf, -inf)
-    r = expm1(mpc(inf, inf))
-    assert abs(r.real) == inf and isnan(r.imag)
-    r = expm1(mpc(inf, -inf))
-    assert abs(r.real) == inf and isnan(r.imag)
-    r = expm1(mpc(inf, nan))
-    assert abs(r.real) == inf and isnan(r.imag)
-    assert expm1(mpc(-inf, 0)) == -1
-    assert expm1(mpc(-inf, 1)) == -1
-    assert expm1(mpc(-inf, -1)) == -1
-    assert expm1(mpc(-inf, inf)) == -1
-    assert expm1(mpc(-inf, -inf)) == -1
-    assert expm1(mpc(-inf, nan)) == -1
-    r = expm1(mpc(nan, 0))
-    assert isnan(r.real) and r.imag == 0
-    r = expm1(mpc(nan, 1))
-    assert isnan(r.real) and isnan(r.imag)
-    r = expm1(mpc(nan, -1))
-    assert isnan(r.real) and isnan(r.imag)
-    r = expm1(mpc(nan, inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = expm1(mpc(nan, -inf))
     assert isnan(r.real) and isnan(r.imag)
     r = expm1(mpc(nan, nan))
     assert isnan(r.real) and isnan(r.imag)

--- a/mpmath/tests/test_functions.py
+++ b/mpmath/tests/test_functions.py
@@ -3,7 +3,10 @@ import inspect
 import math
 import random
 
+import numpy as np
 import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
 
 from mpmath import (acos, acosh, acot, acoth, acsc, acsch, arange, arg, asec,
                     asech, asin, asinh, atan, atan2, atanh, catalan, cbrt,
@@ -22,6 +25,14 @@ from mpmath.libmp import (MPZ, ComplexResult, from_int, mpf_gt, mpf_lt,
                           mpf_mul, mpf_pow_int, mpf_sqrt, round_ceiling,
                           round_down, round_nearest, round_up)
 from mpmath.libmp.libmpf import mpf_rand
+
+
+_exp_component_values = [
+    0.0, 1.0, -1.0, math.pi/4, -math.pi/4, 3*math.pi/4, -3*math.pi/4,
+    math.inf, -math.inf, math.nan]
+_exp_components = st.sampled_from(_exp_component_values)
+_exp_imag_components = st.one_of(st.none(), _exp_components)
+_exp_case_count = len(_exp_component_values) * (len(_exp_component_values) + 1)
 
 
 def mpc_ae(a, b, eps=eps):
@@ -276,99 +287,19 @@ def test_exp():
     assert exp(ln2 * 10).ae(1024)
     assert exp(2+2j).ae(cmath.exp(2+2j))
 
-    # Complex special cases:
-    # https://en.cppreference.com/c/numeric/complex/cexp
-    assert exp(0j) == 1
-    r = exp(mpc(0, nan))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(1, inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(1, -inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(1, nan))
-    assert isnan(r.real) and isnan(r.imag)
-    assert exp(mpc(inf, 0)) == mpc(inf, 0)
-    assert exp(mpc(-inf, 0)) == 0
-    assert exp(mpc(-inf, 1)) == 0
-    assert exp(mpc(inf, pi/4)) == mpc(inf, inf)
-    assert exp(mpc(inf, 3*pi/4)) == mpc(-inf, inf)
-    assert exp(mpc(inf, -3*pi/4)) == mpc(-inf, -inf)
-    assert exp(mpc(inf, -pi/4)) == mpc(inf, -inf)
-    assert exp(mpc(-inf, inf)) == 0
-    assert exp(mpc(-inf, -inf)) == 0
-    r = exp(mpc(inf, inf))
-    assert abs(r.real) == inf and isnan(r.imag)
-    r = exp(mpc(inf, -inf))
-    assert abs(r.real) == inf and isnan(r.imag)
-    assert exp(mpc(-inf, nan)) == 0
-    r = exp(mpc(inf, nan))
-    assert abs(r.real) == inf and isnan(r.imag)
-    r = exp(mpc(nan, 0))
-    assert isnan(r.real) and r.imag == 0
-    r = exp(mpc(nan, 1))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(nan, inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(nan, -inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(nan, nan))
-    assert isnan(r.real) and isnan(r.imag)
 
-    # All combinations of finite and special representative values.
-    assert exp(mpc(0, 0)) == 1
-    assert exp(mpc(0, 1)).ae(cmath.exp(1j))
-    assert exp(mpc(0, -1)).ae(cmath.exp(-1j))
-    r = exp(mpc(0, inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(0, -inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(0, nan))
-    assert isnan(r.real) and isnan(r.imag)
-    assert exp(mpc(1, 0)).ae(cmath.exp(1))
-    assert exp(mpc(1, 1)).ae(cmath.exp(1+1j))
-    assert exp(mpc(1, -1)).ae(cmath.exp(1-1j))
-    r = exp(mpc(1, inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(1, -inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(1, nan))
-    assert isnan(r.real) and isnan(r.imag)
-    assert exp(mpc(-1, 0)).ae(cmath.exp(-1))
-    assert exp(mpc(-1, 1)).ae(cmath.exp(-1+1j))
-    assert exp(mpc(-1, -1)).ae(cmath.exp(-1-1j))
-    r = exp(mpc(-1, inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(-1, -inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(-1, nan))
-    assert isnan(r.real) and isnan(r.imag)
-    assert exp(mpc(inf, 0)) == mpc(inf, 0)
-    assert exp(mpc(inf, 1)) == mpc(inf, inf)
-    assert exp(mpc(inf, -1)) == mpc(inf, -inf)
-    r = exp(mpc(inf, inf))
-    assert abs(r.real) == inf and isnan(r.imag)
-    r = exp(mpc(inf, -inf))
-    assert abs(r.real) == inf and isnan(r.imag)
-    r = exp(mpc(inf, nan))
-    assert abs(r.real) == inf and isnan(r.imag)
-    assert exp(mpc(-inf, 0)) == 0
-    assert exp(mpc(-inf, 1)) == 0
-    assert exp(mpc(-inf, -1)) == 0
-    assert exp(mpc(-inf, inf)) == 0
-    assert exp(mpc(-inf, -inf)) == 0
-    assert exp(mpc(-inf, nan)) == 0
-    r = exp(mpc(nan, 0))
-    assert isnan(r.real) and r.imag == 0
-    r = exp(mpc(nan, 1))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(nan, -1))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(nan, inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(nan, -inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp(mpc(nan, nan))
-    assert isnan(r.real) and isnan(r.imag)
+@settings(max_examples=_exp_case_count + 1)
+@given(real=_exp_components, imag=_exp_imag_components)
+def test_exp_special_cases(real, imag):
+    if imag is None:
+        actual = float(exp(real))
+        expected = np.exp(float(real))
+    else:
+        actual = complex(exp(mpc(real, imag)))
+        with np.errstate(all='ignore'):
+            expected = np.exp(complex(real, imag))
+    np.testing.assert_allclose(actual, expected)
+
 
 def test_issue_73():
     mp.dps = 512
@@ -1261,99 +1192,19 @@ def test_expm1():
     assert expm1(1e-50).ae(1e-50)
     assert (expm1(1e-10)*1e10).ae(1.00000000005)
 
-    # Other real special cases:
-    # https://en.cppreference.com/c/numeric/math/expm1
-    assert isnan(expm1(nan))
-    assert expm1(-inf) == -1
 
-    # Complex special cases:
-    # https://en.cppreference.com/c/numeric/complex/cexp
-    # The expm1 results are the exp results minus 1.
-    assert expm1(0j) == 0
-    r = expm1(mpc(1, inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = expm1(mpc(1, -inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = expm1(mpc(1, nan))
-    assert isnan(r.real) and isnan(r.imag)
-    assert expm1(mpc(inf, 0)) == mpc(inf, 0)
-    assert expm1(mpc(-inf, 0)) == -1
-    assert expm1(mpc(-inf, 1)) == -1
-    assert expm1(mpc(inf, pi/4)) == mpc(inf, inf)
-    assert expm1(mpc(inf, 3*pi/4)) == mpc(-inf, inf)
-    assert expm1(mpc(inf, -3*pi/4)) == mpc(-inf, -inf)
-    assert expm1(mpc(inf, -pi/4)) == mpc(inf, -inf)
-    assert expm1(mpc(-inf, inf)) == -1
-    assert expm1(mpc(-inf, -inf)) == -1
-    r = expm1(mpc(inf, inf))
-    assert abs(r.real) == inf and isnan(r.imag)
-    r = expm1(mpc(inf, -inf))
-    assert abs(r.real) == inf and isnan(r.imag)
-    assert expm1(mpc(-inf, nan)) == -1
-    r = expm1(mpc(inf, nan))
-    assert abs(r.real) == inf and isnan(r.imag)
-    r = expm1(mpc(nan, 0))
-    assert isnan(r.real) and r.imag == 0
-    r = expm1(mpc(nan, 1))
-    assert isnan(r.real) and isnan(r.imag)
-    r = expm1(mpc(nan, nan))
-    assert isnan(r.real) and isnan(r.imag)
+@settings(max_examples=_exp_case_count + 1)
+@given(real=_exp_components, imag=_exp_imag_components)
+def test_expm1_special_cases(real, imag):
+    if imag is None:
+        actual = float(expm1(real))
+        expected = np.exp(float(real)) - 1
+    else:
+        actual = complex(expm1(mpc(real, imag)))
+        with np.errstate(all='ignore'):
+            expected = np.exp(complex(real, imag)) - 1
+    np.testing.assert_allclose(actual, expected)
 
-    # All combinations of finite and special representative values.
-    assert expm1(mpc(0, 0)) == 0
-    assert expm1(mpc(0, 1)).ae(cmath.exp(1j)-1)
-    assert expm1(mpc(0, -1)).ae(cmath.exp(-1j)-1)
-    r = expm1(mpc(0, inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = expm1(mpc(0, -inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = expm1(mpc(0, nan))
-    assert isnan(r.real) and isnan(r.imag)
-    assert expm1(mpc(1, 0)).ae(cmath.exp(1)-1)
-    assert expm1(mpc(1, 1)).ae(cmath.exp(1+1j)-1)
-    assert expm1(mpc(1, -1)).ae(cmath.exp(1-1j)-1)
-    r = expm1(mpc(1, inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = expm1(mpc(1, -inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = expm1(mpc(1, nan))
-    assert isnan(r.real) and isnan(r.imag)
-    assert expm1(mpc(-1, 0)).ae(cmath.exp(-1)-1)
-    assert expm1(mpc(-1, 1)).ae(cmath.exp(-1+1j)-1)
-    assert expm1(mpc(-1, -1)).ae(cmath.exp(-1-1j)-1)
-    r = expm1(mpc(-1, inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = expm1(mpc(-1, -inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = expm1(mpc(-1, nan))
-    assert isnan(r.real) and isnan(r.imag)
-    assert expm1(mpc(inf, 0)) == mpc(inf, 0)
-    assert expm1(mpc(inf, 1)) == mpc(inf, inf)
-    assert expm1(mpc(inf, -1)) == mpc(inf, -inf)
-    r = expm1(mpc(inf, inf))
-    assert abs(r.real) == inf and isnan(r.imag)
-    r = expm1(mpc(inf, -inf))
-    assert abs(r.real) == inf and isnan(r.imag)
-    r = expm1(mpc(inf, nan))
-    assert abs(r.real) == inf and isnan(r.imag)
-    assert expm1(mpc(-inf, 0)) == -1
-    assert expm1(mpc(-inf, 1)) == -1
-    assert expm1(mpc(-inf, -1)) == -1
-    assert expm1(mpc(-inf, inf)) == -1
-    assert expm1(mpc(-inf, -inf)) == -1
-    assert expm1(mpc(-inf, nan)) == -1
-    r = expm1(mpc(nan, 0))
-    assert isnan(r.real) and r.imag == 0
-    r = expm1(mpc(nan, 1))
-    assert isnan(r.real) and isnan(r.imag)
-    r = expm1(mpc(nan, -1))
-    assert isnan(r.real) and isnan(r.imag)
-    r = expm1(mpc(nan, inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = expm1(mpc(nan, -inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = expm1(mpc(nan, nan))
-    assert isnan(r.real) and isnan(r.imag)
 
 def test_log1p():
     assert log1p(0) == 0

--- a/mpmath/tests/test_functions.py
+++ b/mpmath/tests/test_functions.py
@@ -279,6 +279,8 @@ def test_exp():
     # Complex special cases:
     # https://en.cppreference.com/c/numeric/complex/cexp
     assert exp(0j) == 1
+    r = exp(mpc(0, nan))
+    assert isnan(r.real) and isnan(r.imag)
     r = exp(mpc(1, inf))
     assert isnan(r.real) and isnan(r.imag)
     r = exp(mpc(1, -inf))
@@ -304,6 +306,10 @@ def test_exp():
     r = exp(mpc(nan, 0))
     assert isnan(r.real) and r.imag == 0
     r = exp(mpc(nan, 1))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(nan, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(nan, -inf))
     assert isnan(r.real) and isnan(r.imag)
     r = exp(mpc(nan, nan))
     assert isnan(r.real) and isnan(r.imag)

--- a/mpmath/tests/test_functions.py
+++ b/mpmath/tests/test_functions.py
@@ -281,16 +281,22 @@ def test_exp():
     assert exp(0j) == 1
     r = exp(mpc(1, inf))
     assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(1, -inf))
+    assert isnan(r.real) and isnan(r.imag)
     r = exp(mpc(1, nan))
     assert isnan(r.real) and isnan(r.imag)
     assert exp(mpc(inf, 0)) == mpc(inf, 0)
+    assert exp(mpc(-inf, 0)) == 0
     assert exp(mpc(-inf, 1)) == 0
     assert exp(mpc(inf, pi/4)) == mpc(inf, inf)
     assert exp(mpc(inf, 3*pi/4)) == mpc(-inf, inf)
     assert exp(mpc(inf, -3*pi/4)) == mpc(-inf, -inf)
     assert exp(mpc(inf, -pi/4)) == mpc(inf, -inf)
     assert exp(mpc(-inf, inf)) == 0
+    assert exp(mpc(-inf, -inf)) == 0
     r = exp(mpc(inf, inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = exp(mpc(inf, -inf))
     assert abs(r.real) == inf and isnan(r.imag)
     assert exp(mpc(-inf, nan)) == 0
     r = exp(mpc(inf, nan))
@@ -1204,16 +1210,22 @@ def test_expm1():
     assert expm1(0j) == 0
     r = expm1(mpc(1, inf))
     assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(1, -inf))
+    assert isnan(r.real) and isnan(r.imag)
     r = expm1(mpc(1, nan))
     assert isnan(r.real) and isnan(r.imag)
     assert expm1(mpc(inf, 0)) == mpc(inf, 0)
+    assert expm1(mpc(-inf, 0)) == -1
     assert expm1(mpc(-inf, 1)) == -1
     assert expm1(mpc(inf, pi/4)) == mpc(inf, inf)
     assert expm1(mpc(inf, 3*pi/4)) == mpc(-inf, inf)
     assert expm1(mpc(inf, -3*pi/4)) == mpc(-inf, -inf)
     assert expm1(mpc(inf, -pi/4)) == mpc(inf, -inf)
     assert expm1(mpc(-inf, inf)) == -1
+    assert expm1(mpc(-inf, -inf)) == -1
     r = expm1(mpc(inf, inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = expm1(mpc(inf, -inf))
     assert abs(r.real) == inf and isnan(r.imag)
     assert expm1(mpc(-inf, nan)) == -1
     r = expm1(mpc(inf, nan))

--- a/mpmath/tests/test_functions.py
+++ b/mpmath/tests/test_functions.py
@@ -263,34 +263,6 @@ def test_exact_cbrt():
         A = random.randint(10**(prec//2-2), 10**(prec//2-1))
         assert cbrt(mpf(A*A*A)) == A
 
-def _test_exp_special_cases(exp_fun, m):
-    # Special cases:
-    # https://en.cppreference.com/c/numeric/complex/cexp
-    # The expm1 results are the exp results minus 1.
-    assert exp_fun(0j) == 1 - m
-    r = exp_fun(mpc(1, inf))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp_fun(mpc(1, nan))
-    assert isnan(r.real) and isnan(r.imag)
-    assert exp_fun(mpc(inf, 0)) == mpc(inf, 0)
-    assert exp_fun(mpc(-inf, 1)) == -m
-    assert exp_fun(mpc(inf, pi/4)) == mpc(inf, inf)
-    assert exp_fun(mpc(inf, 3*pi/4)) == mpc(-inf, inf)
-    assert exp_fun(mpc(inf, -3*pi/4)) == mpc(-inf, -inf)
-    assert exp_fun(mpc(inf, -pi/4)) == mpc(inf, -inf)
-    assert exp_fun(mpc(-inf, inf)) == -m
-    r = exp_fun(mpc(inf, inf))
-    assert abs(r.real) == inf and isnan(r.imag)
-    assert exp_fun(mpc(-inf, nan)) == -m
-    r = exp_fun(mpc(inf, nan))
-    assert abs(r.real) == inf and isnan(r.imag)
-    r = exp_fun(mpc(nan, 0))
-    assert isnan(r.real) and r.imag == 0
-    r = exp_fun(mpc(nan, 1))
-    assert isnan(r.real) and isnan(r.imag)
-    r = exp_fun(mpc(nan, nan))
-    assert isnan(r.real) and isnan(r.imag)
-
 def test_exp():
     assert exp(0) == 1
     assert exp(10000).ae(mpf('8.8068182256629215873e4342'))
@@ -303,7 +275,32 @@ def test_exp():
     mp.prec = 53
     assert exp(ln2 * 10).ae(1024)
     assert exp(2+2j).ae(cmath.exp(2+2j))
-    _test_exp_special_cases(exp, 0)  # complex special cases
+
+    # Complex special cases:
+    # https://en.cppreference.com/c/numeric/complex/cexp
+    assert exp(0j) == 1
+    r = exp(mpc(1, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(1, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    assert exp(mpc(inf, 0)) == mpc(inf, 0)
+    assert exp(mpc(-inf, 1)) == 0
+    assert exp(mpc(inf, pi/4)) == mpc(inf, inf)
+    assert exp(mpc(inf, 3*pi/4)) == mpc(-inf, inf)
+    assert exp(mpc(inf, -3*pi/4)) == mpc(-inf, -inf)
+    assert exp(mpc(inf, -pi/4)) == mpc(inf, -inf)
+    assert exp(mpc(-inf, inf)) == 0
+    r = exp(mpc(inf, inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    assert exp(mpc(-inf, nan)) == 0
+    r = exp(mpc(inf, nan))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = exp(mpc(nan, 0))
+    assert isnan(r.real) and r.imag == 0
+    r = exp(mpc(nan, 1))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(nan, nan))
+    assert isnan(r.real) and isnan(r.imag)
 
 def test_issue_73():
     mp.dps = 512
@@ -1195,12 +1192,38 @@ def test_expm1():
     assert expm1(inf) == inf
     assert expm1(1e-50).ae(1e-50)
     assert (expm1(1e-10)*1e10).ae(1.00000000005)
-    _test_exp_special_cases(expm1, 1)  # complex special cases
 
     # Other real special cases:
     # https://en.cppreference.com/c/numeric/math/expm1
     assert isnan(expm1(nan))
     assert expm1(-inf) == -1
+
+    # Complex special cases:
+    # https://en.cppreference.com/c/numeric/complex/cexp
+    # The expm1 results are the exp results minus 1.
+    assert expm1(0j) == 0
+    r = expm1(mpc(1, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(1, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    assert expm1(mpc(inf, 0)) == mpc(inf, 0)
+    assert expm1(mpc(-inf, 1)) == -1
+    assert expm1(mpc(inf, pi/4)) == mpc(inf, inf)
+    assert expm1(mpc(inf, 3*pi/4)) == mpc(-inf, inf)
+    assert expm1(mpc(inf, -3*pi/4)) == mpc(-inf, -inf)
+    assert expm1(mpc(inf, -pi/4)) == mpc(inf, -inf)
+    assert expm1(mpc(-inf, inf)) == -1
+    r = expm1(mpc(inf, inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    assert expm1(mpc(-inf, nan)) == -1
+    r = expm1(mpc(inf, nan))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = expm1(mpc(nan, 0))
+    assert isnan(r.real) and r.imag == 0
+    r = expm1(mpc(nan, 1))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(nan, nan))
+    assert isnan(r.real) and isnan(r.imag)
 
 def test_log1p():
     assert log1p(0) == 0

--- a/mpmath/tests/test_functions.py
+++ b/mpmath/tests/test_functions.py
@@ -264,6 +264,7 @@ def test_exact_cbrt():
         assert cbrt(mpf(A*A*A)) == A
 
 def test_exp():
+    # other special real cases are in test_special.py::test_functions_special()
     assert exp(0) == 1
     assert exp(10000).ae(mpf('8.8068182256629215873e4342'))
     assert exp(-10000).ae(mpf('1.1354838653147360985e-4343'))

--- a/mpmath/tests/test_functions.py
+++ b/mpmath/tests/test_functions.py
@@ -263,6 +263,34 @@ def test_exact_cbrt():
         A = random.randint(10**(prec//2-2), 10**(prec//2-1))
         assert cbrt(mpf(A*A*A)) == A
 
+def _test_exp_special_cases(exp_fun, m):
+    # Special cases:
+    # https://en.cppreference.com/c/numeric/complex/cexp
+    # The expm1 results are the exp results minus 1.
+    assert exp_fun(0j) == 1 - m
+    r = exp_fun(mpc(1, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp_fun(mpc(1, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    assert exp_fun(mpc(inf, 0)) == mpc(inf, 0)
+    assert exp_fun(mpc(-inf, 1)) == -m
+    assert exp_fun(mpc(inf, pi/4)) == mpc(inf, inf)
+    assert exp_fun(mpc(inf, 3*pi/4)) == mpc(-inf, inf)
+    assert exp_fun(mpc(inf, -3*pi/4)) == mpc(-inf, -inf)
+    assert exp_fun(mpc(inf, -pi/4)) == mpc(inf, -inf)
+    assert exp_fun(mpc(-inf, inf)) == -m
+    r = exp_fun(mpc(inf, inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    assert exp_fun(mpc(-inf, nan)) == -m
+    r = exp_fun(mpc(inf, nan))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = exp_fun(mpc(nan, 0))
+    assert isnan(r.real) and r.imag == 0
+    r = exp_fun(mpc(nan, 1))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp_fun(mpc(nan, nan))
+    assert isnan(r.real) and isnan(r.imag)
+
 def test_exp():
     assert exp(0) == 1
     assert exp(10000).ae(mpf('8.8068182256629215873e4342'))
@@ -275,6 +303,7 @@ def test_exp():
     mp.prec = 53
     assert exp(ln2 * 10).ae(1024)
     assert exp(2+2j).ae(cmath.exp(2+2j))
+    _test_exp_special_cases(exp, 0)  # complex special cases
 
 def test_issue_73():
     mp.dps = 512
@@ -1166,6 +1195,12 @@ def test_expm1():
     assert expm1(inf) == inf
     assert expm1(1e-50).ae(1e-50)
     assert (expm1(1e-10)*1e10).ae(1.00000000005)
+    _test_exp_special_cases(expm1, 1)  # complex special cases
+
+    # Other real special cases:
+    # https://en.cppreference.com/c/numeric/math/expm1
+    assert isnan(expm1(nan))
+    assert expm1(-inf) == -1
 
 def test_log1p():
     assert log1p(0) == 0

--- a/mpmath/tests/test_functions.py
+++ b/mpmath/tests/test_functions.py
@@ -314,6 +314,62 @@ def test_exp():
     r = exp(mpc(nan, nan))
     assert isnan(r.real) and isnan(r.imag)
 
+    # All combinations of finite and special representative values.
+    assert exp(mpc(0, 0)) == 1
+    assert exp(mpc(0, 1)).ae(cmath.exp(1j))
+    assert exp(mpc(0, -1)).ae(cmath.exp(-1j))
+    r = exp(mpc(0, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(0, -inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(0, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    assert exp(mpc(1, 0)).ae(cmath.exp(1))
+    assert exp(mpc(1, 1)).ae(cmath.exp(1+1j))
+    assert exp(mpc(1, -1)).ae(cmath.exp(1-1j))
+    r = exp(mpc(1, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(1, -inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(1, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    assert exp(mpc(-1, 0)).ae(cmath.exp(-1))
+    assert exp(mpc(-1, 1)).ae(cmath.exp(-1+1j))
+    assert exp(mpc(-1, -1)).ae(cmath.exp(-1-1j))
+    r = exp(mpc(-1, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(-1, -inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(-1, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    assert exp(mpc(inf, 0)) == mpc(inf, 0)
+    assert exp(mpc(inf, 1)) == mpc(inf, inf)
+    assert exp(mpc(inf, -1)) == mpc(inf, -inf)
+    r = exp(mpc(inf, inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = exp(mpc(inf, -inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = exp(mpc(inf, nan))
+    assert abs(r.real) == inf and isnan(r.imag)
+    assert exp(mpc(-inf, 0)) == 0
+    assert exp(mpc(-inf, 1)) == 0
+    assert exp(mpc(-inf, -1)) == 0
+    assert exp(mpc(-inf, inf)) == 0
+    assert exp(mpc(-inf, -inf)) == 0
+    assert exp(mpc(-inf, nan)) == 0
+    r = exp(mpc(nan, 0))
+    assert isnan(r.real) and r.imag == 0
+    r = exp(mpc(nan, 1))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(nan, -1))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(nan, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(nan, -inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = exp(mpc(nan, nan))
+    assert isnan(r.real) and isnan(r.imag)
+
 def test_issue_73():
     mp.dps = 512
     a = exp(-1)
@@ -1239,6 +1295,62 @@ def test_expm1():
     r = expm1(mpc(nan, 0))
     assert isnan(r.real) and r.imag == 0
     r = expm1(mpc(nan, 1))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(nan, nan))
+    assert isnan(r.real) and isnan(r.imag)
+
+    # All combinations of finite and special representative values.
+    assert expm1(mpc(0, 0)) == 0
+    assert expm1(mpc(0, 1)).ae(cmath.exp(1j)-1)
+    assert expm1(mpc(0, -1)).ae(cmath.exp(-1j)-1)
+    r = expm1(mpc(0, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(0, -inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(0, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    assert expm1(mpc(1, 0)).ae(cmath.exp(1)-1)
+    assert expm1(mpc(1, 1)).ae(cmath.exp(1+1j)-1)
+    assert expm1(mpc(1, -1)).ae(cmath.exp(1-1j)-1)
+    r = expm1(mpc(1, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(1, -inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(1, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    assert expm1(mpc(-1, 0)).ae(cmath.exp(-1)-1)
+    assert expm1(mpc(-1, 1)).ae(cmath.exp(-1+1j)-1)
+    assert expm1(mpc(-1, -1)).ae(cmath.exp(-1-1j)-1)
+    r = expm1(mpc(-1, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(-1, -inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(-1, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    assert expm1(mpc(inf, 0)) == mpc(inf, 0)
+    assert expm1(mpc(inf, 1)) == mpc(inf, inf)
+    assert expm1(mpc(inf, -1)) == mpc(inf, -inf)
+    r = expm1(mpc(inf, inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = expm1(mpc(inf, -inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = expm1(mpc(inf, nan))
+    assert abs(r.real) == inf and isnan(r.imag)
+    assert expm1(mpc(-inf, 0)) == -1
+    assert expm1(mpc(-inf, 1)) == -1
+    assert expm1(mpc(-inf, -1)) == -1
+    assert expm1(mpc(-inf, inf)) == -1
+    assert expm1(mpc(-inf, -inf)) == -1
+    assert expm1(mpc(-inf, nan)) == -1
+    r = expm1(mpc(nan, 0))
+    assert isnan(r.real) and r.imag == 0
+    r = expm1(mpc(nan, 1))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(nan, -1))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(nan, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = expm1(mpc(nan, -inf))
     assert isnan(r.real) and isnan(r.imag)
     r = expm1(mpc(nan, nan))
     assert isnan(r.real) and isnan(r.imag)


### PR DESCRIPTION
Toward gh-1172

Add special case logic and regression tests to ensure that `exp` and `expm1` respect special cases defined in the C99 standard and in the Python array API standard.

Applies lessons learned from gh-1173:
- only add tests, and add only the tests from the standard not already present
- use `isnan`, `==`, `.ae`, literals, and predefined constants as appropriate
- cite C standard
- prefer minimal, efficient implementation over the obvious, case by case solution

Similar use of GPT-5.6 Sol for drafting; lots of interactive/manual refinement.