### PR TITLE
 Ensure `cos(h)`/`sin(h)` respect special cases from applicable standards

### DIFF
--- a/mpmath/libmp/libmpc.py
+++ b/mpmath/libmp/libmpc.py
@@ -450,6 +450,8 @@ def mpc_cos(z, prec, rnd=round_down):
         return mpf_cos(a, prec, rnd), fzero
     if a == fzero:
         return mpf_cosh(b, prec, rnd), fzero
+    if a in _infs_nan and b in _infs:
+        return finf, fnan
     wp = prec + 6
     c, s = mpf_cos_sin(a, wp)
     ch, sh = mpf_cosh_sinh(b, wp)
@@ -466,6 +468,8 @@ def mpc_sin(z, prec, rnd=round_down):
         return mpf_sin(a, prec, rnd), fzero
     if a == fzero:
         return fzero, mpf_sinh(b, prec, rnd)
+    if a in _infs_nan and b in _infs:
+        return fnan, b
     wp = prec + 6
     c, s = mpf_cos_sin(a, wp)
     ch, sh = mpf_cosh_sinh(b, wp)

--- a/mpmath/tests/test_functions.py
+++ b/mpmath/tests/test_functions.py
@@ -345,6 +345,145 @@ def test_trig_hyperb_basic():
     assert cos(1+1j).ae(cmath.cos(1+1j))
     assert cos(-4-3.6j).ae(cmath.cos(-4-3.6j))
 
+def test_sin():
+    # Real special cases:
+    # https://en.cppreference.com/c/numeric/math/sin
+    assert isnan(sin(nan))
+    assert sin(0) == 0
+    assert isnan(sin(inf))
+
+    # Complex special cases:
+    # https://en.cppreference.com/c/numeric/complex/csin
+    assert sin(mpc(0, 0)) == mpc(0, 0)
+    r = sin(mpc(inf, 0))
+    assert isnan(r.real) and r.imag == 0
+    r = sin(mpc(nan, 0))
+    assert isnan(r.real) and r.imag == 0
+    r = sin(mpc(inf, 1))
+    assert isnan(r.real) and isnan(r.imag)
+    r = sin(mpc(nan, 1))
+    assert isnan(r.real) and isnan(r.imag)
+    assert sin(mpc(0, inf)) == mpc(0, inf)
+    assert sin(mpc(pi/4, inf)) == mpc(inf, inf)
+    assert sin(mpc(3*pi/4, inf)) == mpc(inf, -inf)
+    assert sin(mpc(-3*pi/4, inf)) == mpc(-inf, -inf)
+    assert sin(mpc(-pi/4, inf)) == mpc(-inf, inf)
+    assert sin(mpc(pi/4, -inf)) == mpc(inf, -inf)
+    r = sin(mpc(inf, inf))
+    assert isnan(r.real) and abs(r.imag) == inf
+    r = sin(mpc(nan, inf))
+    assert isnan(r.real) and abs(r.imag) == inf
+    r = sin(mpc(0, nan))
+    assert r.real == 0 and isnan(r.imag)
+    r = sin(mpc(1, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    r = sin(mpc(nan, nan))
+    assert isnan(r.real) and isnan(r.imag)
+
+def test_cos():
+    # Real special cases:
+    # https://en.cppreference.com/c/numeric/math/cos
+    assert isnan(cos(nan))
+    assert cos(0) == 1
+    assert isnan(cos(inf))
+
+    # Complex special cases:
+    # https://en.cppreference.com/c/numeric/complex/ccos
+    assert cos(mpc(0, 0)) == mpc(1, 0)
+    r = cos(mpc(inf, 0))
+    assert isnan(r.real) and r.imag == 0
+    r = cos(mpc(nan, 0))
+    assert isnan(r.real) and r.imag == 0
+    r = cos(mpc(inf, 1))
+    assert isnan(r.real) and isnan(r.imag)
+    r = cos(mpc(nan, 1))
+    assert isnan(r.real) and isnan(r.imag)
+    assert cos(mpc(0, inf)) == mpc(inf, 0)
+    assert cos(mpc(pi/4, inf)) == mpc(inf, -inf)
+    assert cos(mpc(3*pi/4, inf)) == mpc(-inf, -inf)
+    assert cos(mpc(-3*pi/4, inf)) == mpc(-inf, inf)
+    assert cos(mpc(-pi/4, inf)) == mpc(inf, inf)
+    assert cos(mpc(pi/4, -inf)) == mpc(inf, inf)
+    r = cos(mpc(inf, inf))
+    assert r.real == inf and isnan(r.imag)
+    r = cos(mpc(nan, inf))
+    assert r.real == inf and isnan(r.imag)
+    r = cos(mpc(0, nan))
+    assert isnan(r.real) and r.imag == 0
+    r = cos(mpc(1, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    r = cos(mpc(nan, nan))
+    assert isnan(r.real) and isnan(r.imag)
+
+def test_sinh():
+    # Real special cases:
+    # https://en.cppreference.com/c/numeric/math/sinh
+    assert isnan(sinh(nan))
+    assert sinh(0) == 0
+    assert sinh(inf) == inf
+    assert sinh(-inf) == -inf
+
+    # Complex special cases:
+    # https://en.cppreference.com/c/numeric/complex/csinh
+    assert sinh(mpc(0, 0)) == mpc(0, 0)
+    r = sinh(mpc(0, inf))
+    assert r.real == 0 and isnan(r.imag)
+    r = sinh(mpc(0, nan))
+    assert r.real == 0 and isnan(r.imag)
+    r = sinh(mpc(1, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = sinh(mpc(1, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    assert sinh(mpc(inf, 0)) == mpc(inf, 0)
+    assert sinh(mpc(inf, pi/4)) == mpc(inf, inf)
+    assert sinh(mpc(inf, 3*pi/4)) == mpc(-inf, inf)
+    assert sinh(mpc(inf, -3*pi/4)) == mpc(-inf, -inf)
+    assert sinh(mpc(inf, -pi/4)) == mpc(inf, -inf)
+    r = sinh(mpc(inf, inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = sinh(mpc(inf, nan))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = sinh(mpc(nan, 0))
+    assert isnan(r.real) and r.imag == 0
+    r = sinh(mpc(nan, 1))
+    assert isnan(r.real) and isnan(r.imag)
+    r = sinh(mpc(nan, nan))
+    assert isnan(r.real) and isnan(r.imag)
+
+def test_cosh():
+    # Real special cases:
+    # https://en.cppreference.com/c/numeric/math/cosh
+    assert isnan(cosh(nan))
+    assert cosh(0) == 1
+    assert cosh(inf) == inf
+
+    # Complex special cases:
+    # https://en.cppreference.com/c/numeric/complex/ccosh
+    assert cosh(mpc(0, 0)) == mpc(1, 0)
+    r = cosh(mpc(0, inf))
+    assert isnan(r.real) and r.imag == 0
+    r = cosh(mpc(0, nan))
+    assert isnan(r.real) and r.imag == 0
+    r = cosh(mpc(1, inf))
+    assert isnan(r.real) and isnan(r.imag)
+    r = cosh(mpc(1, nan))
+    assert isnan(r.real) and isnan(r.imag)
+    assert cosh(mpc(inf, 0)) == mpc(inf, 0)
+    assert cosh(mpc(inf, pi/4)) == mpc(inf, inf)
+    assert cosh(mpc(inf, 3*pi/4)) == mpc(-inf, inf)
+    assert cosh(mpc(inf, -3*pi/4)) == mpc(-inf, -inf)
+    assert cosh(mpc(inf, -pi/4)) == mpc(inf, -inf)
+    r = cosh(mpc(inf, inf))
+    assert r.real == inf and isnan(r.imag)
+    r = cosh(mpc(inf, nan))
+    assert r.real == inf and isnan(r.imag)
+    r = cosh(mpc(nan, 0))
+    assert isnan(r.real) and r.imag == 0
+    r = cosh(mpc(nan, 1))
+    assert isnan(r.real) and isnan(r.imag)
+    r = cosh(mpc(nan, nan))
+    assert isnan(r.real) and isnan(r.imag)
+
 def test_degrees():
     assert cos(0*degree) == 1
     assert cos(90*degree).ae(0)

--- a/mpmath/tests/test_functions.py
+++ b/mpmath/tests/test_functions.py
@@ -351,11 +351,14 @@ def test_sin():
     assert isnan(sin(nan))
     assert sin(0) == 0
     assert isnan(sin(inf))
+    assert isnan(sin(-inf))
 
     # Complex special cases:
     # https://en.cppreference.com/c/numeric/complex/csin
     assert sin(mpc(0, 0)) == mpc(0, 0)
     r = sin(mpc(inf, 0))
+    assert isnan(r.real) and r.imag == 0
+    r = sin(mpc(-inf, 0))
     assert isnan(r.real) and r.imag == 0
     r = sin(mpc(nan, 0))
     assert isnan(r.real) and r.imag == 0
@@ -364,6 +367,7 @@ def test_sin():
     r = sin(mpc(nan, 1))
     assert isnan(r.real) and isnan(r.imag)
     assert sin(mpc(0, inf)) == mpc(0, inf)
+    assert sin(mpc(0, -inf)) == mpc(0, -inf)
     assert sin(mpc(pi/4, inf)) == mpc(inf, inf)
     assert sin(mpc(3*pi/4, inf)) == mpc(inf, -inf)
     assert sin(mpc(-3*pi/4, inf)) == mpc(-inf, -inf)
@@ -371,8 +375,16 @@ def test_sin():
     assert sin(mpc(pi/4, -inf)) == mpc(inf, -inf)
     r = sin(mpc(inf, inf))
     assert isnan(r.real) and abs(r.imag) == inf
+    r = sin(mpc(inf, -inf))
+    assert isnan(r.real) and r.imag == -inf
+    r = sin(mpc(-inf, inf))
+    assert isnan(r.real) and r.imag == inf
+    r = sin(mpc(-inf, -inf))
+    assert isnan(r.real) and r.imag == -inf
     r = sin(mpc(nan, inf))
     assert isnan(r.real) and abs(r.imag) == inf
+    r = sin(mpc(nan, -inf))
+    assert isnan(r.real) and r.imag == -inf
     r = sin(mpc(0, nan))
     assert r.real == 0 and isnan(r.imag)
     r = sin(mpc(1, nan))
@@ -386,11 +398,14 @@ def test_cos():
     assert isnan(cos(nan))
     assert cos(0) == 1
     assert isnan(cos(inf))
+    assert isnan(cos(-inf))
 
     # Complex special cases:
     # https://en.cppreference.com/c/numeric/complex/ccos
     assert cos(mpc(0, 0)) == mpc(1, 0)
     r = cos(mpc(inf, 0))
+    assert isnan(r.real) and r.imag == 0
+    r = cos(mpc(-inf, 0))
     assert isnan(r.real) and r.imag == 0
     r = cos(mpc(nan, 0))
     assert isnan(r.real) and r.imag == 0
@@ -399,6 +414,7 @@ def test_cos():
     r = cos(mpc(nan, 1))
     assert isnan(r.real) and isnan(r.imag)
     assert cos(mpc(0, inf)) == mpc(inf, 0)
+    assert cos(mpc(0, -inf)) == mpc(inf, 0)
     assert cos(mpc(pi/4, inf)) == mpc(inf, -inf)
     assert cos(mpc(3*pi/4, inf)) == mpc(-inf, -inf)
     assert cos(mpc(-3*pi/4, inf)) == mpc(-inf, inf)
@@ -406,8 +422,16 @@ def test_cos():
     assert cos(mpc(pi/4, -inf)) == mpc(inf, inf)
     r = cos(mpc(inf, inf))
     assert r.real == inf and isnan(r.imag)
+    r = cos(mpc(inf, -inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = cos(mpc(-inf, inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = cos(mpc(-inf, -inf))
+    assert abs(r.real) == inf and isnan(r.imag)
     r = cos(mpc(nan, inf))
     assert r.real == inf and isnan(r.imag)
+    r = cos(mpc(nan, -inf))
+    assert abs(r.real) == inf and isnan(r.imag)
     r = cos(mpc(0, nan))
     assert isnan(r.real) and r.imag == 0
     r = cos(mpc(1, nan))
@@ -428,24 +452,39 @@ def test_sinh():
     assert sinh(mpc(0, 0)) == mpc(0, 0)
     r = sinh(mpc(0, inf))
     assert r.real == 0 and isnan(r.imag)
+    r = sinh(mpc(0, -inf))
+    assert r.real == 0 and isnan(r.imag)
     r = sinh(mpc(0, nan))
     assert r.real == 0 and isnan(r.imag)
     r = sinh(mpc(1, inf))
     assert isnan(r.real) and isnan(r.imag)
+    r = sinh(mpc(1, -inf))
+    assert isnan(r.real) and isnan(r.imag)
     r = sinh(mpc(1, nan))
     assert isnan(r.real) and isnan(r.imag)
     assert sinh(mpc(inf, 0)) == mpc(inf, 0)
+    assert sinh(mpc(-inf, 0)) == mpc(-inf, 0)
     assert sinh(mpc(inf, pi/4)) == mpc(inf, inf)
     assert sinh(mpc(inf, 3*pi/4)) == mpc(-inf, inf)
     assert sinh(mpc(inf, -3*pi/4)) == mpc(-inf, -inf)
     assert sinh(mpc(inf, -pi/4)) == mpc(inf, -inf)
     r = sinh(mpc(inf, inf))
     assert abs(r.real) == inf and isnan(r.imag)
+    r = sinh(mpc(inf, -inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = sinh(mpc(-inf, inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = sinh(mpc(-inf, -inf))
+    assert abs(r.real) == inf and isnan(r.imag)
     r = sinh(mpc(inf, nan))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = sinh(mpc(-inf, nan))
     assert abs(r.real) == inf and isnan(r.imag)
     r = sinh(mpc(nan, 0))
     assert isnan(r.real) and r.imag == 0
     r = sinh(mpc(nan, 1))
+    assert isnan(r.real) and isnan(r.imag)
+    r = sinh(mpc(nan, -inf))
     assert isnan(r.real) and isnan(r.imag)
     r = sinh(mpc(nan, nan))
     assert isnan(r.real) and isnan(r.imag)
@@ -456,30 +495,46 @@ def test_cosh():
     assert isnan(cosh(nan))
     assert cosh(0) == 1
     assert cosh(inf) == inf
+    assert cosh(-inf) == inf
 
     # Complex special cases:
     # https://en.cppreference.com/c/numeric/complex/ccosh
     assert cosh(mpc(0, 0)) == mpc(1, 0)
     r = cosh(mpc(0, inf))
     assert isnan(r.real) and r.imag == 0
+    r = cosh(mpc(0, -inf))
+    assert isnan(r.real) and r.imag == 0
     r = cosh(mpc(0, nan))
     assert isnan(r.real) and r.imag == 0
     r = cosh(mpc(1, inf))
     assert isnan(r.real) and isnan(r.imag)
+    r = cosh(mpc(1, -inf))
+    assert isnan(r.real) and isnan(r.imag)
     r = cosh(mpc(1, nan))
     assert isnan(r.real) and isnan(r.imag)
     assert cosh(mpc(inf, 0)) == mpc(inf, 0)
+    assert cosh(mpc(-inf, 0)) == mpc(inf, 0)
     assert cosh(mpc(inf, pi/4)) == mpc(inf, inf)
     assert cosh(mpc(inf, 3*pi/4)) == mpc(-inf, inf)
     assert cosh(mpc(inf, -3*pi/4)) == mpc(-inf, -inf)
     assert cosh(mpc(inf, -pi/4)) == mpc(inf, -inf)
     r = cosh(mpc(inf, inf))
     assert r.real == inf and isnan(r.imag)
+    r = cosh(mpc(inf, -inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = cosh(mpc(-inf, inf))
+    assert abs(r.real) == inf and isnan(r.imag)
+    r = cosh(mpc(-inf, -inf))
+    assert abs(r.real) == inf and isnan(r.imag)
     r = cosh(mpc(inf, nan))
     assert r.real == inf and isnan(r.imag)
+    r = cosh(mpc(-inf, nan))
+    assert abs(r.real) == inf and isnan(r.imag)
     r = cosh(mpc(nan, 0))
     assert isnan(r.real) and r.imag == 0
     r = cosh(mpc(nan, 1))
+    assert isnan(r.real) and isnan(r.imag)
+    r = cosh(mpc(nan, -inf))
     assert isnan(r.real) and isnan(r.imag)
     r = cosh(mpc(nan, nan))
     assert isnan(r.real) and isnan(r.imag)


### PR DESCRIPTION
Toward https://github.com/mpmath/mpmath/issues/1172

 Add special case logic and regression tests to ensure that `cos`, `sin`, `cosh`, and
 `sinh` respect special cases defined in the C99 standard and in the Python array API
 standard.